### PR TITLE
deploy: add namespace for the CR.

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -3,6 +3,7 @@ apiVersion: imageregistry.operator.openshift.io/v1alpha1
 kind: ImageRegistry
 metadata:
   name: image-registry
+  namespace: openshift-image-registry
 spec:
   managementState: Managed
   version: 3.10.0


### PR DESCRIPTION
`imageregistries.imageregistry.operator.openshift.io` CRD is Namespaced.
But the cr.yaml doesn't have namespace setup. Cluster Version Operator
will not have context to decide which namespace the CR shouldbe installed in.