### PR TITLE
pkg/clusterconfig: Log missing config-map

### DIFF
--- a/pkg/clusterconfig/clusterconfig.go
+++ b/pkg/clusterconfig/clusterconfig.go
@@ -6,6 +6,7 @@ import (
 	"os/user"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metaapi "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientcore "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -94,6 +95,7 @@ func Get() (*Config, error) {
 	cm, err := client.ConfigMaps(configNamespace).Get(configName, metaapi.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
+			logrus.Warnf("config-map %s/%s not found", configNamespace, configName)
 			return cfg, nil
 		}
 		return nil, err


### PR DESCRIPTION
This may be why some operator runs are [dying with][1] (although I haven't read through #54 yet):

```
time=""2018-11-05T19:42:08Z"" level=info msg=""Cluster Image Registry Operator Version: 601f5c3-dirty""
time=""2018-11-05T19:42:08Z"" level=info msg=""Go Version: go1.10.3""
time=""2018-11-05T19:42:08Z"" level=info msg=""Go OS/Arch: linux/amd64""
time=""2018-11-05T19:42:08Z"" level=info msg=""operator-sdk Version: 0.0.6+git""
time=""2018-11-05T19:42:08Z"" level=info msg=""Metrics service cluster-image-registry-operator created""
time=""2018-11-05T19:42:08Z"" level=info msg=""generating registry custom resource""
time=""2018-11-05T19:42:08Z"" level=fatal msg=""unknown storage backend: """
```

When returning a potentially-troublesome, empty configuration with a `nil` error, we should at least log the fact that the expected config-map wasn't there.

[1]: https://github.com/openshift/cluster-image-registry-operator/issues/58#issue-378091526