### PR TITLE
add temporary hack to copy service ca to cluster nodes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@ FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/openshift/cluster-image-registry-operator/tmp/_output/bin/cluster-image-registry-operator /usr/bin/
 RUN useradd cluster-image-registry-operator
 USER cluster-image-registry-operator
-COPY deploy/image-references deploy/00-crd.yaml deploy/01-namespace.yaml deploy/02-rbac.yaml deploy/03-sa.yaml deploy/04-operator.yaml /manifests/
+COPY deploy/image-references deploy/0* /manifests/
 LABEL io.openshift.release.operator true

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -7,5 +7,5 @@ FROM registry.svc.ci.openshift.org/ocp/4.0:base
 COPY --from=builder /go/src/github.com/openshift/cluster-image-registry-operator/tmp/_output/bin/cluster-image-registry-operator /usr/bin/
 RUN useradd cluster-image-registry-operator
 USER cluster-image-registry-operator
-COPY deploy/image-references deploy/00-crd.yaml deploy/01-namespace.yaml deploy/02-rbac.yaml deploy/03-sa.yaml deploy/04-operator.yaml /manifests/
+COPY deploy/image-references deploy/0* /manifests/
 LABEL io.openshift.release.operator true

--- a/deploy/05-ca-config.yaml
+++ b/deploy/05-ca-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    service.alpha.openshift.io/inject-cabundle: "true"
+  name: serviceca
+  namespace: openshift-image-registry

--- a/deploy/06-ca-rbac.yaml
+++ b/deploy/06-ca-rbac.yaml
@@ -1,0 +1,29 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: registry-ca-hostmapper
+  namespace: openshift-image-registry
+rules:
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+  resourceNames:
+  - privileged
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: registry-ca-hostmapper
+  namespace: openshift-image-registry
+subjects:
+- kind: ServiceAccount
+  name: registry-ca-hostmapper
+  namespace: openshift-image-registry
+roleRef:
+  kind: Role
+  name: registry-ca-hostmapper
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/07-ca-serviceaccount.yaml
+++ b/deploy/07-ca-serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: registry-ca-hostmapper
+  namespace: openshift-image-registry

--- a/deploy/08-ca-daemonset.yaml
+++ b/deploy/08-ca-daemonset.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: registry-ca-hostmapper
+  namespace: openshift-image-registry
+spec:
+  selector:
+    matchLabels:
+      name: registry-ca-hostmapper
+  template:
+    metadata:
+      labels:
+        name: registry-ca-hostmapper
+    spec:      
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      serviceAccountName: registry-ca-hostmapper
+      containers:
+      - name: registry-ca-hostmapper
+        securityContext:
+          privileged: true
+        image: docker.io/openshift/origin-cluster-image-registry-operator:latest
+        command: 
+        - "/bin/sh"
+        - "-c"
+        - |
+          if [ ! -e /etc/docker/certs.d/image-registry.openshift-image-registry.svc.cluster.local:5000 ]; then
+            mkdir /etc/docker/certs.d/image-registry.openshift-image-registry.svc.cluster.local:5000
+          fi
+          while [ true ];
+          do
+            if [ -e /tmp/serviceca/service-ca.crt ]; then
+              cp -u /tmp/serviceca/service-ca.crt /etc/docker/certs.d/image-registry.openshift-image-registry.svc.cluster.local:5000
+            else 
+              rm /etc/docker/certs.d/image-registry.openshift-image-registry.svc.cluster.local:5000/service-ca.crt
+            fi
+            sleep 60
+          done
+        volumeMounts:
+        - name: serviceca
+          mountPath: /tmp/serviceca
+        - name: host
+          mountPath: /etc/docker/certs.d
+      volumes:
+      - name: host
+        hostPath:
+          path: /etc/docker/certs.d
+      - name: serviceca
+        configMap:
+          name: serviceca
+          items:
+          - key: service-ca.crt
+            path: service-ca.crt


### PR DESCRIPTION
This is a temporary hack to ensure the service-ca (which signs the registry service) gets copied to the host nodes.

In the future this needs to be replaced/enhanced in such a way that 

1) it needs less privileges(probably)
2) ~~should use the base image from the release, not centos~~
3) the image-registry operator reports on the state of the daemonset as part of the registry operator status
4) we also copy down additional CAs that are configured in the cluster that represent other registries the nodes may need to pull from.  (ie image.config.openshift.io's additionalCA configmap)

