### PR TITLE
Rollback from k8s.io/klog to github.com/golang/glog

### DIFF
--- a/cmd/cluster-image-registry-operator/main.go
+++ b/cmd/cluster-image-registry-operator/main.go
@@ -5,9 +5,10 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/golang/glog"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog"
 
 	appsset "github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1"
 
@@ -20,36 +21,37 @@ import (
 )
 
 func printVersion() {
-	klog.Infof("Cluster Image Registry Operator Version: %s", version.Version)
-	klog.Infof("Go Version: %s", runtime.Version())
-	klog.Infof("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH)
+	glog.Infof("Cluster Image Registry Operator Version: %s", version.Version)
+	glog.Infof("Go Version: %s", runtime.Version())
+	glog.Infof("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH)
 }
 
 func main() {
 	flag.Parse()
+	flag.Lookup("logtostderr").Value.Set("true")
 
 	printVersion()
 
 	cfg, err := client.GetConfig()
 	if err != nil {
-		klog.Fatalf("Error building kubeconfig: %s", err)
+		glog.Fatalf("Error building kubeconfig: %s", err)
 	}
 
 	namespace, err := client.GetWatchNamespace()
 	if err != nil {
-		klog.Fatalf("failed to get watch namespace: %s", err)
+		glog.Fatalf("failed to get watch namespace: %s", err)
 	}
 
 	if envval := os.Getenv("IMAGE_REGISTRY_OPERATOR_NO_ADOPTION"); envval == "" {
 		client, err := appsset.NewForConfig(cfg)
 		if err != nil {
-			klog.Fatal(err)
+			glog.Fatal(err)
 		}
 
 		_, err = client.DeploymentConfigs("default").Get("docker-registry", metav1.GetOptions{})
 		if err != nil {
 			if !errors.IsNotFound(err) {
-				klog.Fatal(err)
+				glog.Fatal(err)
 			}
 		} else {
 			namespace = "default"
@@ -61,11 +63,11 @@ func main() {
 
 	controller, err := operator.NewController(cfg, namespace)
 	if err != nil {
-		klog.Fatal(err)
+		glog.Fatal(err)
 	}
 
 	err = controller.Run(stopCh)
 	if err != nil {
-		klog.Fatal(err)
+		glog.Fatal(err)
 	}
 }

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -4,10 +4,11 @@ import (
 	"crypto/rand"
 	"fmt"
 
+	"github.com/golang/glog"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog"
 
 	operatorapi "github.com/openshift/api/operator/v1alpha1"
 	appsset "github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1"
@@ -36,7 +37,7 @@ func resourceName(namespace string) string {
 func addImageRegistryChecksum(cr *regopapi.ImageRegistry) {
 	dgst, err := resource.Checksum(cr.Spec)
 	if err != nil {
-		klog.Errorf("unable to generate checksum from ImageRegistry spec: %s", err)
+		glog.Errorf("unable to generate checksum from ImageRegistry spec: %s", err)
 		return
 	}
 
@@ -89,7 +90,7 @@ func (c *Controller) Bootstrap() error {
 	} else if err != nil {
 		return fmt.Errorf("unable to check if the deployment already exists: %s", err)
 	} else {
-		klog.Infof("adopting the existing deployment config...")
+		glog.Infof("adopting the existing deployment config...")
 		var tlsSecret *corev1.Secret
 		spec, tlsSecret, err = migration.NewImageRegistrySpecFromDeploymentConfig(dc, dependency.NewNamespacedResources(c.kubeconfig, dc.ObjectMeta.Namespace))
 		if err != nil {
@@ -114,7 +115,7 @@ func (c *Controller) Bootstrap() error {
 		}
 	}
 
-	klog.Infof("generating registry custom resource")
+	glog.Infof("generating registry custom resource")
 
 	cr := &regopapi.ImageRegistry{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/controller/clusterrolebindings/clusterrolebindings.go
+++ b/pkg/operator/controller/clusterrolebindings/clusterrolebindings.go
@@ -3,13 +3,14 @@ package clusterrolebindings
 import (
 	"fmt"
 
+	"github.com/golang/glog"
+
 	rbacapi "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubeinformers "k8s.io/client-go/informers"
 	kubeset "k8s.io/client-go/kubernetes"
 	rbaclisters "k8s.io/client-go/listers/rbac/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog"
 
 	"github.com/openshift/cluster-image-registry-operator/pkg/client"
 	opcontroller "github.com/openshift/cluster-image-registry-operator/pkg/operator/controller"
@@ -23,7 +24,7 @@ type Controller struct {
 }
 
 func (c *Controller) Start(handler opcontroller.Handler, namespace string, stopCh <-chan struct{}) error {
-	klog.Info("Starting clusterrolebindings controller")
+	glog.Info("Starting clusterrolebindings controller")
 
 	kubeconfig, err := client.GetConfig()
 	if err != nil {
@@ -60,7 +61,7 @@ func (c *Controller) Start(handler opcontroller.Handler, namespace string, stopC
 
 	kubeInformerFactory.Start(stopCh)
 
-	klog.Info("Waiting for clusterrolebindings informer caches to sync")
+	glog.Info("Waiting for clusterrolebindings informer caches to sync")
 	if ok := cache.WaitForCacheSync(stopCh, c.synced); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}

--- a/pkg/operator/controller/clusterroles/clusterroles.go
+++ b/pkg/operator/controller/clusterroles/clusterroles.go
@@ -3,13 +3,14 @@ package clusterroles
 import (
 	"fmt"
 
+	"github.com/golang/glog"
+
 	rbacapi "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubeinformers "k8s.io/client-go/informers"
 	kubeset "k8s.io/client-go/kubernetes"
 	rbaclisters "k8s.io/client-go/listers/rbac/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog"
 
 	"github.com/openshift/cluster-image-registry-operator/pkg/client"
 	opcontroller "github.com/openshift/cluster-image-registry-operator/pkg/operator/controller"
@@ -23,7 +24,7 @@ type Controller struct {
 }
 
 func (c *Controller) Start(handler opcontroller.Handler, namespace string, stopCh <-chan struct{}) error {
-	klog.Info("Starting clusterroles controller")
+	glog.Info("Starting clusterroles controller")
 
 	kubeconfig, err := client.GetConfig()
 	if err != nil {
@@ -60,7 +61,7 @@ func (c *Controller) Start(handler opcontroller.Handler, namespace string, stopC
 
 	kubeInformerFactory.Start(stopCh)
 
-	klog.Info("Waiting for clusterroles informer caches to sync")
+	glog.Info("Waiting for clusterroles informer caches to sync")
 	if ok := cache.WaitForCacheSync(stopCh, c.synced); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}

--- a/pkg/operator/controller/configmaps/configmap.go
+++ b/pkg/operator/controller/configmaps/configmap.go
@@ -3,13 +3,14 @@ package configmap
 import (
 	"fmt"
 
+	"github.com/golang/glog"
+
 	coreapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubeinformers "k8s.io/client-go/informers"
 	kubeset "k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog"
 
 	"github.com/openshift/cluster-image-registry-operator/pkg/client"
 	opcontroller "github.com/openshift/cluster-image-registry-operator/pkg/operator/controller"
@@ -23,7 +24,7 @@ type Controller struct {
 }
 
 func (c *Controller) Start(handler opcontroller.Handler, namespace string, stopCh <-chan struct{}) error {
-	klog.Info("Starting configmaps controller")
+	glog.Info("Starting configmaps controller")
 
 	kubeconfig, err := client.GetConfig()
 	if err != nil {
@@ -60,7 +61,7 @@ func (c *Controller) Start(handler opcontroller.Handler, namespace string, stopC
 
 	kubeInformerFactory.Start(stopCh)
 
-	klog.Info("Waiting for configmaps informer caches to sync")
+	glog.Info("Waiting for configmaps informer caches to sync")
 	if ok := cache.WaitForCacheSync(stopCh, c.synced); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}

--- a/pkg/operator/controller/deployments/deployment.go
+++ b/pkg/operator/controller/deployments/deployment.go
@@ -3,13 +3,14 @@ package deployment
 import (
 	"fmt"
 
+	"github.com/golang/glog"
+
 	kappsapi "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubeinformers "k8s.io/client-go/informers"
 	kubeset "k8s.io/client-go/kubernetes"
 	appslisters "k8s.io/client-go/listers/apps/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog"
 
 	"github.com/openshift/cluster-image-registry-operator/pkg/client"
 	opcontroller "github.com/openshift/cluster-image-registry-operator/pkg/operator/controller"
@@ -23,7 +24,7 @@ type Controller struct {
 }
 
 func (c *Controller) Start(handler opcontroller.Handler, namespace string, stopCh <-chan struct{}) error {
-	klog.Info("Starting deployment controller")
+	glog.Info("Starting deployment controller")
 
 	kubeconfig, err := client.GetConfig()
 	if err != nil {
@@ -62,7 +63,7 @@ func (c *Controller) Start(handler opcontroller.Handler, namespace string, stopC
 
 	kubeInformerFactory.Start(stopCh)
 
-	klog.Info("Waiting for deployment informer caches to sync")
+	glog.Info("Waiting for deployment informer caches to sync")
 	if ok := cache.WaitForCacheSync(stopCh, c.synced); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}

--- a/pkg/operator/controller/imageregistry/imageregistry.go
+++ b/pkg/operator/controller/imageregistry/imageregistry.go
@@ -3,9 +3,10 @@ package imageregistry
 import (
 	"fmt"
 
+	"github.com/golang/glog"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog"
 
 	imageregistryapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1alpha1"
 	imageregistryset "github.com/openshift/cluster-image-registry-operator/pkg/generated/clientset/versioned"
@@ -24,7 +25,7 @@ type Controller struct {
 }
 
 func (c *Controller) Start(handler opcontroller.Handler, namespace string, stopCh <-chan struct{}) error {
-	klog.Info("Starting imageregistry controller")
+	glog.Info("Starting imageregistry controller")
 
 	kubeconfig, err := client.GetConfig()
 	if err != nil {
@@ -61,7 +62,7 @@ func (c *Controller) Start(handler opcontroller.Handler, namespace string, stopC
 
 	informerFactory.Start(stopCh)
 
-	klog.Info("Waiting for imageregistry informer caches to sync")
+	glog.Info("Waiting for imageregistry informer caches to sync")
 	if ok := cache.WaitForCacheSync(stopCh, c.synced); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}

--- a/pkg/operator/controller/routes/routes.go
+++ b/pkg/operator/controller/routes/routes.go
@@ -3,9 +3,10 @@ package routes
 import (
 	"fmt"
 
+	"github.com/golang/glog"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog"
 
 	routeapi "github.com/openshift/api/route/v1"
 	routeset "github.com/openshift/client-go/route/clientset/versioned"
@@ -24,7 +25,7 @@ type Controller struct {
 }
 
 func (c *Controller) Start(handler opcontroller.Handler, namespace string, stopCh <-chan struct{}) error {
-	klog.Info("Starting routes controller")
+	glog.Info("Starting routes controller")
 
 	kubeconfig, err := client.GetConfig()
 	if err != nil {
@@ -61,7 +62,7 @@ func (c *Controller) Start(handler opcontroller.Handler, namespace string, stopC
 
 	informerFactory.Start(stopCh)
 
-	klog.Info("Waiting for routes informer caches to sync")
+	glog.Info("Waiting for routes informer caches to sync")
 	if ok := cache.WaitForCacheSync(stopCh, c.synced); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}

--- a/pkg/operator/controller/secrets/secret.go
+++ b/pkg/operator/controller/secrets/secret.go
@@ -3,13 +3,14 @@ package secret
 import (
 	"fmt"
 
+	"github.com/golang/glog"
+
 	coreapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubeinformers "k8s.io/client-go/informers"
 	kubeset "k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog"
 
 	"github.com/openshift/cluster-image-registry-operator/pkg/client"
 	opcontroller "github.com/openshift/cluster-image-registry-operator/pkg/operator/controller"
@@ -23,7 +24,7 @@ type Controller struct {
 }
 
 func (c *Controller) Start(handler opcontroller.Handler, namespace string, stopCh <-chan struct{}) error {
-	klog.Info("Starting secrets controller")
+	glog.Info("Starting secrets controller")
 
 	kubeconfig, err := client.GetConfig()
 	if err != nil {
@@ -60,7 +61,7 @@ func (c *Controller) Start(handler opcontroller.Handler, namespace string, stopC
 
 	kubeInformerFactory.Start(stopCh)
 
-	klog.Info("Waiting for secrets informer caches to sync")
+	glog.Info("Waiting for secrets informer caches to sync")
 	if ok := cache.WaitForCacheSync(stopCh, c.synced); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}

--- a/pkg/operator/controller/serviceaccounts/serviceaccounts.go
+++ b/pkg/operator/controller/serviceaccounts/serviceaccounts.go
@@ -3,13 +3,14 @@ package serviceaccounts
 import (
 	"fmt"
 
+	"github.com/golang/glog"
+
 	coreapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubeinformers "k8s.io/client-go/informers"
 	kubeset "k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog"
 
 	"github.com/openshift/cluster-image-registry-operator/pkg/client"
 	opcontroller "github.com/openshift/cluster-image-registry-operator/pkg/operator/controller"
@@ -23,7 +24,7 @@ type Controller struct {
 }
 
 func (c *Controller) Start(handler opcontroller.Handler, namespace string, stopCh <-chan struct{}) error {
-	klog.Info("Starting services controller")
+	glog.Info("Starting services controller")
 
 	kubeconfig, err := client.GetConfig()
 	if err != nil {
@@ -60,7 +61,7 @@ func (c *Controller) Start(handler opcontroller.Handler, namespace string, stopC
 
 	kubeInformerFactory.Start(stopCh)
 
-	klog.Info("Waiting for services informer caches to sync")
+	glog.Info("Waiting for services informer caches to sync")
 	if ok := cache.WaitForCacheSync(stopCh, c.synced); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}

--- a/pkg/operator/controller/services/service.go
+++ b/pkg/operator/controller/services/service.go
@@ -3,13 +3,14 @@ package service
 import (
 	"fmt"
 
+	"github.com/golang/glog"
+
 	coreapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubeinformers "k8s.io/client-go/informers"
 	kubeset "k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog"
 
 	"github.com/openshift/cluster-image-registry-operator/pkg/client"
 	opcontroller "github.com/openshift/cluster-image-registry-operator/pkg/operator/controller"
@@ -23,7 +24,7 @@ type Controller struct {
 }
 
 func (c *Controller) Start(handler opcontroller.Handler, namespace string, stopCh <-chan struct{}) error {
-	klog.Info("Starting services controller")
+	glog.Info("Starting services controller")
 
 	kubeconfig, err := client.GetConfig()
 	if err != nil {
@@ -60,7 +61,7 @@ func (c *Controller) Start(handler opcontroller.Handler, namespace string, stopC
 
 	kubeInformerFactory.Start(stopCh)
 
-	klog.Info("Waiting for services informer caches to sync")
+	glog.Info("Waiting for services informer caches to sync")
 	if ok := cache.WaitForCacheSync(stopCh, c.synced); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}

--- a/pkg/operator/finalizer.go
+++ b/pkg/operator/finalizer.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/golang/glog"
+
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/klog"
 
 	osapi "github.com/openshift/cluster-version-operator/pkg/apis/operatorstatus.openshift.io/v1"
 
@@ -25,7 +26,7 @@ func (c *Controller) RemoveResources(o *regopapi.ImageRegistry) error {
 
 	errOp := c.clusterStatus.Update(osapi.OperatorProgressing, osapi.ConditionTrue, "registry is being removed")
 	if errOp != nil {
-		klog.Errorf("unable to update cluster status to %s=%s: %s", osapi.OperatorProgressing, osapi.ConditionTrue, errOp)
+		glog.Errorf("unable to update cluster status to %s=%s: %s", osapi.OperatorProgressing, osapi.ConditionTrue, errOp)
 	}
 
 	return c.generator.Remove(o, &modified)
@@ -47,13 +48,13 @@ func (c *Controller) finalizeResources(o *regopapi.ImageRegistry) error {
 		return nil
 	}
 
-	klog.Infof("finalizing %s", metautil.TypeAndName(o))
+	glog.Infof("finalizing %s", metautil.TypeAndName(o))
 
 	err := c.RemoveResources(o)
 	if err != nil {
 		errOp := c.clusterStatus.Update(osapi.OperatorFailing, osapi.ConditionTrue, "unable to remove registry")
 		if errOp != nil {
-			klog.Errorf("unable to update cluster status to %s=%s: %s", osapi.OperatorFailing, osapi.ConditionTrue, errOp)
+			glog.Errorf("unable to update cluster status to %s=%s: %s", osapi.OperatorFailing, osapi.ConditionTrue, errOp)
 		}
 		return fmt.Errorf("unable to finalize resource: %s", err)
 	}

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -3,10 +3,11 @@ package operator
 import (
 	"fmt"
 
+	"github.com/golang/glog"
+
 	kappsapi "k8s.io/api/apps/v1"
 	metaapi "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/klog"
 
 	appsapi "github.com/openshift/api/apps/v1"
 	operatorapi "github.com/openshift/api/operator/v1alpha1"
@@ -133,7 +134,7 @@ func (c *Controller) syncStatus(cr *regopapi.ImageRegistry, o runtime.Object, ap
 
 	err := c.clusterStatus.Update(osapi.OperatorAvailable, operatorAvailable, operatorAvailableMsg)
 	if err != nil {
-		klog.Errorf("unable to update cluster status to %s=%s (%s): %s", osapi.OperatorAvailable, operatorAvailable, operatorAvailableMsg, err)
+		glog.Errorf("unable to update cluster status to %s=%s (%s): %s", osapi.OperatorAvailable, operatorAvailable, operatorAvailableMsg, err)
 	}
 
 	updateCondition(cr, &operatorapi.OperatorCondition{
@@ -160,7 +161,7 @@ func (c *Controller) syncStatus(cr *regopapi.ImageRegistry, o runtime.Object, ap
 
 	err = c.clusterStatus.Update(osapi.OperatorProgressing, operatorProgressing, operatorProgressingMsg)
 	if err != nil {
-		klog.Errorf("unable to update cluster status to %s=%s (%s): %s", osapi.OperatorProgressing, operatorProgressing, operatorProgressingMsg, err)
+		glog.Errorf("unable to update cluster status to %s=%s (%s): %s", osapi.OperatorProgressing, operatorProgressing, operatorProgressingMsg, err)
 	}
 
 	updateCondition(cr, &operatorapi.OperatorCondition{
@@ -179,7 +180,7 @@ func (c *Controller) syncStatus(cr *regopapi.ImageRegistry, o runtime.Object, ap
 
 	err = c.clusterStatus.Update(osapi.OperatorFailing, operatorFailing, operatorFailingMsg)
 	if err != nil {
-		klog.Errorf("unable to update cluster status to %s=%s (%s): %s", osapi.OperatorFailing, operatorFailing, operatorFailingMsg, err)
+		glog.Errorf("unable to update cluster status to %s=%s (%s): %s", osapi.OperatorFailing, operatorFailing, operatorFailingMsg, err)
 	}
 
 	updateCondition(cr, &operatorapi.OperatorCondition{

--- a/pkg/resource/generator.go
+++ b/pkg/resource/generator.go
@@ -5,13 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/golang/glog"
+
 	routeset "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	kmeta "k8s.io/apimachinery/pkg/api/meta"
 	metaapi "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/klog"
 
 	regopapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1alpha1"
 
@@ -157,7 +158,7 @@ func (g *Generator) applyTemplate(tmpl Template, modified *bool) error {
 				return fmt.Errorf("failed to get object %s: %s", tmpl.Name(), err)
 			}
 
-			klog.Infof("creating object: %s", tmpl.Name())
+			glog.Infof("creating object: %s", tmpl.Name())
 
 			err = tmpl.Create()
 			if err == nil {
@@ -174,7 +175,7 @@ func (g *Generator) applyTemplate(tmpl Template, modified *bool) error {
 
 		curdgst, ok := currentMeta.GetAnnotations()[parameters.ChecksumOperatorAnnotation]
 		if ok && dgst == curdgst {
-			klog.V(1).Infof("object has not changed: %s", tmpl.Name())
+			glog.V(1).Infof("object has not changed: %s", tmpl.Name())
 			return nil
 		}
 
@@ -197,7 +198,7 @@ func (g *Generator) applyTemplate(tmpl Template, modified *bool) error {
 		}
 		updatedMeta.GetAnnotations()[parameters.ChecksumOperatorAnnotation] = dgst
 
-		klog.Infof("updating object: %s", tmpl.Name())
+		glog.Infof("updating object: %s", tmpl.Name())
 
 		err = tmpl.Update(updated)
 		if err == nil {
@@ -238,7 +239,7 @@ func (g *Generator) removeByTemplate(tmpl Template, modified *bool) error {
 		PropagationPolicy:  &propagationPolicy,
 	}
 
-	klog.Infof("deleting object %s", tmpl.Name())
+	glog.Infof("deleting object %s", tmpl.Name())
 
 	err := tmpl.Delete(opts)
 	if err != nil {
@@ -262,7 +263,7 @@ func (g *Generator) Remove(cr *regopapi.ImageRegistry, modified *bool) error {
 		if err != nil {
 			return fmt.Errorf("unable to remove objects: %s", err)
 		}
-		klog.Infof("resource %s removed", tmpl.Name())
+		glog.Infof("resource %s removed", tmpl.Name())
 	}
 
 	return nil

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -3,8 +3,9 @@ package storage
 import (
 	"fmt"
 
+	"github.com/golang/glog"
+
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/klog"
 
 	opapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1alpha1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/clusterconfig"
@@ -95,7 +96,7 @@ func NewDriver(crname string, crnamespace string, cfg *opapi.ImageRegistryConfig
 		case clusterconfig.StorageTypeSwift:
 			cfg.Swift = &opapi.ImageRegistryConfigStorageSwift{}
 		default:
-			klog.Errorf("unknown storage backend: %s", storageType)
+			glog.Errorf("unknown storage backend: %s", storageType)
 			return nil, ErrStorageNotConfigured
 		}
 		return newDriver(crname, crnamespace, cfg)

--- a/pkg/storage/util/util.go
+++ b/pkg/storage/util/util.go
@@ -3,12 +3,13 @@ package util
 import (
 	opapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1alpha1"
 
+	"github.com/golang/glog"
+
 	coreapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metaapi "k8s.io/apimachinery/pkg/apis/meta/v1"
 	coreset "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/klog"
 
 	"github.com/openshift/cluster-image-registry-operator/pkg/client"
 )
@@ -33,7 +34,7 @@ func CreateOrUpdateSecret(name string, namespace string, data map[string]string)
 				return err
 			}
 
-			klog.Warningf("secret %s/%s not found: %s, creating", namespace, secretName, err)
+			glog.Warningf("secret %s/%s not found: %s, creating", namespace, secretName, err)
 
 			cur = &coreapi.Secret{
 				ObjectMeta: metaapi.ObjectMeta{


### PR DESCRIPTION
After discussion with Master team, we came to the conclusion that for
now you need to roll back to glog and wait for kubernetes-1.13 where it
is likely to switch to klog.

But we need to be careful, since messages from modules that use klog
will be lost now and we have no protection against this.

Fixes github.com/openshift/cluster-image-registry-operator/issues/85
