### PR TITLE
A few cleanup items

### DIFF
--- a/cmd/cluster-image-registry-operator/main.go
+++ b/cmd/cluster-image-registry-operator/main.go
@@ -12,7 +12,7 @@ import (
 
 	appsset "github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1"
 
-	"github.com/openshift/cluster-image-registry-operator/pkg/client"
+	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
 	"github.com/openshift/cluster-image-registry-operator/pkg/operator"
 	"github.com/openshift/cluster-image-registry-operator/pkg/signals"
 	"github.com/openshift/cluster-image-registry-operator/version"
@@ -32,12 +32,12 @@ func main() {
 
 	printVersion()
 
-	cfg, err := client.GetConfig()
+	cfg, err := regopclient.GetConfig()
 	if err != nil {
 		glog.Fatalf("Error building kubeconfig: %s", err)
 	}
 
-	namespace, err := client.GetWatchNamespace()
+	namespace, err := regopclient.GetWatchNamespace()
 	if err != nil {
 		glog.Fatalf("failed to get watch namespace: %s", err)
 	}

--- a/pkg/clusterconfig/clusterconfig.go
+++ b/pkg/clusterconfig/clusterconfig.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	coreset "k8s.io/client-go/kubernetes/typed/core/v1"
 
-	"github.com/openshift/cluster-image-registry-operator/pkg/client"
+	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
 )
 
 const (
@@ -59,7 +59,7 @@ type Config struct {
 }
 
 func GetCoreClient() (*coreset.CoreV1Client, error) {
-	kubeconfig, err := client.GetConfig()
+	kubeconfig, err := regopclient.GetConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -103,8 +103,9 @@ func GetAWSConfig() (*Config, error) {
 		return nil, err
 	}
 	cfg.Storage.Type = StorageTypeS3
-	cfg.Storage.S3.Region = installConfig.Platform.AWS.Region
-
+	if installConfig.Platform.AWS != nil {
+		cfg.Storage.S3.Region = installConfig.Platform.AWS.Region
+	}
 	sec, err := client.Secrets(installerConfigNamespace).Get(installerAWSCredsName, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("unable to read aws-creds secret: %v", err)

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -20,7 +20,7 @@ import (
 	regopapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1alpha1"
 	regopset "github.com/openshift/cluster-image-registry-operator/pkg/generated/clientset/versioned/typed/imageregistry/v1alpha1"
 
-	"github.com/openshift/cluster-image-registry-operator/pkg/client"
+	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
 	"github.com/openshift/cluster-image-registry-operator/pkg/clusteroperator"
 	"github.com/openshift/cluster-image-registry-operator/pkg/metautil"
 	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
@@ -51,12 +51,12 @@ func (e permanentError) Error() string {
 }
 
 func NewController(kubeconfig *restclient.Config, namespace string) (*Controller, error) {
-	operatorNamespace, err := client.GetWatchNamespace()
+	operatorNamespace, err := regopclient.GetWatchNamespace()
 	if err != nil {
 		glog.Fatalf("Failed to get watch namespace: %v", err)
 	}
 
-	operatorName, err := client.GetOperatorName()
+	operatorName, err := regopclient.GetOperatorName()
 	if err != nil {
 		glog.Fatalf("Failed to get operator name: %v", err)
 	}

--- a/pkg/operator/controller/imageregistry/imageregistry.go
+++ b/pkg/operator/controller/imageregistry/imageregistry.go
@@ -13,7 +13,7 @@ import (
 	imageregistryinformers "github.com/openshift/cluster-image-registry-operator/pkg/generated/informers/externalversions"
 	imageregistrylisters "github.com/openshift/cluster-image-registry-operator/pkg/generated/listers/imageregistry/v1alpha1"
 
-	"github.com/openshift/cluster-image-registry-operator/pkg/client"
+	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
 	opcontroller "github.com/openshift/cluster-image-registry-operator/pkg/operator/controller"
 )
 
@@ -27,7 +27,7 @@ type Controller struct {
 func (c *Controller) Start(handler opcontroller.Handler, namespace string, stopCh <-chan struct{}) error {
 	glog.Info("Starting imageregistry controller")
 
-	kubeconfig, err := client.GetConfig()
+	kubeconfig, err := regopclient.GetConfig()
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/controller/routes/routes.go
+++ b/pkg/operator/controller/routes/routes.go
@@ -13,7 +13,7 @@ import (
 	routeinformers "github.com/openshift/client-go/route/informers/externalversions"
 	routelisters "github.com/openshift/client-go/route/listers/route/v1"
 
-	"github.com/openshift/cluster-image-registry-operator/pkg/client"
+	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
 	opcontroller "github.com/openshift/cluster-image-registry-operator/pkg/operator/controller"
 )
 
@@ -27,7 +27,7 @@ type Controller struct {
 func (c *Controller) Start(handler opcontroller.Handler, namespace string, stopCh <-chan struct{}) error {
 	glog.Info("Starting routes controller")
 
-	kubeconfig, err := client.GetConfig()
+	kubeconfig, err := regopclient.GetConfig()
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/util/util.go
+++ b/pkg/storage/util/util.go
@@ -9,11 +9,11 @@ import (
 	coreset "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/util/retry"
 
-	"github.com/openshift/cluster-image-registry-operator/pkg/client"
+	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
 )
 
 func CreateOrUpdateSecret(name string, namespace string, data map[string]string) error {
-	kubeconfig, err := client.GetConfig()
+	kubeconfig, err := regopclient.GetConfig()
 	if err != nil {
 		return err
 	}

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -46,19 +46,19 @@ func TestAWS(t *testing.T) {
 	testframework.MustDeployImageRegistry(t, client, nil)
 	testframework.MustEnsureImageRegistryIsAvailable(t, client)
 
-	cfg, err := clusterconfig.GetAWSConfig()
-	if err != nil {
-		t.Errorf("unable to get cluster configuration: %#v", err)
-	}
 	installConfig, err := clusterconfig.GetInstallConfig()
 	if err != nil {
 		t.Errorf("unable to get install configuration: %#v", err)
 	}
 
-	// If the storage type is not S3, skip this test.
-	if cfg.Storage.Type != clusterconfig.StorageTypeS3 {
-		t.Logf("Skipping S3 storage configuration tests")
-		return
+	// If we are not running on AWS, skip this test.
+	if installConfig.Platform.AWS == nil {
+		t.Skip()
+	}
+
+	cfg, err := clusterconfig.GetAWSConfig()
+	if err != nil {
+		t.Errorf("unable to get cluster configuration: %#v", err)
 	}
 
 	// Check that the image-registry-private-configuration secret exists and
@@ -122,10 +122,8 @@ func TestAWS(t *testing.T) {
 	tagShouldExist := map[string]string{
 		"tectonicClusterID": installConfig.ClusterID,
 	}
-	if installConfig.Platform.AWS != nil {
-		for k, v := range installConfig.Platform.AWS.UserTags {
-			tagShouldExist[k] = v
-		}
+	for k, v := range installConfig.Platform.AWS.UserTags {
+		tagShouldExist[k] = v
 	}
 	for tk, tv := range tagShouldExist {
 		found := false

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -122,10 +122,11 @@ func TestAWS(t *testing.T) {
 	tagShouldExist := map[string]string{
 		"tectonicClusterID": installConfig.ClusterID,
 	}
-	for k, v := range installConfig.Platform.AWS.UserTags {
-		tagShouldExist[k] = v
+	if installConfig.Platform.AWS != nil {
+		for k, v := range installConfig.Platform.AWS.UserTags {
+			tagShouldExist[k] = v
+		}
 	}
-
 	for tk, tv := range tagShouldExist {
 		found := false
 


### PR DESCRIPTION
Cleaning up a few items that I noticed during previous work:

- guard against Platform.AWS being nil
- error string should not start with a capital letter
- variable should not mask imported package name

All are in their own commits for easy review