### PR TITLE
replace tectonicClusterID tag with openshiftClusterID

### DIFF
--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -100,7 +100,7 @@ func (d *driver) createAndTagBucket(svc *s3.S3, installConfig *installer.Install
 
 	if installConfig.Platform.AWS != nil {
 		var tagSet []*s3.Tag
-		tagSet = append(tagSet, &s3.Tag{Key: aws.String("tectonicClusterID"), Value: aws.String(installConfig.ClusterID)})
+		tagSet = append(tagSet, &s3.Tag{Key: aws.String("openshiftClusterID"), Value: aws.String(installConfig.ClusterID)})
 		for k, v := range installConfig.Platform.AWS.UserTags {
 			tagSet = append(tagSet, &s3.Tag{Key: aws.String(k), Value: aws.String(v)})
 		}

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -119,7 +119,7 @@ func TestAWS(t *testing.T) {
 	}
 
 	tagShouldExist := map[string]string{
-		"tectonicClusterID": installConfig.ClusterID,
+		"openshiftClusterID": installConfig.ClusterID,
 	}
 	for k, v := range installConfig.Platform.AWS.UserTags {
 		tagShouldExist[k] = v


### PR DESCRIPTION
The tectonicClusterID tag is being replaced with openshiftClusterID in the installer. This change will use the new tag name.

Hold on openshift/installer#817.

/hold