### PR TITLE
fix comment that still refers to tectonicClusterID

### DIFF
--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -102,7 +102,7 @@ func (d *driver) createAndTagBucket(svc *s3.S3, installConfig *installer.Install
 		return err
 	}
 
-	// Tag the bucket with the tectonicClusterID
+	// Tag the bucket with the openshiftClusterID
 	// along with any user defined tags from the cluster configuration
 	if installConfig.Platform.AWS != nil {
 		var tagSet []*s3.Tag


### PR DESCRIPTION
The tectonicClusterID tag was replaced with openshiftClusterID in 63442f4f5ee14287345f1e4d8129197d8b4450e6. However, there was a comment inadvertently left behind that still references tectonicClusterID.

See #114.