### PR TITLE
A few small cleanup items

### DIFF
--- a/pkg/clusterconfig/clusterconfig.go
+++ b/pkg/clusterconfig/clusterconfig.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	STORAGE_PREFIX = "image-registry"
+	StoragePrefix = "image-registry"
 
 	StorageTypeAzure      StorageType = "azure"
 	StorageTypeGCS        StorageType = "gcs"

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -23,7 +23,6 @@ import (
 	routeinformers "github.com/openshift/client-go/route/informers/externalversions"
 
 	regopapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1alpha1"
-	"github.com/openshift/cluster-image-registry-operator/pkg/client"
 	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
 	"github.com/openshift/cluster-image-registry-operator/pkg/clusteroperator"
 	regopset "github.com/openshift/cluster-image-registry-operator/pkg/generated/clientset/versioned"
@@ -67,7 +66,7 @@ func NewController(kubeconfig *restclient.Config, namespace string) (*Controller
 	p.ImageConfig.Name = "cluster"
 	p.CAConfig.Name = "image-registry-certificates"
 
-	listers := &client.Listers{}
+	listers := &regopclient.Listers{}
 	c := &Controller{
 		kubeconfig:    kubeconfig,
 		params:        p,
@@ -89,7 +88,7 @@ type Controller struct {
 	generator     *resource.Generator
 	clusterStatus *clusteroperator.StatusHandler
 	workqueue     workqueue.RateLimitingInterface
-	listers       *client.Listers
+	listers       *regopclient.Listers
 }
 
 func (c *Controller) createOrUpdateResources(cr *regopapi.ImageRegistry, modified *bool) error {

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -178,7 +178,7 @@ func (c *Controller) sync() error {
 			return err
 		}
 
-		_, err = client.Imageregistry().ImageRegistries().Update(cr)
+		_, err = client.ImageregistryV1alpha1().ImageRegistries().Update(cr)
 		if err != nil {
 			if !errors.IsConflict(err) {
 				glog.Errorf("unable to update %s: %s", objectInfo(cr), err)

--- a/pkg/resource/strategy/override_test.go
+++ b/pkg/resource/strategy/override_test.go
@@ -54,7 +54,7 @@ func TestOverride(t *testing.T) {
 		t.Errorf("annotation foo: got %q, want %q", val, "bar")
 	}
 	if len(o.OwnerReferences) != 1 || o.OwnerReferences[0].Name != "owner-name" {
-		t.Errorf("unexpected owner references: %q", o.OwnerReferences)
+		t.Errorf("unexpected owner references: %#v", o.OwnerReferences)
 	}
 	if val := o.Spec.HTTPSecret; val != "new-secret" {
 		t.Errorf("httpsecret: got %q, want %q", val, "new-secret")

--- a/pkg/storage/gcs/gcs.go
+++ b/pkg/storage/gcs/gcs.go
@@ -110,7 +110,7 @@ func (d *driver) CompleteConfiguration(customResourceStatus *opapi.ImageRegistry
 		}
 
 		for {
-			d.Config.Bucket = fmt.Sprintf("%s-%s", clusterconfig.STORAGE_PREFIX, string(uuid.NewUUID()))
+			d.Config.Bucket = fmt.Sprintf("%s-%s", clusterconfig.StoragePrefix, string(uuid.NewUUID()))
 
 			err = client.Bucket(d.Config.Bucket).Create(ctx, projectID, nil)
 

--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -176,7 +176,7 @@ func (d *driver) CompleteConfiguration(customResourceStatus *opapi.ImageRegistry
 
 	if len(d.Config.Bucket) == 0 {
 		for {
-			d.Config.Bucket = fmt.Sprintf("%s-%s-%s-%s", clusterconfig.STORAGE_PREFIX, d.Config.Region, strings.Replace(installConfig.ClusterID, "-", "", -1), strings.Replace(string(uuid.NewUUID()), "-", "", -1))[0:62]
+			d.Config.Bucket = fmt.Sprintf("%s-%s-%s-%s", clusterconfig.StoragePrefix, d.Config.Region, strings.Replace(installConfig.ClusterID, "-", "", -1), strings.Replace(string(uuid.NewUUID()), "-", "", -1))[0:62]
 			if err := d.createAndTagBucket(svc, installConfig, customResourceStatus); err != nil {
 				if aerr, ok := err.(awserr.Error); ok {
 					switch aerr.Code() {


### PR DESCRIPTION
Fixing a few small issues that I have run across:

- Update deprecated ImageRegistry() with ImageRegistryV1alpha1()
- Use snake case instead of CAMEL_CASE
- fix using %q when we shouldn't be
- variable name masks imported package name (and package was imported twice"

Each in it's own commit for easy review.