### PR TITLE
Abort incomplete multipart uploads on AWS/S3

### DIFF
--- a/pkg/apis/imageregistry/v1alpha1/types.go
+++ b/pkg/apis/imageregistry/v1alpha1/types.go
@@ -129,6 +129,10 @@ const (
 	// StorageEncrypted denotes whether or not the registry storage medium
 	// that we created has encryption enabled
 	StorageEncrypted = "StorageEncrypted"
+
+	// StorageIncompleteUploadCleanupEnabled denotes whethere or not the registry storage
+	// medium is configured to automatically cleanup incomplete uploads
+	StorageIncompleteUploadCleanupEnabled = "StorageIncompleteUploadCleanupEnabled"
 )
 
 type ImageRegistryStatus struct {

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -173,6 +173,7 @@ func TestAWSDefaults(t *testing.T) {
 				if *v.Value != tv {
 					t.Errorf("s3 bucket has the wrong value for tag \"%s\": wanted %s, got %s", tk, *v.Value, tv)
 				}
+				break
 			}
 		}
 		if !found {


### PR DESCRIPTION
- Delete the leftover parts of an incomplete multipart upload
- Refactor a few small sections of the s3 driver file (no functionality changes)

Fixes #128