### PR TITLE
a small refactor / cleanup

### DIFF
--- a/pkg/clusterconfig/clusterconfig.go
+++ b/pkg/clusterconfig/clusterconfig.go
@@ -124,12 +124,12 @@ func GetAWSConfig() (*Config, error) {
 		if v, ok := sec.Data["aws_access_key_id"]; ok {
 			cfg.Storage.S3.AccessKey = string(v)
 		} else {
-			return nil, fmt.Errorf("Secret %q does not contain required key \"aws_access_key_id\"", fmt.Sprintf("%s/%s", installerConfigNamespace, installerAWSCredsName))
+			return nil, fmt.Errorf("secret %q does not contain required key \"aws_access_key_id\"", fmt.Sprintf("%s/%s", installerConfigNamespace, installerAWSCredsName))
 		}
 		if v, ok := sec.Data["aws_secret_access_key"]; ok {
 			cfg.Storage.S3.SecretKey = string(v)
 		} else {
-			return nil, fmt.Errorf("Secret %q does not contain required key \"aws_secret_access_key\"", fmt.Sprintf("%s/%s", installerConfigNamespace, installerAWSCredsName))
+			return nil, fmt.Errorf("secret %q does not contain required key \"aws_secret_access_key\"", fmt.Sprintf("%s/%s", installerConfigNamespace, installerAWSCredsName))
 		}
 	} else if err != nil {
 		return nil, err
@@ -137,12 +137,12 @@ func GetAWSConfig() (*Config, error) {
 		if v, ok := sec.Data["REGISTRY_STORAGE_S3_ACCESSKEY"]; ok {
 			cfg.Storage.S3.AccessKey = string(v)
 		} else {
-			return nil, fmt.Errorf("Secret %q does not contain required key \"REGISTRY_STORAGE_S3_ACCESSKEY\"", fmt.Sprintf("%s/%s", operatorNamespace, regopapi.ImageRegistryPrivateConfigurationUser))
+			return nil, fmt.Errorf("secret %q does not contain required key \"REGISTRY_STORAGE_S3_ACCESSKEY\"", fmt.Sprintf("%s/%s", operatorNamespace, regopapi.ImageRegistryPrivateConfigurationUser))
 		}
 		if v, ok := sec.Data["REGISTRY_STORAGE_S3_SECRETKEY"]; ok {
 			cfg.Storage.S3.SecretKey = string(v)
 		} else {
-			return nil, fmt.Errorf("Secret %q does not contain required key \"REGISTRY_STORAGE_S3_SECRETKEY\"", fmt.Sprintf("%s/%s", operatorNamespace, regopapi.ImageRegistryPrivateConfigurationUser))
+			return nil, fmt.Errorf("secret %q does not contain required key \"REGISTRY_STORAGE_S3_SECRETKEY\"", fmt.Sprintf("%s/%s", operatorNamespace, regopapi.ImageRegistryPrivateConfigurationUser))
 
 		}
 	}

--- a/pkg/resource/generator.go
+++ b/pkg/resource/generator.go
@@ -142,13 +142,13 @@ func (g *Generator) syncStorage(cr *regopapi.ImageRegistry, modified *bool) erro
 // and updates the image-registry-private-configuration secret which provides
 // those credentials to the registry pod
 func (g *Generator) syncSecrets(cr *regopapi.ImageRegistry, modified *bool) error {
-	client, err := clusterconfig.GetCoreClient()
+	coreClient, err := clusterconfig.GetCoreClient()
 	if err != nil {
 		return err
 	}
 
 	// Get the existing image-registry-private-configuration secret
-	sec, err := client.Secrets(g.params.Deployment.Namespace).Get(regopapi.ImageRegistryPrivateConfiguration, metav1.GetOptions{})
+	sec, err := coreClient.Secrets(g.params.Deployment.Namespace).Get(regopapi.ImageRegistryPrivateConfiguration, metav1.GetOptions{})
 	if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("unable to get secret %q: %v", fmt.Sprintf("%s/%s", g.params.Deployment.Namespace, regopapi.ImageRegistryPrivateConfiguration), err)
 	}

--- a/pkg/storage/util/util.go
+++ b/pkg/storage/util/util.go
@@ -129,5 +129,5 @@ func GetClusterVersionConfig() (*configv1.ClusterVersion, error) {
 	if err != nil {
 		return nil, err
 	}
-	return client.Config().ClusterVersions().Get("version", metav1.GetOptions{})
+	return client.ConfigV1().ClusterVersions().Get("version", metav1.GetOptions{})
 }

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -33,10 +33,10 @@ func conditionExistsWithStatusAndReason(client *testframework.Clientset, conditi
 			if condition.Type == conditionType {
 				conditionExists = true
 				if condition.Status != conditionStatus {
-					errs = append(errs, fmt.Errorf("condition %s status should be \"%v\" but was %v instead.", conditionType, conditionStatus, condition.Status))
+					errs = append(errs, fmt.Errorf("condition %s status should be \"%v\" but was %v instead", conditionType, conditionStatus, condition.Status))
 				}
 				if condition.Reason != conditionReason {
-					errs = append(errs, fmt.Errorf("condition %s reason should have been \"%s\" but was %s instead.", conditionType, conditionReason, condition.Reason))
+					errs = append(errs, fmt.Errorf("condition %s reason should have been \"%s\" but was %s instead", conditionType, conditionReason, condition.Reason))
 
 				}
 			}


### PR DESCRIPTION
 - variable name should not mask imported package name
 - errors should not start with a capital letter or end with punctuation
 - update to new function name (previous was deprecated)
 - refactor storage finalizer to retry on conflict with a new version of the image registry resource and update the test for the s3 finalizer

