### PR TITLE
be more judicious when setting modified=true

### DIFF
--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -129,7 +129,8 @@ func (c *Controller) Bootstrap() error {
 		return err
 	}
 
-	err = driver.CompleteConfiguration(cr)
+	modified := false
+	err = driver.CompleteConfiguration(cr, &modified)
 	_, cerr := client.ImageRegistries().Create(cr)
 	if cerr != nil {
 		return cerr

--- a/pkg/operator/finalizer.go
+++ b/pkg/operator/finalizer.go
@@ -68,8 +68,8 @@ func (c *Controller) finalizeResources(o *regopapi.ImageRegistry) error {
 				return fmt.Errorf("failed to get %s: %s", objectInfo(o), err)
 			}
 		}
-
-		if err := driver.RemoveStorage(cr); err != nil {
+		modified := false
+		if err := driver.RemoveStorage(cr, &modified); err != nil {
 			cr = nil
 			return err
 		}

--- a/pkg/resource/caconfig.go
+++ b/pkg/resource/caconfig.go
@@ -25,12 +25,13 @@ type generatorCAConfig struct {
 
 func newGeneratorCAConfig(lister corelisters.ConfigMapNamespaceLister, openshiftConfigLister corelisters.ConfigMapNamespaceLister, client coreset.CoreV1Interface, params *parameters.Globals, cr *regopapi.ImageRegistry) *generatorCAConfig {
 	return &generatorCAConfig{
-		lister:       lister,
-		client:       client,
-		name:         params.CAConfig.Name,
-		namespace:    params.Deployment.Namespace,
-		caConfigName: cr.Spec.CAConfigName,
-		owner:        asOwner(cr),
+		lister:                lister,
+		openshiftConfigLister: openshiftConfigLister,
+		client:                client,
+		name:                  params.CAConfig.Name,
+		namespace:             params.Deployment.Namespace,
+		caConfigName:          cr.Spec.CAConfigName,
+		owner:                 asOwner(cr),
 	}
 }
 

--- a/pkg/resource/generator.go
+++ b/pkg/resource/generator.go
@@ -97,7 +97,6 @@ func (g *Generator) list(cr *regopapi.ImageRegistry) ([]Mutator, error) {
 //      b.) see if we need to try to create the new storage
 func (g *Generator) syncStorage(cr *regopapi.ImageRegistry, modified *bool) error {
 	var runCreate bool
-	*modified = true
 	// Create a driver with the current configuration
 	driver, err := storage.NewDriver(cr.Name, cr.Namespace, &cr.Spec.Storage)
 	if err != nil {
@@ -105,14 +104,14 @@ func (g *Generator) syncStorage(cr *regopapi.ImageRegistry, modified *bool) erro
 	}
 
 	// If the storage medium name is blank, we need to create it
-	name, err := driver.GetStorageName(cr)
+	name, err := driver.GetStorageName(cr, modified)
 	if err != nil {
 		return err
 	}
 	if len(name) == 0 {
 		runCreate = true
-	} else if driver.StorageChanged(cr) {
-		exists, err := driver.StorageExists(cr)
+	} else if driver.StorageChanged(cr, modified) {
+		exists, err := driver.StorageExists(cr, modified)
 		if err != nil {
 			return err
 		}
@@ -120,7 +119,7 @@ func (g *Generator) syncStorage(cr *regopapi.ImageRegistry, modified *bool) erro
 			runCreate = true
 		}
 	} else {
-		exists, err := driver.StorageExists(cr)
+		exists, err := driver.StorageExists(cr, modified)
 		if err != nil {
 			return err
 		}
@@ -130,7 +129,7 @@ func (g *Generator) syncStorage(cr *regopapi.ImageRegistry, modified *bool) erro
 	}
 
 	if runCreate {
-		if err := driver.CreateStorage(cr); err != nil {
+		if err := driver.CreateStorage(cr, modified); err != nil {
 			return err
 		}
 	}

--- a/pkg/storage/azure/azure.go
+++ b/pkg/storage/azure/azure.go
@@ -63,26 +63,26 @@ func (d *driver) ConfigEnv() (envs []corev1.EnvVar, err error) {
 	return
 }
 
-func (d *driver) StorageExists(cr *opapi.ImageRegistry) (bool, error) {
+func (d *driver) StorageExists(cr *opapi.ImageRegistry, modified *bool) (bool, error) {
 	return false, nil
 }
 
-func (d *driver) StorageChanged(cr *opapi.ImageRegistry) bool {
+func (d *driver) StorageChanged(cr *opapi.ImageRegistry, modified *bool) bool {
 	return false
 }
 
-func (d *driver) GetStorageName(cr *opapi.ImageRegistry) (string, error) {
+func (d *driver) GetStorageName(cr *opapi.ImageRegistry, modified *bool) (string, error) {
 	if cr.Spec.Storage.Azure != nil {
 		return cr.Spec.Storage.Azure.Container, nil
 	}
 	return "", fmt.Errorf("unable to retrieve container name from image registry resource: %#v", cr.Spec.Storage)
 }
 
-func (d *driver) CreateStorage(cr *opapi.ImageRegistry) error {
+func (d *driver) CreateStorage(cr *opapi.ImageRegistry, modified *bool) error {
 	return nil
 }
 
-func (d *driver) RemoveStorage(cr *opapi.ImageRegistry) error {
+func (d *driver) RemoveStorage(cr *opapi.ImageRegistry, modified *bool) error {
 	if !cr.Status.Storage.Managed {
 		return nil
 	}
@@ -94,6 +94,6 @@ func (d *driver) Volumes() ([]corev1.Volume, []corev1.VolumeMount, error) {
 	return nil, nil, nil
 }
 
-func (d *driver) CompleteConfiguration(cr *opapi.ImageRegistry) error {
+func (d *driver) CompleteConfiguration(cr *opapi.ImageRegistry, modified *bool) error {
 	return nil
 }

--- a/pkg/storage/emptydir/emptydir.go
+++ b/pkg/storage/emptydir/emptydir.go
@@ -57,29 +57,29 @@ func (d *driver) Volumes() ([]corev1.Volume, []corev1.VolumeMount, error) {
 	return []corev1.Volume{vol}, []corev1.VolumeMount{mount}, nil
 }
 
-func (d *driver) StorageExists(cr *opapi.ImageRegistry) (bool, error) {
+func (d *driver) StorageExists(cr *opapi.ImageRegistry, modified *bool) (bool, error) {
 	return false, nil
 }
 
-func (d *driver) StorageChanged(cr *opapi.ImageRegistry) bool {
+func (d *driver) StorageChanged(cr *opapi.ImageRegistry, modified *bool) bool {
 	return false
 }
 
-func (d *driver) GetStorageName(cr *opapi.ImageRegistry) (string, error) {
+func (d *driver) GetStorageName(cr *opapi.ImageRegistry, modified *bool) (string, error) {
 	return "", nil
 }
 
-func (d *driver) CreateStorage(cr *opapi.ImageRegistry) error {
+func (d *driver) CreateStorage(cr *opapi.ImageRegistry, modified *bool) error {
 	return nil
 }
 
-func (d *driver) RemoveStorage(cr *opapi.ImageRegistry) error {
+func (d *driver) RemoveStorage(cr *opapi.ImageRegistry, modified *bool) error {
 	return nil
 }
 
-func (d *driver) CompleteConfiguration(cr *opapi.ImageRegistry) error {
+func (d *driver) CompleteConfiguration(cr *opapi.ImageRegistry, modified *bool) error {
 
 	cr.Status.Storage.State.Filesystem = d.Config
-
+	*modified = true
 	return nil
 }

--- a/pkg/storage/filesystem/filesystem.go
+++ b/pkg/storage/filesystem/filesystem.go
@@ -57,23 +57,23 @@ func (d *driver) Volumes() ([]corev1.Volume, []corev1.VolumeMount, error) {
 	return []corev1.Volume{vol}, []corev1.VolumeMount{mount}, nil
 }
 
-func (d *driver) StorageExists(cr *opapi.ImageRegistry) (bool, error) {
+func (d *driver) StorageExists(cr *opapi.ImageRegistry, modified *bool) (bool, error) {
 	return false, nil
 }
 
-func (d *driver) StorageChanged(cr *opapi.ImageRegistry) bool {
+func (d *driver) StorageChanged(cr *opapi.ImageRegistry, modified *bool) bool {
 	return false
 }
 
-func (d *driver) GetStorageName(cr *opapi.ImageRegistry) (string, error) {
+func (d *driver) GetStorageName(cr *opapi.ImageRegistry, modified *bool) (string, error) {
 	return "", nil
 }
 
-func (d *driver) CreateStorage(cr *opapi.ImageRegistry) error {
+func (d *driver) CreateStorage(cr *opapi.ImageRegistry, modified *bool) error {
 	return nil
 }
 
-func (d *driver) RemoveStorage(cr *opapi.ImageRegistry) error {
+func (d *driver) RemoveStorage(cr *opapi.ImageRegistry, modified *bool) error {
 	if !cr.Status.Storage.Managed {
 		return nil
 	}
@@ -81,7 +81,7 @@ func (d *driver) RemoveStorage(cr *opapi.ImageRegistry) error {
 	return nil
 }
 
-func (d *driver) CompleteConfiguration(cr *opapi.ImageRegistry) error {
+func (d *driver) CompleteConfiguration(cr *opapi.ImageRegistry, modified *bool) error {
 	cr.Status.Storage.State.Filesystem = d.Config
 
 	return nil

--- a/pkg/storage/gcs/gcs.go
+++ b/pkg/storage/gcs/gcs.go
@@ -103,26 +103,26 @@ func (d *driver) Volumes() ([]coreapi.Volume, []coreapi.VolumeMount, error) {
 	return []coreapi.Volume{vol}, []coreapi.VolumeMount{mount}, nil
 }
 
-func (d *driver) StorageExists(cr *opapi.ImageRegistry) (bool, error) {
+func (d *driver) StorageExists(cr *opapi.ImageRegistry, modified *bool) (bool, error) {
 	return false, nil
 }
 
-func (d *driver) StorageChanged(cr *opapi.ImageRegistry) bool {
+func (d *driver) StorageChanged(cr *opapi.ImageRegistry, modified *bool) bool {
 	return false
 }
 
-func (d *driver) GetStorageName(cr *opapi.ImageRegistry) (string, error) {
+func (d *driver) GetStorageName(cr *opapi.ImageRegistry, modified *bool) (string, error) {
 	if cr.Spec.Storage.GCS != nil {
 		return cr.Spec.Storage.GCS.Bucket, nil
 	}
 	return "", fmt.Errorf("unable to retrieve bucket name from image registry resource: %#v", cr.Spec.Storage)
 }
 
-func (d *driver) CreateStorage(cr *opapi.ImageRegistry) error {
+func (d *driver) CreateStorage(cr *opapi.ImageRegistry, modified *bool) error {
 	return nil
 }
 
-func (d *driver) RemoveStorage(cr *opapi.ImageRegistry) error {
+func (d *driver) RemoveStorage(cr *opapi.ImageRegistry, modified *bool) error {
 	if !cr.Status.Storage.Managed {
 		return nil
 	}
@@ -130,7 +130,7 @@ func (d *driver) RemoveStorage(cr *opapi.ImageRegistry) error {
 	return nil
 }
 
-func (d *driver) CompleteConfiguration(cr *opapi.ImageRegistry) error {
+func (d *driver) CompleteConfiguration(cr *opapi.ImageRegistry, modified *bool) error {
 	// Apply global config
 	cfg, err := clusterconfig.GetGCSConfig()
 	if err != nil {
@@ -174,6 +174,7 @@ func (d *driver) CompleteConfiguration(cr *opapi.ImageRegistry) error {
 	}
 
 	cr.Status.Storage.State.GCS = d.Config
+	*modified = true
 
 	return nil
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -26,12 +26,12 @@ type Driver interface {
 	GetType() string
 	ConfigEnv() ([]corev1.EnvVar, error)
 	Volumes() ([]corev1.Volume, []corev1.VolumeMount, error)
-	CompleteConfiguration(*opapi.ImageRegistry) error
-	CreateStorage(*opapi.ImageRegistry) error
-	StorageExists(*opapi.ImageRegistry) (bool, error)
-	RemoveStorage(*opapi.ImageRegistry) error
-	StorageChanged(*opapi.ImageRegistry) bool
-	GetStorageName(*opapi.ImageRegistry) (string, error)
+	CompleteConfiguration(*opapi.ImageRegistry, *bool) error
+	CreateStorage(*opapi.ImageRegistry, *bool) error
+	StorageExists(*opapi.ImageRegistry, *bool) (bool, error)
+	RemoveStorage(*opapi.ImageRegistry, *bool) error
+	StorageChanged(*opapi.ImageRegistry, *bool) bool
+	GetStorageName(*opapi.ImageRegistry, *bool) (string, error)
 	SyncSecrets(*coreapi.Secret) (map[string]string, error)
 }
 

--- a/pkg/storage/swift/swift.go
+++ b/pkg/storage/swift/swift.go
@@ -61,23 +61,23 @@ func (d *driver) ConfigEnv() (envs []corev1.EnvVar, err error) {
 	return
 }
 
-func (d *driver) StorageExists(cr *opapi.ImageRegistry) (bool, error) {
+func (d *driver) StorageExists(cr *opapi.ImageRegistry, modified *bool) (bool, error) {
 	return false, nil
 }
 
-func (d *driver) StorageChanged(cr *opapi.ImageRegistry) bool {
+func (d *driver) StorageChanged(cr *opapi.ImageRegistry, modified *bool) bool {
 	return false
 }
 
-func (d *driver) GetStorageName(cr *opapi.ImageRegistry) (string, error) {
+func (d *driver) GetStorageName(cr *opapi.ImageRegistry, modified *bool) (string, error) {
 	return "", nil
 }
 
-func (d *driver) CreateStorage(cr *opapi.ImageRegistry) error {
+func (d *driver) CreateStorage(cr *opapi.ImageRegistry, modified *bool) error {
 	return nil
 }
 
-func (d *driver) RemoveStorage(cr *opapi.ImageRegistry) error {
+func (d *driver) RemoveStorage(cr *opapi.ImageRegistry, modified *bool) error {
 	if !cr.Status.Storage.Managed {
 		return nil
 	}
@@ -89,6 +89,6 @@ func (d *driver) Volumes() ([]corev1.Volume, []corev1.VolumeMount, error) {
 	return nil, nil, nil
 }
 
-func (d *driver) CompleteConfiguration(cr *opapi.ImageRegistry) error {
+func (d *driver) CompleteConfiguration(cr *opapi.ImageRegistry, modified *bool) error {
 	return nil
 }

--- a/pkg/storage/util/util.go
+++ b/pkg/storage/util/util.go
@@ -28,7 +28,8 @@ import (
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 )
 
-func UpdateCondition(cr *regopapi.ImageRegistry, conditionType string, status operatorapi.ConditionStatus, reason string, message string) {
+// UpdateCondition will update or add the provided condition and updated the modified parameter if it changed the resource
+func UpdateCondition(cr *regopapi.ImageRegistry, conditionType string, status operatorapi.ConditionStatus, reason string, message string, modified *bool) {
 	found := false
 	condition := &operatorapi.OperatorCondition{
 		Type:               conditionType,
@@ -47,12 +48,15 @@ func UpdateCondition(cr *regopapi.ImageRegistry, conditionType string, status op
 		if c.Status != condition.Status {
 			c.Status = condition.Status
 			c.LastTransitionTime = condition.LastTransitionTime
+			*modified = true
 		}
 		if c.Reason != condition.Reason {
 			c.Reason = condition.Reason
+			*modified = true
 		}
 		if c.Message != condition.Message {
 			c.Message = condition.Message
+			*modified = true
 		}
 		conditions = append(conditions, c)
 		found = true
@@ -60,6 +64,7 @@ func UpdateCondition(cr *regopapi.ImageRegistry, conditionType string, status op
 
 	if !found {
 		conditions = append(conditions, *condition)
+		*modified = true
 	}
 
 	cr.Status.Conditions = conditions

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -412,7 +412,8 @@ func TestAWSFinalizerDeleteS3Bucket(t *testing.T) {
 
 	var exists bool
 	err = wait.Poll(1*time.Second, testframework.AsyncOperationTimeout, func() (stop bool, err error) {
-		exists, err := driver.StorageExists(cr)
+		modified := true
+		exists, err := driver.StorageExists(cr, &modified)
 		if aerr, ok := err.(awserr.Error); ok {
 			t.Errorf("%#v, %#v", aerr.Code(), aerr.Error())
 		}


### PR DESCRIPTION
setting "modified=true" everytime we ran syncStorage meant we kept triggering ourselves infinitely.

(we'd update the CR, which would result in an event, which would call syncStorage, which would set modified=true which meant we'd update the CR, and repeat).

Another way to avoid this would be to diff the new/old object and ignore the event if the only change is the resourceVersion, but I think this is the "right" way to solve it.
