### PR TITLE
Rename nodecadaemon to node-ca

### DIFF
--- a/deploy/06-ca-rbac.yaml
+++ b/deploy/06-ca-rbac.yaml
@@ -2,7 +2,7 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: nodecadaemon
+  name: node-ca
   namespace: openshift-image-registry
 rules:
 - apiGroups:
@@ -17,13 +17,13 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: nodecadaemon
+  name: node-ca
   namespace: openshift-image-registry
 subjects:
 - kind: ServiceAccount
-  name: nodecadaemon
+  name: node-ca
   namespace: openshift-image-registry
 roleRef:
   kind: Role
-  name: nodecadaemon
+  name: node-ca
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/07-ca-serviceaccount.yaml
+++ b/deploy/07-ca-serviceaccount.yaml
@@ -2,5 +2,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: nodecadaemon
+  name: node-ca
   namespace: openshift-image-registry

--- a/pkg/resource/nodecadaemon.go
+++ b/pkg/resource/nodecadaemon.go
@@ -21,16 +21,16 @@ const (
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: nodecadaemon
+  name: node-ca
   namespace: openshift-image-registry
 spec:
   selector:
     matchLabels:
-      name: nodecadaemon
+      name: node-ca
   template:
     metadata:
       labels:
-        name: nodecadaemon
+        name: node-ca
     spec:      
       nodeSelector:
         beta.kubernetes.io/os: linux
@@ -39,9 +39,9 @@ spec:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
         operator: Exists
-      serviceAccountName: nodecadaemon
+      serviceAccountName: node-ca
       containers:
-      - name: nodecadaemon
+      - name: node-ca
         securityContext:
           privileged: true
         image: docker.io/openshift/origin-cluster-image-registry-operator:latest
@@ -109,7 +109,7 @@ func (ds *generatorNodeCADaemonSet) GetNamespace() string {
 }
 
 func (ds *generatorNodeCADaemonSet) GetName() string {
-	return "nodecadaemon"
+	return "node-ca"
 }
 
 func (ds *generatorNodeCADaemonSet) Get() (runtime.Object, error) {


### PR DESCRIPTION
Naming wise we don't run words together in resource names, daemon
is redundant, and `node-ca` is easier to type.