### PR TITLE
Cleanup Items

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test-unit:
 	go test ./cmd/... ./pkg/...
 
 test-e2e:
-	GOCACHE=off go test -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/
+	GOCACHE=off go test -timeout 20m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/
 
 verify:
 	hack/verify.sh

--- a/pkg/clusterconfig/clusterconfig.go
+++ b/pkg/clusterconfig/clusterconfig.go
@@ -12,7 +12,7 @@ import (
 
 	coreset "k8s.io/client-go/kubernetes/typed/core/v1"
 
-	regopapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
 )
 
@@ -111,7 +111,7 @@ func GetAWSConfig() (*Config, error) {
 	}
 
 	// Look for a user defined secret to get the AWS credentials from first
-	sec, err := client.Secrets(regopapi.ImageRegistryOperatorNamespace).Get(regopapi.ImageRegistryPrivateConfigurationUser, metav1.GetOptions{})
+	sec, err := client.Secrets(imageregistryv1.ImageRegistryOperatorNamespace).Get(imageregistryv1.ImageRegistryPrivateConfigurationUser, metav1.GetOptions{})
 	if err != nil && errors.IsNotFound(err) {
 		// If no user defined secret is found, use the system one
 		sec, err = client.Secrets(installerConfigNamespace).Get(installerAWSCredsName, metav1.GetOptions{})
@@ -134,12 +134,12 @@ func GetAWSConfig() (*Config, error) {
 		if v, ok := sec.Data["REGISTRY_STORAGE_S3_ACCESSKEY"]; ok {
 			cfg.Storage.S3.AccessKey = string(v)
 		} else {
-			return nil, fmt.Errorf("secret %q does not contain required key \"REGISTRY_STORAGE_S3_ACCESSKEY\"", fmt.Sprintf("%s/%s", regopapi.ImageRegistryOperatorNamespace, regopapi.ImageRegistryPrivateConfigurationUser))
+			return nil, fmt.Errorf("secret %q does not contain required key \"REGISTRY_STORAGE_S3_ACCESSKEY\"", fmt.Sprintf("%s/%s", imageregistryv1.ImageRegistryOperatorNamespace, imageregistryv1.ImageRegistryPrivateConfigurationUser))
 		}
 		if v, ok := sec.Data["REGISTRY_STORAGE_S3_SECRETKEY"]; ok {
 			cfg.Storage.S3.SecretKey = string(v)
 		} else {
-			return nil, fmt.Errorf("secret %q does not contain required key \"REGISTRY_STORAGE_S3_SECRETKEY\"", fmt.Sprintf("%s/%s", regopapi.ImageRegistryOperatorNamespace, regopapi.ImageRegistryPrivateConfigurationUser))
+			return nil, fmt.Errorf("secret %q does not contain required key \"REGISTRY_STORAGE_S3_SECRETKEY\"", fmt.Sprintf("%s/%s", imageregistryv1.ImageRegistryOperatorNamespace, imageregistryv1.ImageRegistryPrivateConfigurationUser))
 
 		}
 	}

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -325,7 +325,7 @@ storage:
 			},
 		},
 		TLS:          tls,
-		DefaultRoute: false,                                         // TODO
+		DefaultRoute: false,                                        // TODO
 		Routes:       []imageregistryv1.ImageRegistryConfigRoute{}, // TODO
 		Replicas:     dc.Spec.Replicas,
 	}, tlsSecret, nil

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -15,7 +15,7 @@ import (
 	appsapi "github.com/openshift/api/apps/v1"
 	operatorapi "github.com/openshift/api/operator/v1"
 
-	imageregistryapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/migration/dependency"
 )
 
@@ -65,8 +65,8 @@ func migrateParameters(params map[string]interface{}, rules map[string]interface
 	return nil
 }
 
-func newImageRegistryConfigStorage(config *configuration.Configuration, dc *appsapi.DeploymentConfig, registry coreapi.Container) (imageregistryapi.ImageRegistryConfigStorage, error) {
-	var emptyConfig imageregistryapi.ImageRegistryConfigStorage
+func newImageRegistryConfigStorage(config *configuration.Configuration, dc *appsapi.DeploymentConfig, registry coreapi.Container) (imageregistryv1.ImageRegistryConfigStorage, error) {
+	var emptyConfig imageregistryv1.ImageRegistryConfigStorage
 
 	storageType := config.Storage.Type()
 	params := config.Storage.Parameters()
@@ -104,13 +104,13 @@ func newImageRegistryConfigStorage(config *configuration.Configuration, dc *apps
 			}
 		}
 
-		return imageregistryapi.ImageRegistryConfigStorage{
-			Filesystem: &imageregistryapi.ImageRegistryConfigStorageFilesystem{
+		return imageregistryv1.ImageRegistryConfigStorage{
+			Filesystem: &imageregistryv1.ImageRegistryConfigStorageFilesystem{
 				VolumeSource: volumeSource,
 			},
 		}, nil
 	case "s3":
-		storageS3 := &imageregistryapi.ImageRegistryConfigStorageS3{}
+		storageS3 := &imageregistryv1.ImageRegistryConfigStorageS3{}
 		err := migrateParameters(params, map[string]interface{}{
 			"bucket": func(bucket string, ok bool) error {
 				storageS3.Bucket = bucket
@@ -132,11 +132,11 @@ func newImageRegistryConfigStorage(config *configuration.Configuration, dc *apps
 		if err != nil {
 			return emptyConfig, fmt.Errorf("failed to migrate parameters for the storage %s: %s", storageType, err)
 		}
-		return imageregistryapi.ImageRegistryConfigStorage{
+		return imageregistryv1.ImageRegistryConfigStorage{
 			S3: storageS3,
 		}, nil
 	case "azure":
-		storageAzure := &imageregistryapi.ImageRegistryConfigStorageAzure{}
+		storageAzure := &imageregistryv1.ImageRegistryConfigStorageAzure{}
 		err := migrateParameters(params, map[string]interface{}{
 			"container": func(container string, ok bool) error {
 				storageAzure.Container = container
@@ -146,11 +146,11 @@ func newImageRegistryConfigStorage(config *configuration.Configuration, dc *apps
 		if err != nil {
 			return emptyConfig, fmt.Errorf("failed to migrate parameters for the storage %s: %s", storageType, err)
 		}
-		return imageregistryapi.ImageRegistryConfigStorage{
+		return imageregistryv1.ImageRegistryConfigStorage{
 			Azure: storageAzure,
 		}, nil
 	case "gcs":
-		storageGCS := &imageregistryapi.ImageRegistryConfigStorageGCS{}
+		storageGCS := &imageregistryv1.ImageRegistryConfigStorageGCS{}
 		err := migrateParameters(params, map[string]interface{}{
 			"bucket": func(bucket string, ok bool) error {
 				storageGCS.Bucket = bucket
@@ -160,11 +160,11 @@ func newImageRegistryConfigStorage(config *configuration.Configuration, dc *apps
 		if err != nil {
 			return emptyConfig, fmt.Errorf("failed to migrate parameters for the storage %s: %s", storageType, err)
 		}
-		return imageregistryapi.ImageRegistryConfigStorage{
+		return imageregistryv1.ImageRegistryConfigStorage{
 			GCS: storageGCS,
 		}, nil
 	case "swift":
-		storageSwift := &imageregistryapi.ImageRegistryConfigStorageSwift{}
+		storageSwift := &imageregistryv1.ImageRegistryConfigStorageSwift{}
 		err := migrateParameters(params, map[string]interface{}{
 			"authurl": func(authURL string, ok bool) error {
 				storageSwift.AuthURL = authURL
@@ -178,7 +178,7 @@ func newImageRegistryConfigStorage(config *configuration.Configuration, dc *apps
 		if err != nil {
 			return emptyConfig, fmt.Errorf("failed to migrate parameters for the storage %s: %s", storageType, err)
 		}
-		return imageregistryapi.ImageRegistryConfigStorage{
+		return imageregistryv1.ImageRegistryConfigStorage{
 			Swift: storageSwift,
 		}, nil
 	default:
@@ -221,11 +221,11 @@ func isEnvVarSupported(name string) bool {
 		name == "OPENSHIFT_DEFAULT_REGISTRY"
 }
 
-func NewImageRegistrySpecFromDeploymentConfig(dc *appsapi.DeploymentConfig, resources dependency.NamespacedResources) (imageregistryapi.ImageRegistrySpec, *coreapi.Secret, error) {
-	fail := func(format string, a ...interface{}) (imageregistryapi.ImageRegistrySpec, *coreapi.Secret, error) {
+func NewImageRegistrySpecFromDeploymentConfig(dc *appsapi.DeploymentConfig, resources dependency.NamespacedResources) (imageregistryv1.ImageRegistrySpec, *coreapi.Secret, error) {
+	fail := func(format string, a ...interface{}) (imageregistryv1.ImageRegistrySpec, *coreapi.Secret, error) {
 		format = "unable to create an image registry spec from the DeploymentConfig %s/%s: " + format
 		a = append([]interface{}{dc.Namespace, dc.Name}, a...)
-		return imageregistryapi.ImageRegistrySpec{}, nil, fmt.Errorf(format, a...)
+		return imageregistryv1.ImageRegistrySpec{}, nil, fmt.Errorf(format, a...)
 	}
 
 	containers := dc.Spec.Template.Spec.Containers
@@ -307,18 +307,18 @@ storage:
 		return fail("unable to process TLS configuration: %s", err)
 	}
 
-	return imageregistryapi.ImageRegistrySpec{
+	return imageregistryv1.ImageRegistrySpec{
 		ManagementState: operatorapi.Managed,
 		HTTPSecret:      config.HTTP.Secret,
-		Proxy:           imageregistryapi.ImageRegistryConfigProxy{}, // TODO
+		Proxy:           imageregistryv1.ImageRegistryConfigProxy{}, // TODO
 		Storage:         storage,
-		Requests: imageregistryapi.ImageRegistryConfigRequests{
-			Read: imageregistryapi.ImageRegistryConfigRequestsLimits{
+		Requests: imageregistryv1.ImageRegistryConfigRequests{
+			Read: imageregistryv1.ImageRegistryConfigRequestsLimits{
 				MaxRunning:     extraConfig.Requests.Read.MaxRunning,
 				MaxInQueue:     extraConfig.Requests.Read.MaxInQueue,
 				MaxWaitInQueue: extraConfig.Requests.Read.MaxWaitInQueue,
 			},
-			Write: imageregistryapi.ImageRegistryConfigRequestsLimits{
+			Write: imageregistryv1.ImageRegistryConfigRequestsLimits{
 				MaxRunning:     extraConfig.Requests.Write.MaxRunning,
 				MaxInQueue:     extraConfig.Requests.Write.MaxInQueue,
 				MaxWaitInQueue: extraConfig.Requests.Write.MaxWaitInQueue,
@@ -326,7 +326,7 @@ storage:
 		},
 		TLS:          tls,
 		DefaultRoute: false,                                         // TODO
-		Routes:       []imageregistryapi.ImageRegistryConfigRoute{}, // TODO
+		Routes:       []imageregistryv1.ImageRegistryConfigRoute{}, // TODO
 		Replicas:     dc.Spec.Replicas,
 	}, tlsSecret, nil
 }

--- a/pkg/migration/migration_test.go
+++ b/pkg/migration/migration_test.go
@@ -14,7 +14,7 @@ import (
 
 	appsapi "github.com/openshift/api/apps/v1"
 
-	imageregistryapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/migration"
 )
 
@@ -65,7 +65,7 @@ func TestNewImageRegistrySpecFromDeploymentConfig(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			var expectedSpec imageregistryapi.ImageRegistrySpec
+			var expectedSpec imageregistryv1.ImageRegistrySpec
 			if err := resourceFromFile(&expectedSpec, "./testdata/"+testName+"/imageregistryspec.yaml"); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/operator/complete.go
+++ b/pkg/operator/complete.go
@@ -3,11 +3,11 @@ package operator
 import (
 	"fmt"
 
-	regopapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
 )
 
-func appendFinalizer(cr *regopapi.Config, modified *bool) {
+func appendFinalizer(cr *imageregistryv1.Config, modified *bool) {
 	for i := range cr.ObjectMeta.Finalizers {
 		if cr.ObjectMeta.Finalizers[i] == parameters.ImageRegistryOperatorResourceFinalizer {
 			return
@@ -18,13 +18,13 @@ func appendFinalizer(cr *regopapi.Config, modified *bool) {
 	*modified = true
 }
 
-func verifyResource(cr *regopapi.Config, p *parameters.Globals) error {
+func verifyResource(cr *imageregistryv1.Config, p *parameters.Globals) error {
 	if cr.Spec.Replicas < 0 {
 		return fmt.Errorf("replicas must be greater than or equal to 0")
 	}
 
 	names := map[string]struct{}{
-		regopapi.ImageRegistryName + "-default-route": {},
+		imageregistryv1.ImageRegistryName + "-default-route": {},
 	}
 
 	for _, routeSpec := range cr.Spec.Routes {

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -22,7 +22,7 @@ import (
 	routeset "github.com/openshift/client-go/route/clientset/versioned"
 	routeinformers "github.com/openshift/client-go/route/informers/externalversions"
 
-	regopapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
 	"github.com/openshift/cluster-image-registry-operator/pkg/clusteroperator"
 	regopset "github.com/openshift/cluster-image-registry-operator/pkg/generated/clientset/versioned"
@@ -62,9 +62,9 @@ func NewController(kubeconfig *restclient.Config, namespace string) (*Controller
 	p.Healthz.Route = "/healthz"
 	p.Healthz.TimeoutSeconds = 5
 
-	p.Service.Name = regopapi.ImageRegistryName
+	p.Service.Name = imageregistryv1.ImageRegistryName
 	p.ImageConfig.Name = "cluster"
-	p.CAConfig.Name = regopapi.ImageRegistryCertificatesName
+	p.CAConfig.Name = imageregistryv1.ImageRegistryCertificatesName
 
 	listers := &regopclient.Listers{}
 	c := &Controller{
@@ -91,7 +91,7 @@ type Controller struct {
 	listers       *regopclient.Listers
 }
 
-func (c *Controller) createOrUpdateResources(cr *regopapi.Config, modified *bool) error {
+func (c *Controller) createOrUpdateResources(cr *imageregistryv1.Config, modified *bool) error {
 	appendFinalizer(cr, modified)
 
 	err := verifyResource(cr, &c.params)
@@ -107,7 +107,7 @@ func (c *Controller) createOrUpdateResources(cr *regopapi.Config, modified *bool
 	return nil
 }
 
-func (c *Controller) CreateOrUpdateResources(cr *regopapi.Config, modified *bool) error {
+func (c *Controller) CreateOrUpdateResources(cr *imageregistryv1.Config, modified *bool) error {
 	if cr.Spec.ManagementState != operatorapi.Managed {
 		return nil
 	}
@@ -156,11 +156,11 @@ func (c *Controller) sync() error {
 		glog.Warningf("unknown custom resource state: %s", cr.Spec.ManagementState)
 	}
 
-	deploy, err := c.listers.Deployments.Get(regopapi.ImageRegistryName)
+	deploy, err := c.listers.Deployments.Get(imageregistryv1.ImageRegistryName)
 	if errors.IsNotFound(err) {
 		deploy = nil
 	} else if err != nil {
-		return fmt.Errorf("failed to get %q deployment: %s", regopapi.ImageRegistryName, err)
+		return fmt.Errorf("failed to get %q deployment: %s", imageregistryv1.ImageRegistryName, err)
 	} else {
 		deploy = deploy.DeepCopy() // make sure we won't corrupt the cached vesrion
 	}

--- a/pkg/operator/finalizer.go
+++ b/pkg/operator/finalizer.go
@@ -14,14 +14,14 @@ import (
 
 	osapi "github.com/openshift/api/config/v1"
 
-	regopapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	regopset "github.com/openshift/cluster-image-registry-operator/pkg/generated/clientset/versioned/typed/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage"
 
 	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
 )
 
-func (c *Controller) RemoveResources(o *regopapi.Config) error {
+func (c *Controller) RemoveResources(o *imageregistryv1.Config) error {
 	modified := false
 
 	errOp := c.clusterStatus.Update(osapi.OperatorProgressing, osapi.ConditionTrue, "registry is being removed")
@@ -32,7 +32,7 @@ func (c *Controller) RemoveResources(o *regopapi.Config) error {
 	return c.generator.Remove(o, &modified)
 }
 
-func (c *Controller) finalizeResources(o *regopapi.Config) error {
+func (c *Controller) finalizeResources(o *imageregistryv1.Config) error {
 	if o.ObjectMeta.DeletionTimestamp == nil {
 		return nil
 	}

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -67,14 +67,14 @@ func (c *Controller) syncStatus(cr *imageregistryv1.Config, deploy *appsapi.Depl
 	operatorAvailable := osapi.ConditionFalse
 	operatorAvailableMsg := ""
 	if deploy == nil {
-		operatorAvailableMsg = "deployment does not exist"
+		operatorAvailableMsg = "Deployment does not exist"
 	} else if deploy.DeletionTimestamp != nil {
-		operatorAvailableMsg = "deployment is being deleted"
+		operatorAvailableMsg = "Deployment is being deleted"
 	} else if !isDeploymentStatusAvailable(deploy) {
-		operatorAvailableMsg = "deployment does not have available replicas"
+		operatorAvailableMsg = "Deployment does not have available replicas"
 	} else {
 		operatorAvailable = osapi.ConditionTrue
-		operatorAvailableMsg = "deployment has minimum availability"
+		operatorAvailableMsg = "Deployment has minimum availability"
 	}
 
 	err := c.clusterStatus.Update(osapi.OperatorAvailable, operatorAvailable, operatorAvailableMsg)
@@ -93,25 +93,25 @@ func (c *Controller) syncStatus(cr *imageregistryv1.Config, deploy *appsapi.Depl
 	operatorProgressingMsg := ""
 	if cr.Spec.ManagementState == operatorapi.Unmanaged {
 		operatorProgressing = osapi.ConditionFalse
-		operatorProgressingMsg = "unmanaged"
+		operatorProgressingMsg = "Unmanaged"
 	} else if removed {
 		if deploy != nil {
-			operatorProgressingMsg = "the deployment still exists"
+			operatorProgressingMsg = "The deployment still exists"
 		} else {
 			operatorProgressing = osapi.ConditionFalse
-			operatorProgressingMsg = "everything is removed"
+			operatorProgressingMsg = "Everything is removed"
 		}
 	} else if applyError != nil {
-		operatorProgressingMsg = fmt.Sprintf("unable to apply resources: %s", applyError)
+		operatorProgressingMsg = fmt.Sprintf("Unable to apply resources: %s", applyError)
 	} else if deploy == nil {
-		operatorProgressingMsg = "all resources are successfully applied, but the deployment does not exist"
+		operatorProgressingMsg = "All resources are successfully applied, but the deployment does not exist"
 	} else if deploy.DeletionTimestamp != nil {
-		operatorProgressingMsg = "the deployment is being deleted"
+		operatorProgressingMsg = "The deployment is being deleted"
 	} else if !isDeploymentStatusComplete(deploy) {
-		operatorProgressingMsg = "the deployment has not completed"
+		operatorProgressingMsg = "The deployment has not completed"
 	} else {
 		operatorProgressing = osapi.ConditionFalse
-		operatorProgressingMsg = "everything is ready"
+		operatorProgressingMsg = "Everything is ready"
 	}
 
 	err = c.clusterStatus.Update(osapi.OperatorProgressing, operatorProgressing, operatorProgressingMsg)
@@ -149,7 +149,7 @@ func (c *Controller) syncStatus(cr *imageregistryv1.Config, deploy *appsapi.Depl
 	operatorRemovedMsg := ""
 	if removed {
 		operatorRemoved = osapi.ConditionTrue
-		operatorRemovedMsg = "the image registry is removed"
+		operatorRemovedMsg = "The image registry is removed"
 	}
 
 	updateCondition(cr, &operatorapi.OperatorCondition{

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -11,10 +11,10 @@ import (
 	operatorapi "github.com/openshift/api/operator/v1"
 
 	osapi "github.com/openshift/api/config/v1"
-	regopapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 )
 
-func updateCondition(cr *regopapi.Config, condition *operatorapi.OperatorCondition, modified *bool) {
+func updateCondition(cr *imageregistryv1.Config, condition *operatorapi.OperatorCondition, modified *bool) {
 	found := false
 	conditions := []operatorapi.OperatorCondition{}
 
@@ -63,7 +63,7 @@ func isDeploymentStatusComplete(deploy *appsapi.Deployment) bool {
 		deploy.Status.ObservedGeneration >= deploy.Generation
 }
 
-func (c *Controller) syncStatus(cr *regopapi.Config, deploy *appsapi.Deployment, applyError error, removed bool, statusChanged *bool) {
+func (c *Controller) syncStatus(cr *imageregistryv1.Config, deploy *appsapi.Deployment, applyError error, removed bool, statusChanged *bool) {
 	operatorAvailable := osapi.ConditionFalse
 	operatorAvailableMsg := ""
 	if deploy == nil {
@@ -153,7 +153,7 @@ func (c *Controller) syncStatus(cr *regopapi.Config, deploy *appsapi.Deployment,
 	}
 
 	updateCondition(cr, &operatorapi.OperatorCondition{
-		Type:               regopapi.OperatorStatusTypeRemoved,
+		Type:               imageregistryv1.OperatorStatusTypeRemoved,
 		Status:             operatorapi.ConditionStatus(operatorRemoved),
 		LastTransitionTime: metaapi.Now(),
 		Message:            operatorRemovedMsg,

--- a/pkg/resource/caconfig.go
+++ b/pkg/resource/caconfig.go
@@ -7,7 +7,7 @@ import (
 	coreset "k8s.io/client-go/kubernetes/typed/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 
-	regopapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
 )
 
@@ -23,7 +23,7 @@ type generatorCAConfig struct {
 	owner                 metav1.OwnerReference
 }
 
-func newGeneratorCAConfig(lister corelisters.ConfigMapNamespaceLister, openshiftConfigLister corelisters.ConfigMapNamespaceLister, client coreset.CoreV1Interface, params *parameters.Globals, cr *regopapi.Config) *generatorCAConfig {
+func newGeneratorCAConfig(lister corelisters.ConfigMapNamespaceLister, openshiftConfigLister corelisters.ConfigMapNamespaceLister, client coreset.CoreV1Interface, params *parameters.Globals, cr *imageregistryv1.Config) *generatorCAConfig {
 	return &generatorCAConfig{
 		lister:                lister,
 		openshiftConfigLister: openshiftConfigLister,

--- a/pkg/resource/clusterrole.go
+++ b/pkg/resource/clusterrole.go
@@ -7,7 +7,7 @@ import (
 	rbacset "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	rbaclisters "k8s.io/client-go/listers/rbac/v1"
 
-	regopapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 )
 
 var _ Mutator = &generatorClusterRole{}
@@ -18,7 +18,7 @@ type generatorClusterRole struct {
 	owner  metav1.OwnerReference
 }
 
-func newGeneratorClusterRole(lister rbaclisters.ClusterRoleLister, client rbacset.RbacV1Interface, cr *regopapi.Config) *generatorClusterRole {
+func newGeneratorClusterRole(lister rbaclisters.ClusterRoleLister, client rbacset.RbacV1Interface, cr *imageregistryv1.Config) *generatorClusterRole {
 	return &generatorClusterRole{
 		lister: lister,
 		client: client,

--- a/pkg/resource/clusterrolebinding.go
+++ b/pkg/resource/clusterrolebinding.go
@@ -7,7 +7,7 @@ import (
 	rbacset "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	rbaclisters "k8s.io/client-go/listers/rbac/v1"
 
-	regopapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
 )
 
@@ -21,7 +21,7 @@ type generatorClusterRoleBinding struct {
 	owner       metav1.OwnerReference
 }
 
-func newGeneratorClusterRoleBinding(lister rbaclisters.ClusterRoleBindingLister, client rbacset.RbacV1Interface, params *parameters.Globals, cr *regopapi.Config) *generatorClusterRoleBinding {
+func newGeneratorClusterRoleBinding(lister rbaclisters.ClusterRoleBindingLister, client rbacset.RbacV1Interface, params *parameters.Globals, cr *imageregistryv1.Config) *generatorClusterRoleBinding {
 	return &generatorClusterRoleBinding{
 		lister:      lister,
 		client:      client,

--- a/pkg/resource/deployment.go
+++ b/pkg/resource/deployment.go
@@ -9,7 +9,7 @@ import (
 	appslisters "k8s.io/client-go/listers/apps/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 
-	regopapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
 )
 
@@ -22,10 +22,10 @@ type generatorDeployment struct {
 	coreClient      coreset.CoreV1Interface
 	client          appsset.AppsV1Interface
 	params          *parameters.Globals
-	cr              *regopapi.Config
+	cr              *imageregistryv1.Config
 }
 
-func newGeneratorDeployment(lister appslisters.DeploymentNamespaceLister, configMapLister corelisters.ConfigMapNamespaceLister, secretLister corelisters.SecretNamespaceLister, coreClient coreset.CoreV1Interface, client appsset.AppsV1Interface, params *parameters.Globals, cr *regopapi.Config) *generatorDeployment {
+func newGeneratorDeployment(lister appslisters.DeploymentNamespaceLister, configMapLister corelisters.ConfigMapNamespaceLister, secretLister corelisters.SecretNamespaceLister, coreClient coreset.CoreV1Interface, client appsset.AppsV1Interface, params *parameters.Globals, cr *imageregistryv1.Config) *generatorDeployment {
 	return &generatorDeployment{
 		lister:          lister,
 		configMapLister: configMapLister,
@@ -46,7 +46,7 @@ func (gd *generatorDeployment) GetNamespace() string {
 }
 
 func (gd *generatorDeployment) GetName() string {
-	return regopapi.ImageRegistryName
+	return imageregistryv1.ImageRegistryName
 }
 
 func (gd *generatorDeployment) expected() (runtime.Object, error) {

--- a/pkg/resource/imageconfig.go
+++ b/pkg/resource/imageconfig.go
@@ -8,7 +8,7 @@ import (
 	configset "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	configlisters "github.com/openshift/client-go/config/listers/config/v1"
 
-	regopapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
 )
 
@@ -22,7 +22,7 @@ type generatorImageConfig struct {
 	owner    metav1.OwnerReference
 }
 
-func newGeneratorImageConfig(lister configlisters.ImageLister, client configset.ConfigV1Interface, params *parameters.Globals, cr *regopapi.Config) *generatorImageConfig {
+func newGeneratorImageConfig(lister configlisters.ImageLister, client configset.ConfigV1Interface, params *parameters.Globals, cr *imageregistryv1.Config) *generatorImageConfig {
 	return &generatorImageConfig{
 		lister:   lister,
 		client:   client,

--- a/pkg/resource/nodecadaemon.go
+++ b/pkg/resource/nodecadaemon.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 
-	regopapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
 )
 
@@ -91,7 +91,7 @@ type generatorNodeCADaemonSet struct {
 	params   *parameters.Globals
 }
 
-func newGeneratorNodeCADaemonSet(lister appslisters.DaemonSetNamespaceLister, client appsclientv1.AppsV1Interface, params *parameters.Globals, cr *regopapi.Config) *generatorNodeCADaemonSet {
+func newGeneratorNodeCADaemonSet(lister appslisters.DaemonSetNamespaceLister, client appsclientv1.AppsV1Interface, params *parameters.Globals, cr *imageregistryv1.Config) *generatorNodeCADaemonSet {
 	return &generatorNodeCADaemonSet{
 		lister:   lister,
 		client:   client,

--- a/pkg/resource/route.go
+++ b/pkg/resource/route.go
@@ -9,7 +9,7 @@ import (
 	routeset "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	routelisters "github.com/openshift/client-go/route/listers/route/v1"
 
-	regopapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
 )
 
@@ -23,10 +23,10 @@ type generatorRoute struct {
 	serviceName  string
 	tls          bool
 	owner        metav1.OwnerReference
-	route        regopapi.ImageRegistryConfigRoute
+	route        imageregistryv1.ImageRegistryConfigRoute
 }
 
-func newGeneratorRoute(lister routelisters.RouteNamespaceLister, secretLister corelisters.SecretNamespaceLister, client routeset.RouteV1Interface, params *parameters.Globals, cr *regopapi.Config, route regopapi.ImageRegistryConfigRoute) *generatorRoute {
+func newGeneratorRoute(lister routelisters.RouteNamespaceLister, secretLister corelisters.SecretNamespaceLister, client routeset.RouteV1Interface, params *parameters.Globals, cr *imageregistryv1.Config, route imageregistryv1.ImageRegistryConfigRoute) *generatorRoute {
 	return &generatorRoute{
 		lister:       lister,
 		secretLister: secretLister,

--- a/pkg/resource/secret.go
+++ b/pkg/resource/secret.go
@@ -7,7 +7,7 @@ import (
 	coreset "k8s.io/client-go/kubernetes/typed/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 
-	regopapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
 	"github.com/openshift/cluster-image-registry-operator/pkg/resource/strategy"
 )
@@ -22,11 +22,11 @@ type generatorSecret struct {
 	owner     metav1.OwnerReference
 }
 
-func newGeneratorSecret(lister corelisters.SecretNamespaceLister, client coreset.CoreV1Interface, params *parameters.Globals, cr *regopapi.Config) *generatorSecret {
+func newGeneratorSecret(lister corelisters.SecretNamespaceLister, client coreset.CoreV1Interface, params *parameters.Globals, cr *imageregistryv1.Config) *generatorSecret {
 	return &generatorSecret{
 		lister:    lister,
 		client:    client,
-		name:      regopapi.ImageRegistryPrivateConfiguration,
+		name:      imageregistryv1.ImageRegistryPrivateConfiguration,
 		namespace: params.Deployment.Namespace,
 		owner:     asOwner(cr),
 	}
@@ -41,7 +41,7 @@ func (gs *generatorSecret) GetNamespace() string {
 }
 
 func (gs *generatorSecret) GetName() string {
-	return regopapi.ImageRegistryName
+	return imageregistryv1.ImageRegistryName
 }
 
 func (gs *generatorSecret) expected() (*corev1.Secret, error) {

--- a/pkg/resource/service.go
+++ b/pkg/resource/service.go
@@ -10,7 +10,7 @@ import (
 	coreset "k8s.io/client-go/kubernetes/typed/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 
-	regopapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
 	"github.com/openshift/cluster-image-registry-operator/pkg/resource/strategy"
 )
@@ -29,7 +29,7 @@ type generatorService struct {
 	owner      metav1.OwnerReference
 }
 
-func newGeneratorService(lister corelisters.ServiceNamespaceLister, client coreset.CoreV1Interface, params *parameters.Globals, cr *regopapi.Config) *generatorService {
+func newGeneratorService(lister corelisters.ServiceNamespaceLister, client coreset.CoreV1Interface, params *parameters.Globals, cr *imageregistryv1.Config) *generatorService {
 	return &generatorService{
 		lister:     lister,
 		client:     client,
@@ -37,7 +37,7 @@ func newGeneratorService(lister corelisters.ServiceNamespaceLister, client cores
 		namespace:  params.Deployment.Namespace,
 		labels:     params.Deployment.Labels,
 		port:       params.Container.Port,
-		secretName: regopapi.ImageRegistryName + "-tls",
+		secretName: imageregistryv1.ImageRegistryName + "-tls",
 		tls:        cr.Spec.TLS,
 		owner:      asOwner(cr),
 	}

--- a/pkg/resource/serviceaccount.go
+++ b/pkg/resource/serviceaccount.go
@@ -7,7 +7,7 @@ import (
 	coreset "k8s.io/client-go/kubernetes/typed/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 
-	regopapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
 )
 
@@ -21,7 +21,7 @@ type generatorServiceAccount struct {
 	owner     metav1.OwnerReference
 }
 
-func newGeneratorServiceAccount(lister corelisters.ServiceAccountNamespaceLister, client coreset.CoreV1Interface, params *parameters.Globals, cr *regopapi.Config) *generatorServiceAccount {
+func newGeneratorServiceAccount(lister corelisters.ServiceAccountNamespaceLister, client coreset.CoreV1Interface, params *parameters.Globals, cr *imageregistryv1.Config) *generatorServiceAccount {
 	return &generatorServiceAccount{
 		lister:    lister,
 		client:    client,

--- a/pkg/resource/strategy/override_test.go
+++ b/pkg/resource/strategy/override_test.go
@@ -5,11 +5,11 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	imageregistryapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 )
 
 func TestOverride(t *testing.T) {
-	o := &imageregistryapi.Config{
+	o := &imageregistryv1.Config{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
 			ResourceVersion: "12345",
@@ -17,11 +17,11 @@ func TestOverride(t *testing.T) {
 				"hello": "world",
 			},
 		},
-		Spec: imageregistryapi.ImageRegistrySpec{
+		Spec: imageregistryv1.ImageRegistrySpec{
 			HTTPSecret: "secret",
 		},
 	}
-	n := &imageregistryapi.Config{
+	n := &imageregistryv1.Config{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "foo",
 			Annotations: map[string]string{
@@ -33,7 +33,7 @@ func TestOverride(t *testing.T) {
 				},
 			},
 		},
-		Spec: imageregistryapi.ImageRegistrySpec{
+		Spec: imageregistryv1.ImageRegistrySpec{
 			HTTPSecret: "new-secret",
 		},
 	}

--- a/pkg/storage/azure/azure.go
+++ b/pkg/storage/azure/azure.go
@@ -4,17 +4,17 @@ import (
 	coreapi "k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
 
-	opapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/clusterconfig"
 )
 
 type driver struct {
 	Name      string
 	Namespace string
-	Config    *opapi.ImageRegistryConfigStorageAzure
+	Config    *imageregistryv1.ImageRegistryConfigStorageAzure
 }
 
-func NewDriver(crname string, crnamespace string, c *opapi.ImageRegistryConfigStorageAzure) *driver {
+func NewDriver(crname string, crnamespace string, c *imageregistryv1.ImageRegistryConfigStorageAzure) *driver {
 	return &driver{
 		Name:      crname,
 		Namespace: crnamespace,
@@ -22,7 +22,7 @@ func NewDriver(crname string, crnamespace string, c *opapi.ImageRegistryConfigSt
 	}
 }
 
-func (d *driver) UpdateFromStorage(cfg opapi.ImageRegistryConfigStorage) {
+func (d *driver) UpdateFromStorage(cfg imageregistryv1.ImageRegistryConfigStorage) {
 	d.Config = cfg.Azure.DeepCopy()
 }
 
@@ -65,11 +65,11 @@ func (d *driver) ConfigEnv() (envs []corev1.EnvVar, err error) {
 	return
 }
 
-func (d *driver) StorageExists(cr *opapi.Config, modified *bool) (bool, error) {
+func (d *driver) StorageExists(cr *imageregistryv1.Config, modified *bool) (bool, error) {
 	return false, nil
 }
 
-func (d *driver) StorageChanged(cr *opapi.Config, modified *bool) bool {
+func (d *driver) StorageChanged(cr *imageregistryv1.Config, modified *bool) bool {
 	return false
 }
 
@@ -80,11 +80,11 @@ func (d *driver) GetStorageName() string {
 	return d.Config.Container
 }
 
-func (d *driver) CreateStorage(cr *opapi.Config, modified *bool) error {
+func (d *driver) CreateStorage(cr *imageregistryv1.Config, modified *bool) error {
 	return nil
 }
 
-func (d *driver) RemoveStorage(cr *opapi.Config, modified *bool) error {
+func (d *driver) RemoveStorage(cr *imageregistryv1.Config, modified *bool) error {
 	if !cr.Status.StorageManaged {
 		return nil
 	}
@@ -96,6 +96,6 @@ func (d *driver) Volumes() ([]corev1.Volume, []corev1.VolumeMount, error) {
 	return nil, nil, nil
 }
 
-func (d *driver) CompleteConfiguration(cr *opapi.Config, modified *bool) error {
+func (d *driver) CompleteConfiguration(cr *imageregistryv1.Config, modified *bool) error {
 	return nil
 }

--- a/pkg/storage/emptydir/emptydir.go
+++ b/pkg/storage/emptydir/emptydir.go
@@ -8,7 +8,7 @@ import (
 	coreapi "k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
 
-	opapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/clusterconfig"
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage/util"
 )
@@ -20,10 +20,10 @@ const (
 type driver struct {
 	Name      string
 	Namespace string
-	Config    *opapi.ImageRegistryConfigStorageFilesystem
+	Config    *imageregistryv1.ImageRegistryConfigStorageFilesystem
 }
 
-func NewDriver(crname string, crnamespace string, c *opapi.ImageRegistryConfigStorageFilesystem) *driver {
+func NewDriver(crname string, crnamespace string, c *imageregistryv1.ImageRegistryConfigStorageFilesystem) *driver {
 	return &driver{
 		Name:      crname,
 		Namespace: crnamespace,
@@ -31,7 +31,7 @@ func NewDriver(crname string, crnamespace string, c *opapi.ImageRegistryConfigSt
 	}
 }
 
-func (d *driver) UpdateFromStorage(cfg opapi.ImageRegistryConfigStorage) {
+func (d *driver) UpdateFromStorage(cfg imageregistryv1.ImageRegistryConfigStorage) {
 	d.Config = cfg.Filesystem.DeepCopy()
 }
 
@@ -66,13 +66,13 @@ func (d *driver) Volumes() ([]corev1.Volume, []corev1.VolumeMount, error) {
 	return []corev1.Volume{vol}, []corev1.VolumeMount{mount}, nil
 }
 
-func (d *driver) StorageExists(cr *opapi.Config, modified *bool) (bool, error) {
+func (d *driver) StorageExists(cr *imageregistryv1.Config, modified *bool) (bool, error) {
 	return true, nil
 }
 
-func (d *driver) StorageChanged(cr *opapi.Config, modified *bool) bool {
+func (d *driver) StorageChanged(cr *imageregistryv1.Config, modified *bool) bool {
 	if !reflect.DeepEqual(cr.Status.Storage.Filesystem, cr.Spec.Storage.Filesystem) {
-		util.UpdateCondition(cr, opapi.StorageExists, operatorapi.ConditionUnknown, "EmptyDir Configuration Changed", "EmptyDir storage is in an unknown state", modified)
+		util.UpdateCondition(cr, imageregistryv1.StorageExists, operatorapi.ConditionUnknown, "EmptyDir Configuration Changed", "EmptyDir storage is in an unknown state", modified)
 		return true
 	}
 
@@ -83,7 +83,7 @@ func (d *driver) GetStorageName() string {
 	return "EmptyDir"
 }
 
-func (d *driver) CreateStorage(cr *opapi.Config, modified *bool) error {
+func (d *driver) CreateStorage(cr *imageregistryv1.Config, modified *bool) error {
 	if !reflect.DeepEqual(cr.Status.Storage.Filesystem, cr.Spec.Storage.Filesystem) {
 		cr.Status.Storage.Filesystem = d.Config.DeepCopy()
 		*modified = true
@@ -92,11 +92,11 @@ func (d *driver) CreateStorage(cr *opapi.Config, modified *bool) error {
 	return nil
 }
 
-func (d *driver) RemoveStorage(cr *opapi.Config, modified *bool) error {
+func (d *driver) RemoveStorage(cr *imageregistryv1.Config, modified *bool) error {
 	return nil
 }
 
-func (d *driver) CompleteConfiguration(cr *opapi.Config, modified *bool) error {
+func (d *driver) CompleteConfiguration(cr *imageregistryv1.Config, modified *bool) error {
 
 	cr.Spec.Storage.Filesystem = d.Config.DeepCopy()
 	*modified = true

--- a/pkg/storage/filesystem/filesystem.go
+++ b/pkg/storage/filesystem/filesystem.go
@@ -4,7 +4,7 @@ import (
 	coreapi "k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
 
-	opapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/clusterconfig"
 )
 
@@ -15,10 +15,10 @@ const (
 type driver struct {
 	Name      string
 	Namespace string
-	Config    *opapi.ImageRegistryConfigStorageFilesystem
+	Config    *imageregistryv1.ImageRegistryConfigStorageFilesystem
 }
 
-func NewDriver(crname string, crnamespace string, c *opapi.ImageRegistryConfigStorageFilesystem) *driver {
+func NewDriver(crname string, crnamespace string, c *imageregistryv1.ImageRegistryConfigStorageFilesystem) *driver {
 	return &driver{
 		Name:      crname,
 		Namespace: crnamespace,
@@ -26,7 +26,7 @@ func NewDriver(crname string, crnamespace string, c *opapi.ImageRegistryConfigSt
 	}
 }
 
-func (d *driver) UpdateFromStorage(cfg opapi.ImageRegistryConfigStorage) {
+func (d *driver) UpdateFromStorage(cfg imageregistryv1.ImageRegistryConfigStorage) {
 	d.Config = cfg.Filesystem.DeepCopy()
 }
 
@@ -61,11 +61,11 @@ func (d *driver) Volumes() ([]corev1.Volume, []corev1.VolumeMount, error) {
 	return []corev1.Volume{vol}, []corev1.VolumeMount{mount}, nil
 }
 
-func (d *driver) StorageExists(cr *opapi.Config, modified *bool) (bool, error) {
+func (d *driver) StorageExists(cr *imageregistryv1.Config, modified *bool) (bool, error) {
 	return false, nil
 }
 
-func (d *driver) StorageChanged(cr *opapi.Config, modified *bool) bool {
+func (d *driver) StorageChanged(cr *imageregistryv1.Config, modified *bool) bool {
 	return false
 }
 
@@ -73,11 +73,11 @@ func (d *driver) GetStorageName() string {
 	return ""
 }
 
-func (d *driver) CreateStorage(cr *opapi.Config, modified *bool) error {
+func (d *driver) CreateStorage(cr *imageregistryv1.Config, modified *bool) error {
 	return nil
 }
 
-func (d *driver) RemoveStorage(cr *opapi.Config, modified *bool) error {
+func (d *driver) RemoveStorage(cr *imageregistryv1.Config, modified *bool) error {
 	if !cr.Status.StorageManaged {
 		return nil
 	}
@@ -85,7 +85,7 @@ func (d *driver) RemoveStorage(cr *opapi.Config, modified *bool) error {
 	return nil
 }
 
-func (d *driver) CompleteConfiguration(cr *opapi.Config, modified *bool) error {
+func (d *driver) CompleteConfiguration(cr *imageregistryv1.Config, modified *bool) error {
 	cr.Status.Storage.Filesystem = d.Config.DeepCopy()
 	*modified = true
 	return nil

--- a/pkg/storage/gcs/gcs.go
+++ b/pkg/storage/gcs/gcs.go
@@ -14,17 +14,17 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/uuid"
 
-	opapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/clusterconfig"
 )
 
 type driver struct {
 	Name      string
 	Namespace string
-	Config    *opapi.ImageRegistryConfigStorageGCS
+	Config    *imageregistryv1.ImageRegistryConfigStorageGCS
 }
 
-func NewDriver(crname string, crnamespace string, c *opapi.ImageRegistryConfigStorageGCS) *driver {
+func NewDriver(crname string, crnamespace string, c *imageregistryv1.ImageRegistryConfigStorageGCS) *driver {
 	return &driver{
 		Name:      crname,
 		Namespace: crnamespace,
@@ -32,7 +32,7 @@ func NewDriver(crname string, crnamespace string, c *opapi.ImageRegistryConfigSt
 	}
 }
 
-func (d *driver) UpdateFromStorage(cfg opapi.ImageRegistryConfigStorage) {
+func (d *driver) UpdateFromStorage(cfg imageregistryv1.ImageRegistryConfigStorage) {
 	d.Config = cfg.GCS.DeepCopy()
 }
 
@@ -107,11 +107,11 @@ func (d *driver) Volumes() ([]coreapi.Volume, []coreapi.VolumeMount, error) {
 	return []coreapi.Volume{vol}, []coreapi.VolumeMount{mount}, nil
 }
 
-func (d *driver) StorageExists(cr *opapi.Config, modified *bool) (bool, error) {
+func (d *driver) StorageExists(cr *imageregistryv1.Config, modified *bool) (bool, error) {
 	return false, nil
 }
 
-func (d *driver) StorageChanged(cr *opapi.Config, modified *bool) bool {
+func (d *driver) StorageChanged(cr *imageregistryv1.Config, modified *bool) bool {
 	return false
 }
 
@@ -122,11 +122,11 @@ func (d *driver) GetStorageName() string {
 	return d.Config.Bucket
 }
 
-func (d *driver) CreateStorage(cr *opapi.Config, modified *bool) error {
+func (d *driver) CreateStorage(cr *imageregistryv1.Config, modified *bool) error {
 	return nil
 }
 
-func (d *driver) RemoveStorage(cr *opapi.Config, modified *bool) error {
+func (d *driver) RemoveStorage(cr *imageregistryv1.Config, modified *bool) error {
 	if !cr.Status.StorageManaged {
 		return nil
 	}
@@ -134,7 +134,7 @@ func (d *driver) RemoveStorage(cr *opapi.Config, modified *bool) error {
 	return nil
 }
 
-func (d *driver) CompleteConfiguration(cr *opapi.Config, modified *bool) error {
+func (d *driver) CompleteConfiguration(cr *imageregistryv1.Config, modified *bool) error {
 	// Apply global config
 	cfg, err := clusterconfig.GetGCSConfig()
 	if err != nil {
@@ -159,7 +159,7 @@ func (d *driver) CompleteConfiguration(cr *opapi.Config, modified *bool) error {
 		}
 
 		for {
-			d.Config.Bucket = fmt.Sprintf("%s-%s", opapi.ImageRegistryName, string(uuid.NewUUID()))
+			d.Config.Bucket = fmt.Sprintf("%s-%s", imageregistryv1.ImageRegistryName, string(uuid.NewUUID()))
 
 			err = client.Bucket(d.Config.Bucket).Create(ctx, projectID, nil)
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -8,7 +8,7 @@ import (
 	coreapi "k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
 
-	opapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/clusterconfig"
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage/azure"
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage/emptydir"
@@ -26,17 +26,17 @@ type Driver interface {
 	GetType() string
 	ConfigEnv() ([]corev1.EnvVar, error)
 	Volumes() ([]corev1.Volume, []corev1.VolumeMount, error)
-	CompleteConfiguration(*opapi.Config, *bool) error
-	CreateStorage(*opapi.Config, *bool) error
-	StorageExists(*opapi.Config, *bool) (bool, error)
-	RemoveStorage(*opapi.Config, *bool) error
-	StorageChanged(*opapi.Config, *bool) bool
+	CompleteConfiguration(*imageregistryv1.Config, *bool) error
+	CreateStorage(*imageregistryv1.Config, *bool) error
+	StorageExists(*imageregistryv1.Config, *bool) (bool, error)
+	RemoveStorage(*imageregistryv1.Config, *bool) error
+	StorageChanged(*imageregistryv1.Config, *bool) bool
 	GetStorageName() string
 	SyncSecrets(*coreapi.Secret) (map[string]string, error)
-	UpdateFromStorage(cfg opapi.ImageRegistryConfigStorage)
+	UpdateFromStorage(cfg imageregistryv1.ImageRegistryConfigStorage)
 }
 
-func newDriver(crname string, crnamespace string, cfg *opapi.ImageRegistryConfigStorage) (Driver, error) {
+func newDriver(crname string, crnamespace string, cfg *imageregistryv1.ImageRegistryConfigStorage) (Driver, error) {
 	var drivers []Driver
 
 	if cfg.Azure != nil {
@@ -78,7 +78,7 @@ func newDriver(crname string, crnamespace string, cfg *opapi.ImageRegistryConfig
 	return nil, fmt.Errorf("exactly one storage type should be configured at the same time, got %d: %v", len(drivers), names)
 }
 
-func NewDriver(crname string, crnamespace string, cfg *opapi.ImageRegistryConfigStorage) (Driver, error) {
+func NewDriver(crname string, crnamespace string, cfg *imageregistryv1.ImageRegistryConfigStorage) (Driver, error) {
 	drv, err := newDriver(crname, crnamespace, cfg)
 	if err == ErrStorageNotConfigured {
 		storageType, err := getPlatformStorage()
@@ -87,21 +87,21 @@ func NewDriver(crname string, crnamespace string, cfg *opapi.ImageRegistryConfig
 		}
 		switch storageType {
 		case clusterconfig.StorageTypeAzure:
-			cfg.Azure = &opapi.ImageRegistryConfigStorageAzure{}
+			cfg.Azure = &imageregistryv1.ImageRegistryConfigStorageAzure{}
 		case clusterconfig.StorageTypeFileSystem:
-			cfg.Filesystem = &opapi.ImageRegistryConfigStorageFilesystem{}
+			cfg.Filesystem = &imageregistryv1.ImageRegistryConfigStorageFilesystem{}
 		case clusterconfig.StorageTypeEmptyDir:
-			cfg.Filesystem = &opapi.ImageRegistryConfigStorageFilesystem{
+			cfg.Filesystem = &imageregistryv1.ImageRegistryConfigStorageFilesystem{
 				VolumeSource: corev1.VolumeSource{
 					EmptyDir: &corev1.EmptyDirVolumeSource{},
 				},
 			}
 		case clusterconfig.StorageTypeGCS:
-			cfg.GCS = &opapi.ImageRegistryConfigStorageGCS{}
+			cfg.GCS = &imageregistryv1.ImageRegistryConfigStorageGCS{}
 		case clusterconfig.StorageTypeS3:
-			cfg.S3 = &opapi.ImageRegistryConfigStorageS3{}
+			cfg.S3 = &imageregistryv1.ImageRegistryConfigStorageS3{}
 		case clusterconfig.StorageTypeSwift:
-			cfg.Swift = &opapi.ImageRegistryConfigStorageSwift{}
+			cfg.Swift = &imageregistryv1.ImageRegistryConfigStorageSwift{}
 		default:
 			glog.Errorf("unknown storage backend: %s", storageType)
 			return nil, ErrStorageNotConfigured

--- a/pkg/storage/swift/swift.go
+++ b/pkg/storage/swift/swift.go
@@ -4,17 +4,17 @@ import (
 	coreapi "k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
 
-	opapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/clusterconfig"
 )
 
 type driver struct {
 	Name      string
 	Namespace string
-	Config    *opapi.ImageRegistryConfigStorageSwift
+	Config    *imageregistryv1.ImageRegistryConfigStorageSwift
 }
 
-func NewDriver(crname string, crnamespace string, c *opapi.ImageRegistryConfigStorageSwift) *driver {
+func NewDriver(crname string, crnamespace string, c *imageregistryv1.ImageRegistryConfigStorageSwift) *driver {
 	return &driver{
 		Name:      crname,
 		Namespace: crnamespace,
@@ -22,7 +22,7 @@ func NewDriver(crname string, crnamespace string, c *opapi.ImageRegistryConfigSt
 	}
 }
 
-func (d *driver) UpdateFromStorage(cfg opapi.ImageRegistryConfigStorage) {
+func (d *driver) UpdateFromStorage(cfg imageregistryv1.ImageRegistryConfigStorage) {
 	d.Config = cfg.Swift.DeepCopy()
 }
 
@@ -65,11 +65,11 @@ func (d *driver) ConfigEnv() (envs []corev1.EnvVar, err error) {
 	return
 }
 
-func (d *driver) StorageExists(cr *opapi.Config, modified *bool) (bool, error) {
+func (d *driver) StorageExists(cr *imageregistryv1.Config, modified *bool) (bool, error) {
 	return false, nil
 }
 
-func (d *driver) StorageChanged(cr *opapi.Config, modified *bool) bool {
+func (d *driver) StorageChanged(cr *imageregistryv1.Config, modified *bool) bool {
 	return false
 }
 
@@ -77,11 +77,11 @@ func (d *driver) GetStorageName() string {
 	return ""
 }
 
-func (d *driver) CreateStorage(cr *opapi.Config, modified *bool) error {
+func (d *driver) CreateStorage(cr *imageregistryv1.Config, modified *bool) error {
 	return nil
 }
 
-func (d *driver) RemoveStorage(cr *opapi.Config, modified *bool) error {
+func (d *driver) RemoveStorage(cr *imageregistryv1.Config, modified *bool) error {
 	if !cr.Status.StorageManaged {
 		return nil
 	}
@@ -93,6 +93,6 @@ func (d *driver) Volumes() ([]corev1.Volume, []corev1.VolumeMount, error) {
 	return nil, nil, nil
 }
 
-func (d *driver) CompleteConfiguration(cr *opapi.Config, modified *bool) error {
+func (d *driver) CompleteConfiguration(cr *imageregistryv1.Config, modified *bool) error {
 	return nil
 }

--- a/pkg/storage/util/util.go
+++ b/pkg/storage/util/util.go
@@ -11,7 +11,7 @@ import (
 
 	operatorapi "github.com/openshift/api/operator/v1"
 
-	regopapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
 
 	coreapi "k8s.io/api/core/v1"
@@ -29,7 +29,7 @@ import (
 )
 
 // UpdateCondition will update or add the provided condition and updated the modified parameter if it changed the resource
-func UpdateCondition(cr *regopapi.Config, conditionType string, status operatorapi.ConditionStatus, reason string, message string, modified *bool) {
+func UpdateCondition(cr *imageregistryv1.Config, conditionType string, status operatorapi.ConditionStatus, reason string, message string, modified *bool) {
 	found := false
 	condition := &operatorapi.OperatorCondition{
 		Type:               conditionType,

--- a/pkg/testframework/framework.go
+++ b/pkg/testframework/framework.go
@@ -57,7 +57,7 @@ func DeleteCompletely(getObject func() (metav1.Object, error), deleteObject func
 		return err
 	}
 
-	return wait.Poll(1*time.Second, 5*time.Minute, func() (stop bool, err error) {
+	return wait.Poll(1*time.Second, AsyncOperationTimeout, func() (stop bool, err error) {
 		obj, err = getObject()
 		if err != nil {
 			if errors.IsNotFound(err) {

--- a/pkg/testframework/framework.go
+++ b/pkg/testframework/framework.go
@@ -15,7 +15,9 @@ var (
 	// AsyncOperationTimeout is how long we want to wait for asynchronous
 	// operations to complete. ForeverTestTimeout is not long enough to create
 	// several replicas and get them available on a slow machine.
-	AsyncOperationTimeout = 120 * time.Second
+	// Setting this to 5 minutes:w
+	
+	AsyncOperationTimeout = 5 * time.Minute
 )
 
 // Logger is an interface to report events from tests. It is implemented by

--- a/pkg/testframework/imageregistry.go
+++ b/pkg/testframework/imageregistry.go
@@ -17,12 +17,6 @@ import (
 	imageregistryapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 )
 
-const (
-	ImageRegistryResourceName        = imageregistryapi.ImageRegistryResourceName
-	ImageRegistryDeploymentName      = imageregistryapi.ImageRegistryName
-	ImageRegistryDeploymentNamespace = imageregistryapi.ImageRegistryOperatorNamespace
-)
-
 type ConditionStatus struct {
 	status *operatorapi.ConditionStatus
 }
@@ -80,7 +74,7 @@ func (c ImageRegistryConditions) String() string {
 }
 
 func ensureImageRegistryToBeRemoved(logger Logger, client *Clientset) error {
-	if _, err := client.Configs().Patch(ImageRegistryResourceName, types.MergePatchType, []byte(`{"spec": {"managementState": "Removed"}}`)); err != nil {
+	if _, err := client.Configs().Patch(imageregistryapi.ImageRegistryResourceName, types.MergePatchType, []byte(`{"spec": {"managementState": "Removed"}}`)); err != nil {
 		if errors.IsNotFound(err) {
 			// That's not exactly what we are asked for. And few seconds later
 			// the operator may bootstrap it. However, if the operator is
@@ -93,7 +87,7 @@ func ensureImageRegistryToBeRemoved(logger Logger, client *Clientset) error {
 
 	var cr *imageregistryapi.Config
 	err := wait.Poll(1*time.Second, AsyncOperationTimeout, func() (stop bool, err error) {
-		cr, err = client.Configs().Get(ImageRegistryResourceName, metav1.GetOptions{})
+		cr, err = client.Configs().Get(imageregistryapi.ImageRegistryResourceName, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			cr = nil
 			return true, nil
@@ -115,7 +109,7 @@ func ensureImageRegistryToBeRemoved(logger Logger, client *Clientset) error {
 
 func deleteImageRegistryResource(client *Clientset) error {
 	// TODO(dmage): the finalizer should be removed by the operator
-	cr, err := client.Configs().Get(ImageRegistryResourceName, metav1.GetOptions{})
+	cr, err := client.Configs().Get(imageregistryapi.ImageRegistryResourceName, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil
@@ -129,10 +123,10 @@ func deleteImageRegistryResource(client *Clientset) error {
 
 	if err := DeleteCompletely(
 		func() (metav1.Object, error) {
-			return client.Configs().Get(ImageRegistryResourceName, metav1.GetOptions{})
+			return client.Configs().Get(imageregistryapi.ImageRegistryResourceName, metav1.GetOptions{})
 		},
 		func(deleteOptions *metav1.DeleteOptions) error {
-			return client.Configs().Delete(ImageRegistryResourceName, deleteOptions)
+			return client.Configs().Delete(imageregistryapi.ImageRegistryResourceName, deleteOptions)
 		},
 	); err != nil {
 		if errors.IsNotFound(err) {
@@ -186,7 +180,7 @@ func MustDeployImageRegistry(t *testing.T, client *Clientset, cr *imageregistrya
 }
 
 func DumpImageRegistryResource(logger Logger, client *Clientset) {
-	cr, err := client.Configs().Get(ImageRegistryResourceName, metav1.GetOptions{})
+	cr, err := client.Configs().Get(imageregistryapi.ImageRegistryResourceName, metav1.GetOptions{})
 	if err != nil {
 		logger.Logf("unable to dump the image registry resource: %s", err)
 		return
@@ -197,7 +191,7 @@ func DumpImageRegistryResource(logger Logger, client *Clientset) {
 func ensureImageRegistryIsProcessed(logger Logger, client *Clientset) (*imageregistryapi.Config, error) {
 	var cr *imageregistryapi.Config
 	err := wait.Poll(1*time.Second, AsyncOperationTimeout, func() (stop bool, err error) {
-		cr, err = client.Configs().Get(ImageRegistryResourceName, metav1.GetOptions{})
+		cr, err = client.Configs().Get(imageregistryapi.ImageRegistryResourceName, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			logger.Logf("waiting for the registry: the resource does not exist")
 			cr = nil
@@ -254,7 +248,7 @@ func MustEnsureImageRegistryIsAvailable(t *testing.T, client *Clientset) {
 func ensureInternalRegistryHostnameIsSet(logger Logger, client *Clientset) error {
 	var cr *imageregistryapi.Config
 	err := wait.Poll(1*time.Second, AsyncOperationTimeout, func() (stop bool, err error) {
-		cr, err = client.Configs().Get(ImageRegistryResourceName, metav1.GetOptions{})
+		cr, err = client.Configs().Get(imageregistryapi.ImageRegistryResourceName, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			logger.Logf("waiting for the registry: the resource does not exist")
 			cr = nil

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -33,7 +33,7 @@ import (
 
 	operatorapi "github.com/openshift/api/operator/v1"
 
-	regopapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/clusterconfig"
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage"
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage/util"
@@ -73,40 +73,40 @@ func TestAWSDefaults(t *testing.T) {
 
 	// Check that the image-registry-private-configuration secret exists and
 	// contains the correct information
-	imageRegistryPrivateConfiguration, err := client.Secrets(testframework.ImageRegistryDeploymentNamespace).Get(regopapi.ImageRegistryPrivateConfiguration, metav1.GetOptions{})
+	imageRegistryPrivateConfiguration, err := client.Secrets(imageregistryapi.ImageRegistryOperatorNamespace).Get(imageregistryapi.ImageRegistryPrivateConfiguration, metav1.GetOptions{})
 	if err != nil {
-		t.Errorf("unable to get secret %s/%s: %#v", testframework.ImageRegistryDeploymentNamespace, regopapi.ImageRegistryPrivateConfiguration, err)
+		t.Errorf("unable to get secret %s/%s: %#v", imageregistryapi.ImageRegistryOperatorNamespace, imageregistryapi.ImageRegistryPrivateConfiguration, err)
 	}
 	accessKey, _ := imageRegistryPrivateConfiguration.Data["REGISTRY_STORAGE_S3_ACCESSKEY"]
 	secretKey, _ := imageRegistryPrivateConfiguration.Data["REGISTRY_STORAGE_S3_SECRETKEY"]
 	if string(accessKey) != cfg.Storage.S3.AccessKey || string(secretKey) != cfg.Storage.S3.SecretKey {
-		t.Errorf("secret %s/%s contains incorrect aws credentials (AccessKey or SecretKey)", testframework.ImageRegistryDeploymentNamespace, regopapi.ImageRegistryPrivateConfiguration)
+		t.Errorf("secret %s/%s contains incorrect aws credentials (AccessKey or SecretKey)", imageregistryapi.ImageRegistryOperatorNamespace, imageregistryapi.ImageRegistryPrivateConfiguration)
 	}
 
 	// Check that the image registry resource exists
 	// and contains the correct region and a non-empty bucket name
-	cr, err := client.Configs().Get(testframework.ImageRegistryResourceName, metav1.GetOptions{})
+	cr, err := client.Configs().Get(imageregistryapi.ImageRegistryResourceName, metav1.GetOptions{})
 	if err != nil {
-		t.Errorf("unable to get custom resource %s/%s: %#v", testframework.ImageRegistryDeploymentNamespace, testframework.ImageRegistryResourceName, err)
+		t.Errorf("unable to get custom resource %s/%s: %#v", imageregistryapi.ImageRegistryOperatorNamespace, imageregistryapi.ImageRegistryResourceName, err)
 	}
 	if cr.Spec.Storage.S3 == nil {
-		t.Errorf("custom resource %s/%s is missing the S3 configuration", testframework.ImageRegistryDeploymentNamespace, testframework.ImageRegistryResourceName)
+		t.Errorf("custom resource %s/%s is missing the S3 configuration", imageregistryapi.ImageRegistryOperatorNamespace, imageregistryapi.ImageRegistryResourceName)
 	} else {
 		if cr.Spec.Storage.S3.Region != cfg.Storage.S3.Region {
-			t.Errorf("custom resource %s/%s contains incorrect data. S3 Region was %v but should have been %v", testframework.ImageRegistryDeploymentNamespace, testframework.ImageRegistryResourceName, cfg.Storage.S3.Region, cr.Spec.Storage.S3)
+			t.Errorf("custom resource %s/%s contains incorrect data. S3 Region was %v but should have been %v", imageregistryapi.ImageRegistryOperatorNamespace, imageregistryapi.ImageRegistryResourceName, cfg.Storage.S3.Region, cr.Spec.Storage.S3)
 
 		}
 		if cr.Spec.Storage.S3.Bucket == "" {
-			t.Errorf("custom resource %s/%s contains incorrect data. S3 Bucket name should not be empty", testframework.ImageRegistryDeploymentNamespace, testframework.ImageRegistryResourceName)
+			t.Errorf("custom resource %s/%s contains incorrect data. S3 Bucket name should not be empty", imageregistryapi.ImageRegistryOperatorNamespace, imageregistryapi.ImageRegistryResourceName)
 		}
 
 		if !cr.Status.StorageManaged {
-			t.Errorf("custom resource %s/%s contains incorrect data. Status.StorageManaged was %v but should have been \"true\"", testframework.ImageRegistryDeploymentNamespace, testframework.ImageRegistryResourceName, cr.Status.StorageManaged)
+			t.Errorf("custom resource %s/%s contains incorrect data. Status.StorageManaged was %v but should have been \"true\"", imageregistryapi.ImageRegistryOperatorNamespace, imageregistryapi.ImageRegistryResourceName, cr.Status.StorageManaged)
 		}
 	}
 
 	// Wait for the image registry resource to have an updated StorageExists condition
-	errs := conditionExistsWithStatusAndReason(client, regopapi.StorageExists, operatorapi.ConditionTrue, "S3 Bucket Exists")
+	errs := conditionExistsWithStatusAndReason(client, imageregistryapi.StorageExists, operatorapi.ConditionTrue, "S3 Bucket Exists")
 	if len(errs) != 0 {
 		for _, err := range errs {
 			t.Errorf("%#v", err)
@@ -114,7 +114,7 @@ func TestAWSDefaults(t *testing.T) {
 	}
 
 	// Wait for the image registry resource to have an updated StorageTagged condition
-	errs = conditionExistsWithStatusAndReason(client, regopapi.StorageTagged, operatorapi.ConditionTrue, "Tagging Successful")
+	errs = conditionExistsWithStatusAndReason(client, imageregistryapi.StorageTagged, operatorapi.ConditionTrue, "Tagging Successful")
 	if len(errs) != 0 {
 		for _, err := range errs {
 			t.Errorf("%#v", err)
@@ -122,7 +122,7 @@ func TestAWSDefaults(t *testing.T) {
 	}
 
 	// Wait for the image registry resource to have an updated StorageEncrypted condition
-	errs = conditionExistsWithStatusAndReason(client, regopapi.StorageEncrypted, operatorapi.ConditionTrue, "Encryption Successful")
+	errs = conditionExistsWithStatusAndReason(client, imageregistryapi.StorageEncrypted, operatorapi.ConditionTrue, "Encryption Successful")
 	if len(errs) != 0 {
 		for _, err := range errs {
 			t.Errorf("%#v", err)
@@ -130,7 +130,7 @@ func TestAWSDefaults(t *testing.T) {
 	}
 
 	// Wait for the image registry resource to have an updated StorageIncompleteUploadCleanupEnabled condition
-	errs = conditionExistsWithStatusAndReason(client, regopapi.StorageIncompleteUploadCleanupEnabled, operatorapi.ConditionTrue, "Enable Cleanup Successful")
+	errs = conditionExistsWithStatusAndReason(client, imageregistryapi.StorageIncompleteUploadCleanupEnabled, operatorapi.ConditionTrue, "Enable Cleanup Successful")
 	if len(errs) != 0 {
 		for _, err := range errs {
 			t.Errorf("%#v", err)
@@ -230,7 +230,7 @@ func TestAWSDefaults(t *testing.T) {
 		}
 	}
 
-	registryDeployment, err := client.Deployments(testframework.ImageRegistryDeploymentNamespace).Get(testframework.ImageRegistryDeploymentName, metav1.GetOptions{})
+	registryDeployment, err := client.Deployments(imageregistryapi.ImageRegistryOperatorNamespace).Get(imageregistryapi.ImageRegistryName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -286,15 +286,15 @@ func TestAWSUnableToCreateBucketOnStartup(t *testing.T) {
 	client := testframework.MustNewClientset(t, nil)
 
 	// Create the image-registry-private-configuration-user secret using the invalid credentials
-	if _, err := util.CreateOrUpdateSecret(regopapi.ImageRegistryPrivateConfigurationUser, testframework.ImageRegistryDeploymentNamespace, fakeAWSCredsData); err != nil {
-		t.Fatalf("unable to create secret %q: %#v", fmt.Sprintf("%s/%s", testframework.ImageRegistryDeploymentNamespace, regopapi.ImageRegistryPrivateConfigurationUser), err)
+	if _, err := util.CreateOrUpdateSecret(imageregistryapi.ImageRegistryPrivateConfigurationUser, imageregistryapi.ImageRegistryOperatorNamespace, fakeAWSCredsData); err != nil {
+		t.Fatalf("unable to create secret %q: %#v", fmt.Sprintf("%s/%s", imageregistryapi.ImageRegistryOperatorNamespace, imageregistryapi.ImageRegistryPrivateConfigurationUser), err)
 	}
 
 	defer testframework.MustRemoveImageRegistry(t, client)
 	testframework.MustDeployImageRegistry(t, client, nil)
 
 	// Wait for the image registry resource to have an updated StorageExists condition
-	errs := conditionExistsWithStatusAndReason(client, regopapi.StorageExists, operatorapi.ConditionFalse, "InvalidAccessKeyId")
+	errs := conditionExistsWithStatusAndReason(client, imageregistryapi.StorageExists, operatorapi.ConditionFalse, "InvalidAccessKeyId")
 	if len(errs) != 0 {
 		for _, err := range errs {
 			t.Errorf("%#v", err)
@@ -302,13 +302,13 @@ func TestAWSUnableToCreateBucketOnStartup(t *testing.T) {
 	}
 
 	// Remove the image-registry-private-configuration-user secret
-	err = client.Secrets(testframework.ImageRegistryDeploymentNamespace).Delete(regopapi.ImageRegistryPrivateConfigurationUser, &metav1.DeleteOptions{})
+	err = client.Secrets(imageregistryapi.ImageRegistryOperatorNamespace).Delete(imageregistryapi.ImageRegistryPrivateConfigurationUser, &metav1.DeleteOptions{})
 	if err != nil {
-		t.Errorf("unable to remove %s/%s: %#v", testframework.ImageRegistryDeploymentNamespace, regopapi.ImageRegistryPrivateConfigurationUser, err)
+		t.Errorf("unable to remove %s/%s: %#v", imageregistryapi.ImageRegistryOperatorNamespace, imageregistryapi.ImageRegistryPrivateConfigurationUser, err)
 	}
 
 	// Wait for the image registry resource to have an updated StorageExists condition
-	errs = conditionExistsWithStatusAndReason(client, regopapi.StorageExists, operatorapi.ConditionTrue, "S3 Bucket Exists")
+	errs = conditionExistsWithStatusAndReason(client, imageregistryapi.StorageExists, operatorapi.ConditionTrue, "S3 Bucket Exists")
 	if len(errs) != 0 {
 		for _, err := range errs {
 			t.Errorf("%#v", err)
@@ -340,8 +340,8 @@ func TestAWSUpdateCredentials(t *testing.T) {
 
 	// Create the image-registry-private-configuration-user secret using the invalid credentials
 	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		if _, err := util.CreateOrUpdateSecret(regopapi.ImageRegistryPrivateConfigurationUser, testframework.ImageRegistryDeploymentNamespace, fakeAWSCredsData); err != nil {
-			return fmt.Errorf("unable to create secret %q: %#v", fmt.Sprintf("%s/%s", testframework.ImageRegistryDeploymentNamespace, regopapi.ImageRegistryPrivateConfigurationUser), err)
+		if _, err := util.CreateOrUpdateSecret(imageregistryapi.ImageRegistryPrivateConfigurationUser, imageregistryapi.ImageRegistryOperatorNamespace, fakeAWSCredsData); err != nil {
+			return fmt.Errorf("unable to create secret %q: %#v", fmt.Sprintf("%s/%s", imageregistryapi.ImageRegistryOperatorNamespace, imageregistryapi.ImageRegistryPrivateConfigurationUser), err)
 		}
 		return nil
 	})
@@ -359,7 +359,7 @@ func TestAWSUpdateCredentials(t *testing.T) {
 	}
 
 	// Wait for the image registry resource to have an updated StorageExists condition
-	errs := conditionExistsWithStatusAndReason(client, regopapi.StorageExists, operatorapi.ConditionFalse, "InvalidAccessKeyId")
+	errs := conditionExistsWithStatusAndReason(client, imageregistryapi.StorageExists, operatorapi.ConditionFalse, "InvalidAccessKeyId")
 	if len(errs) != 0 {
 		for _, err := range errs {
 			t.Errorf("%#v", err)
@@ -367,13 +367,13 @@ func TestAWSUpdateCredentials(t *testing.T) {
 	}
 
 	// Remove the image-registry-private-configuration-user secret
-	err = client.Secrets(testframework.ImageRegistryDeploymentNamespace).Delete(regopapi.ImageRegistryPrivateConfigurationUser, &metav1.DeleteOptions{})
+	err = client.Secrets(imageregistryapi.ImageRegistryOperatorNamespace).Delete(imageregistryapi.ImageRegistryPrivateConfigurationUser, &metav1.DeleteOptions{})
 	if err != nil {
-		t.Errorf("unable to remove %s/%s: %#v", testframework.ImageRegistryDeploymentNamespace, regopapi.ImageRegistryPrivateConfigurationUser, err)
+		t.Errorf("unable to remove %s/%s: %#v", imageregistryapi.ImageRegistryOperatorNamespace, imageregistryapi.ImageRegistryPrivateConfigurationUser, err)
 	}
 
 	// Wait for the image registry resource to have an updated StorageExists condition
-	errs = conditionExistsWithStatusAndReason(client, regopapi.StorageExists, operatorapi.ConditionTrue, "S3 Bucket Exists")
+	errs = conditionExistsWithStatusAndReason(client, imageregistryapi.StorageExists, operatorapi.ConditionTrue, "S3 Bucket Exists")
 	if len(errs) != 0 {
 		for _, err := range errs {
 			t.Errorf("%#v", err)
@@ -403,12 +403,12 @@ func TestAWSFinalizerDeleteS3Bucket(t *testing.T) {
 	testframework.MustEnsureInternalRegistryHostnameIsSet(t, client)
 	testframework.MustEnsureClusterOperatorStatusIsSet(t, client)
 
-	cr, err := client.Configs().Get(testframework.ImageRegistryResourceName, metav1.GetOptions{})
+	cr, err := client.Configs().Get(imageregistryapi.ImageRegistryResourceName, metav1.GetOptions{})
 	if err != nil {
-		t.Errorf("unable to get custom resource %s/%s: %#v", testframework.ImageRegistryDeploymentNamespace, testframework.ImageRegistryResourceName, err)
+		t.Errorf("unable to get custom resource %s/%s: %#v", imageregistryapi.ImageRegistryOperatorNamespace, imageregistryapi.ImageRegistryResourceName, err)
 	}
 	// Check that the S3 bucket gets cleaned up by the finalizer (if we manage it)
-	err = client.Configs().Delete(testframework.ImageRegistryResourceName, &metav1.DeleteOptions{})
+	err = client.Configs().Delete(imageregistryapi.ImageRegistryResourceName, &metav1.DeleteOptions{})
 	if err != nil {
 		t.Errorf("unable to get image registry resource: %#v", err)
 	}

--- a/test/e2e/basic_empty_dir_test.go
+++ b/test/e2e/basic_empty_dir_test.go
@@ -24,7 +24,7 @@ func TestBasicEmptyDir(t *testing.T) {
 			Kind:       "Config",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: testframework.ImageRegistryResourceName,
+			Name: imageregistryapi.ImageRegistryResourceName,
 		},
 		Spec: imageregistryapi.ImageRegistrySpec{
 			ManagementState: operatorapi.Managed,
@@ -43,7 +43,7 @@ func TestBasicEmptyDir(t *testing.T) {
 	testframework.MustEnsureInternalRegistryHostnameIsSet(t, client)
 	testframework.MustEnsureClusterOperatorStatusIsSet(t, client)
 
-	deploy, err := client.Deployments(testframework.ImageRegistryDeploymentNamespace).Get(testframework.ImageRegistryDeploymentName, metav1.GetOptions{})
+	deploy, err := client.Deployments(imageregistryapi.ImageRegistryOperatorNamespace).Get(imageregistryapi.ImageRegistryName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/basic_empty_dir_test.go
+++ b/test/e2e/basic_empty_dir_test.go
@@ -9,7 +9,7 @@ import (
 
 	operatorapi "github.com/openshift/api/operator/v1"
 
-	imageregistryapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/testframework"
 )
 
@@ -18,18 +18,18 @@ func TestBasicEmptyDir(t *testing.T) {
 
 	defer testframework.MustRemoveImageRegistry(t, client)
 
-	cr := &imageregistryapi.Config{
+	cr := &imageregistryv1.Config{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: imageregistryapi.SchemeGroupVersion.String(),
+			APIVersion: imageregistryv1.SchemeGroupVersion.String(),
 			Kind:       "Config",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: imageregistryapi.ImageRegistryResourceName,
+			Name: imageregistryv1.ImageRegistryResourceName,
 		},
-		Spec: imageregistryapi.ImageRegistrySpec{
+		Spec: imageregistryv1.ImageRegistrySpec{
 			ManagementState: operatorapi.Managed,
-			Storage: imageregistryapi.ImageRegistryConfigStorage{
-				Filesystem: &imageregistryapi.ImageRegistryConfigStorageFilesystem{
+			Storage: imageregistryv1.ImageRegistryConfigStorage{
+				Filesystem: &imageregistryv1.ImageRegistryConfigStorageFilesystem{
 					VolumeSource: corev1.VolumeSource{
 						EmptyDir: &corev1.EmptyDirVolumeSource{},
 					},
@@ -43,7 +43,7 @@ func TestBasicEmptyDir(t *testing.T) {
 	testframework.MustEnsureInternalRegistryHostnameIsSet(t, client)
 	testframework.MustEnsureClusterOperatorStatusIsSet(t, client)
 
-	deploy, err := client.Deployments(imageregistryapi.ImageRegistryOperatorNamespace).Get(imageregistryapi.ImageRegistryName, metav1.GetOptions{})
+	deploy, err := client.Deployments(imageregistryv1.ImageRegistryOperatorNamespace).Get(imageregistryv1.ImageRegistryName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/failing_test.go
+++ b/test/e2e/failing_test.go
@@ -9,7 +9,7 @@ import (
 
 	operatorapi "github.com/openshift/api/operator/v1"
 
-	imageregistryapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/testframework"
 )
 
@@ -18,14 +18,14 @@ func TestFailing(t *testing.T) {
 
 	defer testframework.MustRemoveImageRegistry(t, client)
 
-	testframework.MustDeployImageRegistry(t, client, &imageregistryapi.Config{
+	testframework.MustDeployImageRegistry(t, client, &imageregistryv1.Config{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: imageregistryapi.ImageRegistryResourceName,
+			Name: imageregistryv1.ImageRegistryResourceName,
 		},
-		Spec: imageregistryapi.ImageRegistrySpec{
+		Spec: imageregistryv1.ImageRegistrySpec{
 			ManagementState: operatorapi.Managed,
-			Storage: imageregistryapi.ImageRegistryConfigStorage{
-				Filesystem: &imageregistryapi.ImageRegistryConfigStorageFilesystem{
+			Storage: imageregistryv1.ImageRegistryConfigStorage{
+				Filesystem: &imageregistryv1.ImageRegistryConfigStorageFilesystem{
 					VolumeSource: corev1.VolumeSource{
 						EmptyDir: &corev1.EmptyDirVolumeSource{},
 					},

--- a/test/e2e/failing_test.go
+++ b/test/e2e/failing_test.go
@@ -20,7 +20,7 @@ func TestFailing(t *testing.T) {
 
 	testframework.MustDeployImageRegistry(t, client, &imageregistryapi.Config{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: testframework.ImageRegistryResourceName,
+			Name: imageregistryapi.ImageRegistryResourceName,
 		},
 		Spec: imageregistryapi.ImageRegistrySpec{
 			ManagementState: operatorapi.Managed,

--- a/test/e2e/recreate_deployment_test.go
+++ b/test/e2e/recreate_deployment_test.go
@@ -26,7 +26,7 @@ func TestRecreateDeployment(t *testing.T) {
 			Kind:       "Config",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: testframework.ImageRegistryResourceName,
+			Name: imageregistryapi.ImageRegistryResourceName,
 		},
 		Spec: imageregistryapi.ImageRegistrySpec{
 			ManagementState: operatorapi.Managed,
@@ -46,10 +46,10 @@ func TestRecreateDeployment(t *testing.T) {
 	t.Logf("deleting the image registry deployment...")
 	if err := testframework.DeleteCompletely(
 		func() (metav1.Object, error) {
-			return client.Deployments(testframework.ImageRegistryDeploymentNamespace).Get(testframework.ImageRegistryDeploymentName, metav1.GetOptions{})
+			return client.Deployments(imageregistryapi.ImageRegistryOperatorNamespace).Get(imageregistryapi.ImageRegistryName, metav1.GetOptions{})
 		},
 		func(deleteOptions *metav1.DeleteOptions) error {
-			return client.Deployments(testframework.ImageRegistryDeploymentNamespace).Delete(testframework.ImageRegistryDeploymentName, deleteOptions)
+			return client.Deployments(imageregistryapi.ImageRegistryOperatorNamespace).Delete(imageregistryapi.ImageRegistryName, deleteOptions)
 		},
 	); err != nil {
 		t.Fatalf("unable to delete the deployment: %s", err)
@@ -57,7 +57,7 @@ func TestRecreateDeployment(t *testing.T) {
 
 	t.Logf("waiting the operator to recreate the deployment...")
 	err := wait.Poll(1*time.Second, testframework.AsyncOperationTimeout, func() (stop bool, err error) {
-		_, err = client.Deployments(testframework.ImageRegistryDeploymentNamespace).Get(testframework.ImageRegistryDeploymentName, metav1.GetOptions{})
+		_, err = client.Deployments(imageregistryapi.ImageRegistryOperatorNamespace).Get(imageregistryapi.ImageRegistryName, metav1.GetOptions{})
 		if err == nil {
 			return true, nil
 		}

--- a/test/e2e/recreate_deployment_test.go
+++ b/test/e2e/recreate_deployment_test.go
@@ -11,7 +11,7 @@ import (
 
 	operatorapi "github.com/openshift/api/operator/v1"
 
-	imageregistryapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/testframework"
 )
 
@@ -20,18 +20,18 @@ func TestRecreateDeployment(t *testing.T) {
 
 	defer testframework.MustRemoveImageRegistry(t, client)
 
-	cr := &imageregistryapi.Config{
+	cr := &imageregistryv1.Config{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: imageregistryapi.SchemeGroupVersion.String(),
+			APIVersion: imageregistryv1.SchemeGroupVersion.String(),
 			Kind:       "Config",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: imageregistryapi.ImageRegistryResourceName,
+			Name: imageregistryv1.ImageRegistryResourceName,
 		},
-		Spec: imageregistryapi.ImageRegistrySpec{
+		Spec: imageregistryv1.ImageRegistrySpec{
 			ManagementState: operatorapi.Managed,
-			Storage: imageregistryapi.ImageRegistryConfigStorage{
-				Filesystem: &imageregistryapi.ImageRegistryConfigStorageFilesystem{
+			Storage: imageregistryv1.ImageRegistryConfigStorage{
+				Filesystem: &imageregistryv1.ImageRegistryConfigStorageFilesystem{
 					VolumeSource: corev1.VolumeSource{
 						EmptyDir: &corev1.EmptyDirVolumeSource{},
 					},
@@ -46,10 +46,10 @@ func TestRecreateDeployment(t *testing.T) {
 	t.Logf("deleting the image registry deployment...")
 	if err := testframework.DeleteCompletely(
 		func() (metav1.Object, error) {
-			return client.Deployments(imageregistryapi.ImageRegistryOperatorNamespace).Get(imageregistryapi.ImageRegistryName, metav1.GetOptions{})
+			return client.Deployments(imageregistryv1.ImageRegistryOperatorNamespace).Get(imageregistryv1.ImageRegistryName, metav1.GetOptions{})
 		},
 		func(deleteOptions *metav1.DeleteOptions) error {
-			return client.Deployments(imageregistryapi.ImageRegistryOperatorNamespace).Delete(imageregistryapi.ImageRegistryName, deleteOptions)
+			return client.Deployments(imageregistryv1.ImageRegistryOperatorNamespace).Delete(imageregistryv1.ImageRegistryName, deleteOptions)
 		},
 	); err != nil {
 		t.Fatalf("unable to delete the deployment: %s", err)
@@ -57,7 +57,7 @@ func TestRecreateDeployment(t *testing.T) {
 
 	t.Logf("waiting the operator to recreate the deployment...")
 	err := wait.Poll(1*time.Second, testframework.AsyncOperationTimeout, func() (stop bool, err error) {
-		_, err = client.Deployments(imageregistryapi.ImageRegistryOperatorNamespace).Get(imageregistryapi.ImageRegistryName, metav1.GetOptions{})
+		_, err = client.Deployments(imageregistryv1.ImageRegistryOperatorNamespace).Get(imageregistryv1.ImageRegistryName, metav1.GetOptions{})
 		if err == nil {
 			return true, nil
 		}

--- a/test/e2e/unmanaged_test.go
+++ b/test/e2e/unmanaged_test.go
@@ -13,7 +13,7 @@ import (
 
 	operatorapi "github.com/openshift/api/operator/v1"
 
-	imageregistryapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/testframework"
 )
 
@@ -22,18 +22,18 @@ func TestUnmanaged(t *testing.T) {
 
 	defer testframework.MustRemoveImageRegistry(t, client)
 
-	testframework.MustDeployImageRegistry(t, client, &imageregistryapi.Config{
+	testframework.MustDeployImageRegistry(t, client, &imageregistryv1.Config{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: imageregistryapi.SchemeGroupVersion.String(),
+			APIVersion: imageregistryv1.SchemeGroupVersion.String(),
 			Kind:       "Config",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: imageregistryapi.ImageRegistryResourceName,
+			Name: imageregistryv1.ImageRegistryResourceName,
 		},
-		Spec: imageregistryapi.ImageRegistrySpec{
+		Spec: imageregistryv1.ImageRegistrySpec{
 			ManagementState: operatorapi.Managed,
-			Storage: imageregistryapi.ImageRegistryConfigStorage{
-				Filesystem: &imageregistryapi.ImageRegistryConfigStorageFilesystem{
+			Storage: imageregistryv1.ImageRegistryConfigStorage{
+				Filesystem: &imageregistryv1.ImageRegistryConfigStorageFilesystem{
 					VolumeSource: corev1.VolumeSource{
 						EmptyDir: &corev1.EmptyDirVolumeSource{},
 					},
@@ -44,10 +44,10 @@ func TestUnmanaged(t *testing.T) {
 	})
 	testframework.MustEnsureImageRegistryIsAvailable(t, client)
 
-	var cr *imageregistryapi.Config
+	var cr *imageregistryv1.Config
 	var err error
 	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		cr, err = client.Configs().Get(imageregistryapi.ImageRegistryResourceName, metav1.GetOptions{})
+		cr, err = client.Configs().Get(imageregistryv1.ImageRegistryResourceName, metav1.GetOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -66,13 +66,13 @@ func TestUnmanaged(t *testing.T) {
 
 	// TODO(dmage): wait for the resource to be observed
 
-	err = client.Deployments(imageregistryapi.ImageRegistryOperatorNamespace).Delete(imageregistryapi.ImageRegistryName, &metav1.DeleteOptions{})
+	err = client.Deployments(imageregistryv1.ImageRegistryOperatorNamespace).Delete(imageregistryv1.ImageRegistryName, &metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	err = wait.Poll(1*time.Second, testframework.AsyncOperationTimeout, func() (stop bool, err error) {
-		cr, err = client.Configs().Get(imageregistryapi.ImageRegistryResourceName, metav1.GetOptions{})
+		cr, err = client.Configs().Get(imageregistryv1.ImageRegistryResourceName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}

--- a/test/e2e/unmanaged_test.go
+++ b/test/e2e/unmanaged_test.go
@@ -28,7 +28,7 @@ func TestUnmanaged(t *testing.T) {
 			Kind:       "Config",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: testframework.ImageRegistryResourceName,
+			Name: imageregistryapi.ImageRegistryResourceName,
 		},
 		Spec: imageregistryapi.ImageRegistrySpec{
 			ManagementState: operatorapi.Managed,
@@ -47,7 +47,7 @@ func TestUnmanaged(t *testing.T) {
 	var cr *imageregistryapi.Config
 	var err error
 	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		cr, err = client.Configs().Get(testframework.ImageRegistryResourceName, metav1.GetOptions{})
+		cr, err = client.Configs().Get(imageregistryapi.ImageRegistryResourceName, metav1.GetOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -66,13 +66,13 @@ func TestUnmanaged(t *testing.T) {
 
 	// TODO(dmage): wait for the resource to be observed
 
-	err = client.Deployments(testframework.ImageRegistryDeploymentNamespace).Delete(testframework.ImageRegistryDeploymentName, &metav1.DeleteOptions{})
+	err = client.Deployments(imageregistryapi.ImageRegistryOperatorNamespace).Delete(imageregistryapi.ImageRegistryName, &metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	err = wait.Poll(1*time.Second, testframework.AsyncOperationTimeout, func() (stop bool, err error) {
-		cr, err = client.Configs().Get(testframework.ImageRegistryResourceName, metav1.GetOptions{})
+		cr, err = client.Configs().Get(imageregistryapi.ImageRegistryResourceName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -10,6 +10,7 @@ import (
 
 	operatorapi "github.com/openshift/api/operator/v1"
 
+	imageregistryapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/testframework"
 )
 
@@ -22,7 +23,7 @@ func conditionExistsWithStatusAndReason(client *testframework.Clientset, conditi
 		conditionExists := false
 
 		// Get a fresh version of the image registry resource
-		cr, err := client.Configs().Get(testframework.ImageRegistryResourceName, metav1.GetOptions{})
+		cr, err := client.Configs().Get(imageregistryapi.ImageRegistryResourceName, metav1.GetOptions{})
 		if err != nil {
 			if errors.IsNotFound(err) {
 				return false, nil

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -10,7 +10,7 @@ import (
 
 	operatorapi "github.com/openshift/api/operator/v1"
 
-	imageregistryapi "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/testframework"
 )
 
@@ -23,7 +23,7 @@ func conditionExistsWithStatusAndReason(client *testframework.Clientset, conditi
 		conditionExists := false
 
 		// Get a fresh version of the image registry resource
-		cr, err := client.Configs().Get(imageregistryapi.ImageRegistryResourceName, metav1.GetOptions{})
+		cr, err := client.Configs().Get(imageregistryv1.ImageRegistryResourceName, metav1.GetOptions{})
 		if err != nil {
 			if errors.IsNotFound(err) {
 				return false, nil


### PR DESCRIPTION
 - Replace testframework constants with api constants
 - Set DeleteCompletely timeout back to AsyncOperationTimeout
 - Standardize the imageregistry/v1 api alias to be imageregistryv1
 - All CVO status messages should start with a capital letter