### PR TITLE
set external registry hostnames on cluster image config

### DIFF
--- a/pkg/apis/imageregistry/v1/types.go
+++ b/pkg/apis/imageregistry/v1/types.go
@@ -11,6 +11,9 @@ import (
 
 const (
 
+	// DefaultRouteName is the name of the default route created for the registry
+	// when a default route is requested from the operator
+	DefaultRouteName = "default-route"
 	// ImageRegistryName is the name of the image-registry workload resource (deployment)
 	ImageRegistryName = "image-registry"
 

--- a/pkg/operator/complete.go
+++ b/pkg/operator/complete.go
@@ -24,7 +24,7 @@ func verifyResource(cr *imageregistryv1.Config, p *parameters.Globals) error {
 	}
 
 	names := map[string]struct{}{
-		imageregistryv1.ImageRegistryName + "-default-route": {},
+		imageregistryv1.DefaultRouteName: {},
 	}
 
 	for _, routeSpec := range cr.Spec.Routes {

--- a/pkg/resource/generator.go
+++ b/pkg/resource/generator.go
@@ -46,7 +46,7 @@ func (g *Generator) listRoutes(routeClient routeset.RouteV1Interface, cr *imager
 	var mutators []Mutator
 	if cr.Spec.DefaultRoute {
 		mutators = append(mutators, newGeneratorRoute(g.listers.Routes, g.listers.Secrets, routeClient, g.params, cr, imageregistryv1.ImageRegistryConfigRoute{
-			Name: cr.Name + "-default-route",
+			Name: imageregistryv1.DefaultRouteName,
 		}))
 	}
 	for _, route := range cr.Spec.Routes {
@@ -87,7 +87,7 @@ func (g *Generator) list(cr *imageregistryv1.Config) ([]Mutator, error) {
 	mutators = append(mutators, newGeneratorServiceAccount(g.listers.ServiceAccounts, coreClient, g.params, cr))
 	mutators = append(mutators, newGeneratorCAConfig(g.listers.ConfigMaps, g.listers.OpenShiftConfig, coreClient, g.params, cr))
 	mutators = append(mutators, newGeneratorSecret(g.listers.Secrets, coreClient, g.params, cr))
-	mutators = append(mutators, newGeneratorImageConfig(g.listers.ImageConfigs, configClient, g.params, cr))
+	mutators = append(mutators, newGeneratorImageConfig(g.listers.ImageConfigs, g.listers.Routes, configClient, g.params, cr))
 	mutators = append(mutators, newGeneratorNodeCADaemonSet(g.listers.DaemonSets, appsClient, g.params, cr))
 	mutators = append(mutators, newGeneratorService(g.listers.Services, coreClient, g.params, cr))
 	mutators = append(mutators, newGeneratorDeployment(g.listers.Deployments, g.listers.ConfigMaps, g.listers.Secrets, coreClient, appsClient, g.params, cr))

--- a/pkg/testframework/clientset.go
+++ b/pkg/testframework/clientset.go
@@ -9,6 +9,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 
 	clientconfigv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	clientroutev1 "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/client"
 	clientimageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/generated/clientset/versioned/typed/imageregistry/v1"
 )
@@ -19,6 +20,7 @@ type Clientset struct {
 	clientappsv1.AppsV1Interface
 	clientconfigv1.ConfigV1Interface
 	clientimageregistryv1.ImageregistryV1Interface
+	clientroutev1.RouteV1Interface
 }
 
 // NewClientset creates a set of Kubernetes clients. The default kubeconfig is
@@ -45,6 +47,10 @@ func NewClientset(kubeconfig *restclient.Config) (clientset *Clientset, err erro
 		return
 	}
 	clientset.ImageregistryV1Interface, err = clientimageregistryv1.NewForConfig(kubeconfig)
+	if err != nil {
+		return
+	}
+	clientset.RouteV1Interface, err = clientroutev1.NewForConfig(kubeconfig)
 	if err != nil {
 		return
 	}

--- a/test/e2e/configuration_test.go
+++ b/test/e2e/configuration_test.go
@@ -3,18 +3,23 @@ package e2e_test
 import (
 	"strings"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 
-	operatorapi "github.com/openshift/api/operator/v1"
+	configapiv1 "github.com/openshift/api/config/v1"
+	operatorapiv1 "github.com/openshift/api/operator/v1"
+	routeapiv1 "github.com/openshift/api/route/v1"
 
 	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/testframework"
 )
 
-func TestConfiguration(t *testing.T) {
+func TestPodResourceConfiguration(t *testing.T) {
 	client := testframework.MustNewClientset(t, nil)
 
 	defer testframework.MustRemoveImageRegistry(t, client)
@@ -28,7 +33,7 @@ func TestConfiguration(t *testing.T) {
 			Name: imageregistryv1.ImageRegistryResourceName,
 		},
 		Spec: imageregistryv1.ImageRegistrySpec{
-			ManagementState: operatorapi.Managed,
+			ManagementState: operatorapiv1.Managed,
 			Storage: imageregistryv1.ImageRegistryConfigStorage{
 				Filesystem: &imageregistryv1.ImageRegistryConfigStorageFilesystem{
 					VolumeSource: corev1.VolumeSource{
@@ -70,5 +75,113 @@ func TestConfiguration(t *testing.T) {
 			}
 		}
 	}
+}
 
+func TestRouteConfiguration(t *testing.T) {
+	client := testframework.MustNewClientset(t, nil)
+
+	defer testframework.MustRemoveImageRegistry(t, client)
+
+	cr := &imageregistryv1.Config{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: imageregistryv1.SchemeGroupVersion.String(),
+			Kind:       "Config",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: imageregistryv1.ImageRegistryResourceName,
+		},
+		Spec: imageregistryv1.ImageRegistrySpec{
+			ManagementState: operatorapiv1.Managed,
+			Storage: imageregistryv1.ImageRegistryConfigStorage{
+				Filesystem: &imageregistryv1.ImageRegistryConfigStorageFilesystem{
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+			},
+			Replicas:     1,
+			DefaultRoute: true,
+			Routes: []imageregistryv1.ImageRegistryConfigRoute{
+				{
+					Name:     "testroute",
+					Hostname: "test.example.com",
+				},
+			},
+		},
+	}
+	testframework.MustDeployImageRegistry(t, client, cr)
+	testframework.MustEnsureImageRegistryIsAvailable(t, client)
+	testframework.MustEnsureClusterOperatorStatusIsSet(t, client)
+	ensureExternalRegistryHostnamesAreSet(t, client)
+	ensureExternalRoutesExist(t, client)
+
+}
+
+func ensureExternalRegistryHostnamesAreSet(t *testing.T, client *testframework.Clientset) {
+	var cfg *configapiv1.Image
+	var err error
+	externalHosts := []string{}
+	err = wait.Poll(1*time.Second, testframework.AsyncOperationTimeout, func() (bool, error) {
+		var err error
+		cfg, err = client.Images().Get("cluster", metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			t.Logf("waiting for the image config resource: the resource does not exist")
+			cfg = nil
+			return false, nil
+		} else if err != nil {
+			return false, err
+		}
+		if cfg == nil {
+			return false, nil
+		}
+		externalHosts = cfg.Status.ExternalRegistryHostnames
+
+		foundDefaultRoute := false
+		foundUserRoute := false
+		for _, h := range externalHosts {
+			if strings.HasPrefix(h, imageregistryv1.DefaultRouteName+"-"+imageregistryv1.ImageRegistryOperatorNamespace) {
+				foundDefaultRoute = true
+				continue
+			}
+			if h == "test.example.com" {
+				foundUserRoute = true
+				continue
+			}
+		}
+		return foundDefaultRoute && foundUserRoute, nil
+	})
+	if err != nil {
+		t.Errorf("cluster image config resource was not updated with default external registry hostname: %v, err: %v", externalHosts, err)
+	}
+}
+
+func ensureExternalRoutesExist(t *testing.T, client *testframework.Clientset) {
+	var err error
+	var routes *routeapiv1.RouteList
+	err = wait.Poll(1*time.Second, testframework.AsyncOperationTimeout, func() (bool, error) {
+		routes, err = client.Routes(imageregistryv1.ImageRegistryOperatorNamespace).List(metav1.ListOptions{})
+		if err != nil {
+			return false, err
+		}
+		if routes == nil || len(routes.Items) < 2 {
+			t.Logf("insuffient routes found: %#v", routes)
+			return false, nil
+		}
+
+		foundDefaultRoute := false
+		foundUserRoute := false
+		for _, r := range routes.Items {
+			if strings.HasPrefix(r.Spec.Host, imageregistryv1.DefaultRouteName+"-"+imageregistryv1.ImageRegistryOperatorNamespace) {
+				foundDefaultRoute = true
+				continue
+			}
+			if r.Spec.Host == "test.example.com" {
+				foundUserRoute = true
+			}
+		}
+		return foundDefaultRoute && foundUserRoute, nil
+	})
+	if err != nil {
+		t.Errorf("did not find expected routes: %#v, err: %v", routes, err)
+	}
 }


### PR DESCRIPTION
Set the external registry hostname in the cluster configuration (this drives the imagestream public docker repository value) when routes are configured for the registry.
