### PR TITLE
Remove storage medium if ManagementState set to Removed

### DIFF
--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -29,6 +29,7 @@ import (
 	regopinformers "github.com/openshift/cluster-image-registry-operator/pkg/generated/informers/externalversions"
 	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
 	"github.com/openshift/cluster-image-registry-operator/pkg/resource"
+	"github.com/openshift/cluster-image-registry-operator/pkg/util"
 )
 
 const (
@@ -168,7 +169,7 @@ func (c *Controller) sync() error {
 	c.syncStatus(cr, deploy, applyError, removed, &statusChanged)
 
 	if statusChanged {
-		glog.Infof("status changed: %s", objectInfo(cr))
+		glog.Infof("status changed: %s", util.ObjectInfo(cr))
 
 		cr.Status.ObservedGeneration = cr.Generation
 
@@ -180,7 +181,7 @@ func (c *Controller) sync() error {
 		_, err = client.ImageregistryV1().Configs().Update(cr)
 		if err != nil {
 			if !errors.IsConflict(err) {
-				glog.Errorf("unable to update %s: %s", objectInfo(cr), err)
+				glog.Errorf("unable to update %s: %s", util.ObjectInfo(cr), err)
 			}
 			return err
 		}
@@ -224,7 +225,7 @@ func (c *Controller) eventProcessor() {
 func (c *Controller) handler() cache.ResourceEventHandlerFuncs {
 	return cache.ResourceEventHandlerFuncs{
 		AddFunc: func(o interface{}) {
-			glog.V(1).Infof("add event to workqueue due to %s (add)", objectInfo(o))
+			glog.V(1).Infof("add event to workqueue due to %s (add)", util.ObjectInfo(o))
 			c.workqueue.Add(workqueueKey)
 		},
 		UpdateFunc: func(o, n interface{}) {
@@ -243,7 +244,7 @@ func (c *Controller) handler() cache.ResourceEventHandlerFuncs {
 				// Two different versions of the same resource will always have different RVs.
 				return
 			}
-			glog.V(1).Infof("add event to workqueue due to %s (update)", objectInfo(n))
+			glog.V(1).Infof("add event to workqueue due to %s (update)", util.ObjectInfo(n))
 			c.workqueue.Add(workqueueKey)
 		},
 		DeleteFunc: func(o interface{}) {
@@ -261,7 +262,7 @@ func (c *Controller) handler() cache.ResourceEventHandlerFuncs {
 				}
 				glog.V(4).Infof("recovered deleted object %q from tombstone", object.GetName())
 			}
-			glog.V(1).Infof("add event to workqueue due to %s (delete)", objectInfo(object))
+			glog.V(1).Infof("add event to workqueue due to %s (delete)", util.ObjectInfo(object))
 			c.workqueue.Add(workqueueKey)
 		},
 	}

--- a/pkg/storage/azure/azure.go
+++ b/pkg/storage/azure/azure.go
@@ -84,12 +84,12 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config, modified *bool) error
 	return nil
 }
 
-func (d *driver) RemoveStorage(cr *imageregistryv1.Config, modified *bool) error {
+func (d *driver) RemoveStorage(cr *imageregistryv1.Config, modified *bool) (bool, error) {
 	if !cr.Status.StorageManaged {
-		return nil
+		return false, nil
 	}
 
-	return nil
+	return false, nil
 }
 
 func (d *driver) Volumes() ([]corev1.Volume, []corev1.VolumeMount, error) {

--- a/pkg/storage/emptydir/emptydir.go
+++ b/pkg/storage/emptydir/emptydir.go
@@ -93,8 +93,8 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config, modified *bool) error
 	return nil
 }
 
-func (d *driver) RemoveStorage(cr *imageregistryv1.Config, modified *bool) error {
-	return nil
+func (d *driver) RemoveStorage(cr *imageregistryv1.Config, modified *bool) (bool, error) {
+	return false, nil
 }
 
 func (d *driver) CompleteConfiguration(cr *imageregistryv1.Config, modified *bool) error {

--- a/pkg/storage/filesystem/filesystem.go
+++ b/pkg/storage/filesystem/filesystem.go
@@ -77,12 +77,12 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config, modified *bool) error
 	return nil
 }
 
-func (d *driver) RemoveStorage(cr *imageregistryv1.Config, modified *bool) error {
+func (d *driver) RemoveStorage(cr *imageregistryv1.Config, modified *bool) (bool, error) {
 	if !cr.Status.StorageManaged {
-		return nil
+		return false, nil
 	}
 
-	return nil
+	return false, nil
 }
 
 func (d *driver) CompleteConfiguration(cr *imageregistryv1.Config, modified *bool) error {

--- a/pkg/storage/gcs/gcs.go
+++ b/pkg/storage/gcs/gcs.go
@@ -126,12 +126,12 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config, modified *bool) error
 	return nil
 }
 
-func (d *driver) RemoveStorage(cr *imageregistryv1.Config, modified *bool) error {
+func (d *driver) RemoveStorage(cr *imageregistryv1.Config, modified *bool) (bool, error) {
 	if !cr.Status.StorageManaged {
-		return nil
+		return false, nil
 	}
 
-	return nil
+	return false, nil
 }
 
 func (d *driver) CompleteConfiguration(cr *imageregistryv1.Config, modified *bool) error {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -29,7 +29,7 @@ type Driver interface {
 	CompleteConfiguration(*imageregistryv1.Config, *bool) error
 	CreateStorage(*imageregistryv1.Config, *bool) error
 	StorageExists(*imageregistryv1.Config, *bool) (bool, error)
-	RemoveStorage(*imageregistryv1.Config, *bool) error
+	RemoveStorage(*imageregistryv1.Config, *bool) (bool, error)
 	StorageChanged(*imageregistryv1.Config, *bool) bool
 	GetStorageName() string
 	SyncSecrets(*coreapi.Secret) (map[string]string, error)

--- a/pkg/storage/swift/swift.go
+++ b/pkg/storage/swift/swift.go
@@ -81,12 +81,12 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config, modified *bool) error
 	return nil
 }
 
-func (d *driver) RemoveStorage(cr *imageregistryv1.Config, modified *bool) error {
+func (d *driver) RemoveStorage(cr *imageregistryv1.Config, modified *bool) (bool, error) {
 	if !cr.Status.StorageManaged {
-		return nil
+		return false, nil
 	}
 
-	return nil
+	return false, nil
 }
 
 func (d *driver) Volumes() ([]corev1.Volume, []corev1.VolumeMount, error) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,4 +1,4 @@
-package operator
+package util
 
 import (
 	"fmt"
@@ -6,7 +6,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func objectInfo(o interface{}) string {
+func ObjectInfo(o interface{}) string {
 	object := o.(metav1.Object)
 	s := fmt.Sprintf("%T, ", o)
 	if namespace := object.GetNamespace(); namespace != "" {


### PR DESCRIPTION
Remove the storage medium (if we manage it):
 - When the finalizer runs
 - When the ManagementState is set to Removed

Also moved objectInfo to pkg/util/util.go (ObjectInfo) so that it can easily be used in more places.