### PR TITLE
Remove CRD for images.config.openshift.io

### DIFF
--- a/deploy/00-crd.yaml
+++ b/deploy/00-crd.yaml
@@ -12,19 +12,3 @@ spec:
     listKind: ConfigList
     plural: configs
     singular: config
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: images.config.openshift.io
-spec:
-  group: config.openshift.io
-  scope: Cluster
-  version: v1
-  names:
-    kind: Image
-    listKind: ImageList
-    plural: images
-    singular: image
-  subresources:
-    status: {}


### PR DESCRIPTION
The CRD is now managed by [cluster-config-operator](https://github.com/openshift/cluster-config-operator/blob/master/manifests/0000_05_config-operator_01_image.crd.yaml).