### PR TITLE
Refactoring bootstrap.go to only look for one custom resource

### DIFF
--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -6,110 +6,56 @@ import (
 
 	"github.com/golang/glog"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	coreset "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	operatorapi "github.com/openshift/api/operator/v1"
 
 	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
 	regopset "github.com/openshift/cluster-image-registry-operator/pkg/generated/clientset/versioned/typed/imageregistry/v1"
-	"github.com/openshift/cluster-image-registry-operator/pkg/migration"
-	"github.com/openshift/cluster-image-registry-operator/pkg/migration/dependency"
 	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage"
 )
 
-// randomSecretSize is the number of random bytes to generate if no secret
-// was specified.
+// randomSecretSize is the number of random bytes to generate
+// for the http secret
 const randomSecretSize = 64
 
-func resourceName(namespace string) string {
-	if namespace == "default" {
-		return "docker-registry"
-	}
-	return imageregistryv1.ImageRegistryResourceName
-}
-
 func (c *Controller) Bootstrap() error {
-	client, err := regopset.NewForConfig(c.kubeconfig)
-	if err != nil {
-		return err
-	}
-	crList, err := c.listers.RegistryConfigs.List(labels.Everything())
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			return fmt.Errorf("failed to list registry custom resources: %s", err)
-		}
+	cr, err := c.listers.RegistryConfigs.Get(imageregistryv1.ImageRegistryResourceName)
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("unable to get the registry custom resources: %s", err)
 	}
 
-	switch len(crList) {
-	case 0:
-		// let's create it.
-	case 1:
+	// If the registry resource already exists,
+	// no bootstrapping is required
+	if cr != nil {
 		return nil
-	default:
-		return fmt.Errorf("only one registry custom resource expected in %s namespace, got %d", c.params.Deployment.Namespace, len(crList))
 	}
 
-	var spec imageregistryv1.ImageRegistrySpec
+	// If no registry resource exists,
+	// let's create one with sane defaults
+	glog.Infof("generating registry custom resource")
 
-	dc, err := c.listers.DeploymentConfigs.Get(resourceName(c.params.Deployment.Namespace))
-	if errors.IsNotFound(err) {
-		spec = imageregistryv1.ImageRegistrySpec{
+	var secretBytes [randomSecretSize]byte
+	if _, err := rand.Read(secretBytes[:]); err != nil {
+		return fmt.Errorf("could not generate random bytes for HTTP secret: %s", err)
+	}
+
+	cr = &imageregistryv1.Config{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       imageregistryv1.ImageRegistryResourceName,
+			Namespace:  c.params.Deployment.Namespace,
+			Finalizers: []string{parameters.ImageRegistryOperatorResourceFinalizer},
+		},
+		Spec: imageregistryv1.ImageRegistrySpec{
 			ManagementState: operatorapi.Managed,
 			LogLevel:        2,
 			Storage:         imageregistryv1.ImageRegistryConfigStorage{},
 			Replicas:        1,
-		}
-	} else if err != nil {
-		return fmt.Errorf("unable to check if the deployment already exists: %s", err)
-	} else {
-		glog.Infof("adopting the existing deployment config...")
-		var tlsSecret *corev1.Secret
-		spec, tlsSecret, err = migration.NewImageRegistrySpecFromDeploymentConfig(dc, dependency.NewNamespacedResources(c.kubeconfig, dc.ObjectMeta.Namespace))
-		if err != nil {
-			return fmt.Errorf("unable to adopt the existing deployment config: %s", err)
-		}
-		if tlsSecret != nil {
-			tlsSecret.ObjectMeta = metav1.ObjectMeta{
-				Name:      dc.ObjectMeta.Name + "-tls",
-				Namespace: dc.ObjectMeta.Namespace,
-			}
-
-			coreclient, err := coreset.NewForConfig(c.kubeconfig)
-			if err != nil {
-				return err
-			}
-
-			_, err = coreclient.Secrets(dc.ObjectMeta.Namespace).Create(tlsSecret)
-			// TODO: it might already exist
-			if err != nil {
-				return fmt.Errorf("unable to create the tls secret: %s", err)
-			}
-		}
-	}
-
-	glog.Infof("generating registry custom resource")
-
-	cr := &imageregistryv1.Config{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       resourceName(c.params.Deployment.Namespace),
-			Namespace:  c.params.Deployment.Namespace,
-			Finalizers: []string{parameters.ImageRegistryOperatorResourceFinalizer},
+			HTTPSecret:      fmt.Sprintf("%x", string(secretBytes[:])),
 		},
-		Spec:   spec,
 		Status: imageregistryv1.ImageRegistryStatus{},
-	}
-
-	if len(cr.Spec.HTTPSecret) == 0 {
-		var secretBytes [randomSecretSize]byte
-		if _, err := rand.Read(secretBytes[:]); err != nil {
-			return fmt.Errorf("could not generate random bytes for HTTP secret: %s", err)
-		}
-		cr.Spec.HTTPSecret = fmt.Sprintf("%x", string(secretBytes[:]))
 	}
 
 	driver, err := storage.NewDriver(&cr.Spec.Storage, c.listers)
@@ -122,6 +68,12 @@ func (c *Controller) Bootstrap() error {
 	if driver != nil {
 		err = driver.CompleteConfiguration(cr, &modified)
 	}
+
+	client, err := regopset.NewForConfig(c.kubeconfig)
+	if err != nil {
+		return err
+	}
+
 	_, cerr := client.Configs().Create(cr)
 	if cerr != nil {
 		return cerr

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -112,7 +112,7 @@ func (c *Controller) createOrUpdateResources(cr *imageregistryv1.Config, modifie
 }
 
 func (c *Controller) sync() error {
-	cr, err := c.listers.RegistryConfigs.Get(resourceName(c.params.Deployment.Namespace))
+	cr, err := c.listers.RegistryConfigs.Get(imageregistryv1.ImageRegistryResourceName)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return c.Bootstrap()


### PR DESCRIPTION
The bootstrap process only needs to look for a single custom resource, not a list.