### PR TITLE
Add credentials request for AWS.

### DIFF
--- a/deploy/01-registry-credentials-request.yaml
+++ b/deploy/01-registry-credentials-request.yaml
@@ -1,0 +1,35 @@
+apiVersion: cloudcredential.openshift.io/v1beta1
+kind: CredentialsRequest
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: openshift-image-registry
+  namespace: openshift-cloud-credential-operator
+spec:
+  secretRef:
+    name: installer-cloud-credentials
+    namespace: openshift-image-registry
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1beta1
+    kind: AWSProviderSpec
+    statementEntries:
+    - effect: Allow
+      action:
+      - s3:CreateBucket
+      - s3:DeleteBucket
+      - s3:PutBucketTagging
+      - s3:GetBucketTagging
+      - s3:PutEncryptionConfiguration
+      - s3:GetEncryptionConfiguration
+      - s3:PutLifecycleConfiguration
+      - s3:GetLifecycleConfiguration
+      - s3:GetBucketLocation
+      - s3:ListBucket
+      - s3:HeadBucket
+      - s3:GetObject
+      - s3:PutObject
+      - s3:DeleteObject
+      - s3:ListBucketMultipartUploads
+      - s3:AbortMultipartUpload
+      resource: "*"
+---


### PR DESCRIPTION
This file is being moved from the cloud-credentials-operator repo and will be
removed there once this merged. Image registry operator team now has
control over merging changes to your AWS credentials.