### PR TITLE
confirm internal registry hostname propagation to api server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test-unit: verify
 	./hack/test-go.sh ./cmd/... ./pkg/...
 
 test-e2e:
-	GOCACHE=off ./hack/test-go.sh -timeout 20m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/
+	GOCACHE=off ./hack/test-go.sh -timeout 40m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/
 
 verify:
 	hack/verify.sh

--- a/manifests/02-config-validation-imagestream.yaml
+++ b/manifests/02-config-validation-imagestream.yaml
@@ -1,0 +1,16 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: config-validation
+  namespace: openshift-image-registry
+  metadata: 
+    annotations:
+      description: This imagestream is intentionally invalid and is used to confirm the openshift apiserver has configured the internal registry hostname correctly.
+spec:
+  tags:
+  - from:
+      kind: DockerImage
+      name: quay.io/configuration/validation:latest
+    name: latest
+    referencePolicy:
+      type: Source

--- a/pkg/apis/imageregistry/v1/types.go
+++ b/pkg/apis/imageregistry/v1/types.go
@@ -66,6 +66,10 @@ const (
 	// StorageIncompleteUploadCleanupEnabled denotes whethere or not the registry storage
 	// medium is configured to automatically cleanup incomplete uploads
 	StorageIncompleteUploadCleanupEnabled = "StorageIncompleteUploadCleanupEnabled"
+
+	// InternalRegistryHostnamePropagated indicates whether or not the openshift api server
+	// has consumed the internal registry hostname provided by this operator.
+	InternalRegistryHostnamePropagated = "InternalRegistryHostnamePropagated"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -111,7 +111,7 @@ type Controller struct {
 // change so there is no watch event generated when the status.dockerrepository value
 // changes.
 func (c *Controller) imageStreamPoll() {
-	glog.V(4).Infof("Polling for imagestream status")
+	glog.Infof("Polling for imagestream status")
 	imageClient, err := imageset.NewForConfig(c.kubeconfig)
 	if err != nil {
 		glog.Warningf("failed to create client config: %v", err)
@@ -149,7 +149,7 @@ func (c *Controller) imageStreamPoll() {
 			glog.Warningf("failed to get %q cluster image config resource: %s", c.params.ImageConfig.Name, err)
 			return
 		}
-		glog.V(4).Infof("checking: %s vs %s", validationIS.Status.DockerImageRepository, ic.Status.InternalRegistryHostname)
+		glog.Infof("checking: %s vs %s", validationIS.Status.DockerImageRepository, ic.Status.InternalRegistryHostname)
 		if validationIS.Status.DockerImageRepository != "" && strings.HasPrefix(validationIS.Status.DockerImageRepository, ic.Status.InternalRegistryHostname) {
 			successCount += 1
 			continue

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -149,6 +149,7 @@ func (c *Controller) imageStreamPoll() {
 			glog.Warningf("failed to get %q cluster image config resource: %s", c.params.ImageConfig.Name, err)
 			return
 		}
+		glog.V(4).Infof("checking: %s vs %s", validationIS.Status.DockerImageRepository, ic.Status.InternalRegistryHostname)
 		if validationIS.Status.DockerImageRepository != "" && strings.HasPrefix(validationIS.Status.DockerImageRepository, ic.Status.InternalRegistryHostname) {
 			successCount += 1
 			continue

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -80,7 +80,6 @@ func (c *Controller) syncStatus(cr *imageregistryv1.Config, deploy *appsapi.Depl
 	case !isDeploymentStatusAvailable(deploy):
 		operatorAvailableMsg = "Deployment does not have available replicas"
 	case hostnameCondition == nil || hostnameCondition.Status != operatorapi.ConditionTrue:
-		operatorAvailable = osapi.ConditionFalse
 		operatorAvailableMsg = "Internal registry hostname has not propagated to the api server"
 	default:
 		operatorAvailable = osapi.ConditionTrue

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -380,7 +380,7 @@ func TestAWSUpdateCredentials(t *testing.T) {
 	framework.MustEnsureClusterOperatorStatusIsSet(t, client)
 
 	// Create the image-registry-private-configuration-user secret using the invalid credentials
-	err = wait.PollImmediate(1*time.Second, framework.AsyncOperationTimeout, func() (stop bool, err error) {
+	err = wait.PollImmediate(5*time.Second, framework.AsyncOperationTimeout, func() (stop bool, err error) {
 		if _, err := util.CreateOrUpdateSecret(imageregistryv1.ImageRegistryPrivateConfigurationUser, imageregistryv1.ImageRegistryOperatorNamespace, fakeAWSCredsData); err != nil {
 			t.Logf("unable to create secret: %s", err)
 			return false, nil
@@ -518,7 +518,7 @@ func TestAWSChangeS3Encryption(t *testing.T) {
 	}
 
 	found := false
-	err = wait.Poll(1*time.Second, framework.AsyncOperationTimeout, func() (stop bool, err error) {
+	err = wait.Poll(5*time.Second, framework.AsyncOperationTimeout, func() (stop bool, err error) {
 		// Check that the S3 bucket has the correct encryption configuration
 		getBucketEncryptionResult, err = svc.GetBucketEncryption(&s3.GetBucketEncryptionInput{
 			Bucket: aws.String(cr.Spec.Storage.S3.Bucket),
@@ -646,7 +646,7 @@ func TestAWSFinalizerDeleteS3Bucket(t *testing.T) {
 	}
 
 	var exists bool
-	err = wait.Poll(1*time.Second, framework.AsyncOperationTimeout, func() (stop bool, err error) {
+	err = wait.Poll(5*time.Second, framework.AsyncOperationTimeout, func() (stop bool, err error) {
 		exists, err := driver.StorageExists(cr)
 		if aerr, ok := err.(awserr.Error); ok {
 			t.Errorf("%#v, %#v", aerr.Code(), aerr.Error())

--- a/test/e2e/recreate_deployment_test.go
+++ b/test/e2e/recreate_deployment_test.go
@@ -56,7 +56,7 @@ func TestRecreateDeployment(t *testing.T) {
 	}
 
 	t.Logf("waiting the operator to recreate the deployment...")
-	err := wait.Poll(1*time.Second, framework.AsyncOperationTimeout, func() (stop bool, err error) {
+	err := wait.Poll(5*time.Second, framework.AsyncOperationTimeout, func() (stop bool, err error) {
 		_, err = client.Deployments(imageregistryv1.ImageRegistryOperatorNamespace).Get(imageregistryv1.ImageRegistryName, metav1.GetOptions{})
 		if err == nil {
 			return true, nil

--- a/test/e2e/unmanaged_test.go
+++ b/test/e2e/unmanaged_test.go
@@ -71,7 +71,7 @@ func TestUnmanaged(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = wait.Poll(1*time.Second, framework.AsyncOperationTimeout, func() (stop bool, err error) {
+	err = wait.Poll(5*time.Second, framework.AsyncOperationTimeout, func() (stop bool, err error) {
 		cr, err = client.Configs().Get(imageregistryv1.ImageRegistryResourceName, metav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/test/framework/condition.go
+++ b/test/framework/condition.go
@@ -17,7 +17,7 @@ func ConditionExistsWithStatusAndReason(client *Clientset, conditionType string,
 	var errs []error
 
 	// Wait for the image registry resource to have an updated condition
-	err := wait.Poll(1*time.Second, AsyncOperationTimeout, func() (stop bool, err error) {
+	err := wait.Poll(5*time.Second, AsyncOperationTimeout, func() (stop bool, err error) {
 		errs = nil
 		conditionExists := false
 

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -59,7 +59,7 @@ func DeleteCompletely(getObject func() (metav1.Object, error), deleteObject func
 		return err
 	}
 
-	return wait.Poll(1*time.Second, AsyncOperationTimeout, func() (stop bool, err error) {
+	return wait.Poll(5*time.Second, AsyncOperationTimeout, func() (stop bool, err error) {
 		obj, err = getObject()
 		if err != nil {
 			if errors.IsNotFound(err) {

--- a/test/framework/hostname.go
+++ b/test/framework/hostname.go
@@ -18,7 +18,7 @@ func MustEnsureDefaultExternalRegistryHostnameIsSet(t *testing.T, client *Client
 	var cfg *configapiv1.Image
 	var err error
 	externalHosts := []string{}
-	err = wait.Poll(1*time.Second, AsyncOperationTimeout, func() (bool, error) {
+	err = wait.Poll(5*time.Second, AsyncOperationTimeout, func() (bool, error) {
 		var err error
 		cfg, err = client.Images().Get("cluster", metav1.GetOptions{})
 		if errors.IsNotFound(err) {
@@ -48,7 +48,7 @@ func MustEnsureDefaultExternalRegistryHostnameIsSet(t *testing.T, client *Client
 func EnsureExternalRegistryHostnamesAreSet(t *testing.T, client *Clientset, wantedHostnames []string) {
 	var cfg *configapiv1.Image
 	var err error
-	err = wait.Poll(1*time.Second, AsyncOperationTimeout, func() (bool, error) {
+	err = wait.Poll(5*time.Second, AsyncOperationTimeout, func() (bool, error) {
 		var err error
 		cfg, err = client.Images().Get("cluster", metav1.GetOptions{})
 		if errors.IsNotFound(err) {

--- a/test/framework/operator.go
+++ b/test/framework/operator.go
@@ -24,7 +24,7 @@ func startOperator(client *Clientset) error {
 func stopOperator(logger Logger, client *Clientset) error {
 	var err error
 	var realErr error
-	err = wait.Poll(1*time.Second, 30*time.Second, func() (bool, error) {
+	err = wait.Poll(5*time.Second, 30*time.Second, func() (bool, error) {
 		if _, realErr = client.Deployments(OperatorDeploymentNamespace).Patch(OperatorDeploymentName, types.MergePatchType, []byte(`{"spec": {"replicas": "0"}}`)); err != nil {
 			logger.Logf("failed to patch operator to zero replicas: %v", realErr)
 			return false, nil
@@ -35,7 +35,7 @@ func stopOperator(logger Logger, client *Clientset) error {
 		return fmt.Errorf("unable to patch operator to zero replicas: %v", err)
 	}
 
-	return wait.Poll(1*time.Second, AsyncOperationTimeout, func() (stop bool, err error) {
+	return wait.Poll(5*time.Second, AsyncOperationTimeout, func() (stop bool, err error) {
 		deploy, err := client.Deployments(OperatorDeploymentNamespace).Get(OperatorDeploymentName, metav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/test/framework/route.go
+++ b/test/framework/route.go
@@ -16,7 +16,7 @@ import (
 func MustEnsureDefaultExternalRouteExists(t *testing.T, client *Clientset) {
 	var err error
 	var routes *routeapiv1.RouteList
-	err = wait.Poll(1*time.Second, AsyncOperationTimeout, func() (bool, error) {
+	err = wait.Poll(5*time.Second, AsyncOperationTimeout, func() (bool, error) {
 		routes, err = client.Routes(imageregistryv1.ImageRegistryOperatorNamespace).List(metav1.ListOptions{})
 		if err != nil {
 			return false, err
@@ -41,7 +41,7 @@ func MustEnsureDefaultExternalRouteExists(t *testing.T, client *Clientset) {
 func EnsureExternalRoutesExist(t *testing.T, client *Clientset, wantedRoutes []string) {
 	var err error
 	var routes *routeapiv1.RouteList
-	err = wait.Poll(1*time.Second, AsyncOperationTimeout, func() (bool, error) {
+	err = wait.Poll(5*time.Second, AsyncOperationTimeout, func() (bool, error) {
 		routes, err = client.Routes(imageregistryv1.ImageRegistryOperatorNamespace).List(metav1.ListOptions{})
 		if err != nil {
 			return false, err


### PR DESCRIPTION
per discussion on aos-devel, block the registry operator from reporting available
until the internal registry hostname has been picked up by the openshift apiserver