### PR TITLE
WIP: operator: Report cluster operator version as per the new standard

### DIFF
--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -35,6 +35,8 @@ spec:
             requests:
               cpu: 10m
           env:
+            - name: RELEASE_VERSION
+              value: "0.0.1-snapshot"
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/manifests/08-clusteroperator.yaml
+++ b/manifests/08-clusteroperator.yaml
@@ -3,3 +3,7 @@ kind: ClusterOperator
 metadata:
   name: image-registry
 spec: {}
+status:
+  versions:
+    - name: operator
+      version: "0.0.1-snapshot"

--- a/test/e2e/configuration_test.go
+++ b/test/e2e/configuration_test.go
@@ -107,6 +107,7 @@ func TestRouteConfiguration(t *testing.T) {
 			},
 		},
 	}
+
 	framework.MustDeployImageRegistry(t, client, cr)
 	framework.MustEnsureImageRegistryIsAvailable(t, client)
 	framework.MustEnsureClusterOperatorStatusIsSet(t, client)


### PR DESCRIPTION
The cluster operator should report the release image version as its
operator version when it reaches level (Available=true). This operator
version covers the entire functional area for coverage. More specific
versions may be allowed later.

If no release version is set we reset versions to empty.

This is the model we will be implementing across all operators for 4.0.