### PR TITLE
resource: specify system-cluster-critical priority for registry

### DIFF
--- a/pkg/resource/podtemplatespec.go
+++ b/pkg/resource/podtemplatespec.go
@@ -238,7 +238,8 @@ func makePodTemplateSpec(coreClient coreset.CoreV1Interface, driver storage.Driv
 					Effect:   "NoSchedule",
 				},
 			},
-			NodeSelector: cr.Spec.NodeSelector,
+			NodeSelector:      cr.Spec.NodeSelector,
+			PriorityClassName: "system-cluster-critical",
 			Containers: []corev1.Container{
 				{
 					Name:  "registry",


### PR DESCRIPTION
specifies system-cluster-critical priority for operands that run on masters.
blocks passing smoke tests for ensuring control plane pods always schedule.

see: openshift/origin#22217