### PR TITLE
Re-enable TestAWSUnableToCreateBucketOnStartup

### DIFF
--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -307,7 +307,7 @@ func TestAWSDefaults(t *testing.T) {
 	}
 }
 
-func DISABLEDTestAWSUnableToCreateBucketOnStartup(t *testing.T) {
+func TestAWSUnableToCreateBucketOnStartup(t *testing.T) {
 	installConfig, err := clusterconfig.GetInstallConfig()
 	if err != nil {
 		t.Fatalf("unable to get install configuration: %v", err)


### PR DESCRIPTION
This test has passed multiple times for me locally running by itself and as part of the test suite.

Fixes #221 

