### PR TITLE
Bug 1701422: use port 443 for registry service

### DIFF
--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -66,6 +66,8 @@ func NewController(kubeconfig *restclient.Config) (*Controller, error) {
 
 	p := parameters.Globals{}
 
+	p.Service.Name = imageregistryv1.ImageRegistryName
+
 	p.Deployment.Namespace = namespace
 	p.Deployment.Labels = map[string]string{"docker-registry": "default"}
 
@@ -75,7 +77,6 @@ func NewController(kubeconfig *restclient.Config) (*Controller, error) {
 	p.Healthz.Route = "/healthz"
 	p.Healthz.TimeoutSeconds = 5
 
-	p.Service.Name = imageregistryv1.ImageRegistryName
 	p.ImageConfig.Name = "cluster"
 	p.CAConfig.Name = imageregistryv1.ImageRegistryCertificatesName
 

--- a/pkg/resource/imageconfig.go
+++ b/pkg/resource/imageconfig.go
@@ -180,6 +180,8 @@ func (gic *generatorImageConfig) getRouteHostnames() ([]string, error) {
 	return externalHostnames, nil
 }
 
+// getServiceHostname returns the host name for the internal registry service.
+// This value is propagated to the OpenShift cluster via the image.config.openshift.io/cluster object.
 func getServiceHostname(serviceLister kcorelisters.ServiceNamespaceLister, serviceName string) (string, error) {
 	svc, err := serviceLister.Get(serviceName)
 	if errors.IsNotFound(err) {
@@ -188,6 +190,6 @@ func getServiceHostname(serviceLister kcorelisters.ServiceNamespaceLister, servi
 	if svc == nil || err != nil {
 		return "", err
 	}
-	svcHostname := fmt.Sprintf("%s.%s.svc:%d", svc.Name, svc.Namespace, svc.Spec.Ports[0].Port)
+	svcHostname := fmt.Sprintf("%s.%s.svc", svc.Name, svc.Namespace)
 	return svcHostname, nil
 }

--- a/pkg/resource/service.go
+++ b/pkg/resource/service.go
@@ -24,17 +24,20 @@ type generatorService struct {
 	namespace  string
 	labels     map[string]string
 	port       int
+	targetPort int
 	secretName string
 }
 
 func newGeneratorService(lister corelisters.ServiceNamespaceLister, client coreset.CoreV1Interface, params *parameters.Globals, cr *imageregistryv1.Config) *generatorService {
 	return &generatorService{
-		lister:     lister,
-		client:     client,
-		name:       params.Service.Name,
-		namespace:  params.Deployment.Namespace,
-		labels:     params.Deployment.Labels,
-		port:       params.Container.Port,
+		lister:    lister,
+		client:    client,
+		name:      params.Service.Name,
+		namespace: params.Deployment.Namespace,
+		labels:    params.Deployment.Labels,
+		// Bug 1701422: Hard-code service to use HTTPS port
+		port:       443,
+		targetPort: params.Container.Port,
 		secretName: imageregistryv1.ImageRegistryName + "-tls",
 	}
 }
@@ -73,7 +76,7 @@ func (gs *generatorService) expected() *corev1.Service {
 					Name:       fmt.Sprintf("%d-tcp", gs.port),
 					Port:       int32(gs.port),
 					Protocol:   "TCP",
-					TargetPort: intstr.FromInt(gs.port),
+					TargetPort: intstr.FromInt(gs.targetPort),
 				},
 			},
 		},

--- a/test/framework/imageregistry.go
+++ b/test/framework/imageregistry.go
@@ -271,8 +271,17 @@ func ensureInternalRegistryHostnameIsSet(logger Logger, client *Clientset) error
 		} else if err != nil {
 			return false, err
 		}
-		if cfg == nil || cfg.Status.InternalRegistryHostname != "image-registry.openshift-image-registry.svc:5000" {
+		if cfg == nil {
 			return false, nil
+		}
+		if len(cfg.Status.InternalRegistryHostname) == 0 {
+			return false, nil
+		}
+		// Bug 1701422: drop port number since we are using HTTPS default port on service
+		if cfg.Status.InternalRegistryHostname != "image-registry.openshift-image-registry.svc" {
+			return false, fmt.Errorf("expected internal registry hostname %s; got %s",
+				"image-registry.openshift-image-registry.svc",
+				cfg.Status.InternalRegistryHostname)
 		}
 		return true, nil
 	})


### PR DESCRIPTION
Use the default HTTPS port for the internal registry service.
This lets us drop the port when referencing images on cluster.