### PR TITLE
WIP - Verify clusteroperator behavior

### DIFF
--- a/test/e2e/configuration_test.go
+++ b/test/e2e/configuration_test.go
@@ -114,7 +114,7 @@ func TestPodTolerationsConfiguration(t *testing.T) {
 	}
 	framework.MustDeployImageRegistry(t, client, cr)
 	framework.MustEnsureImageRegistryIsAvailable(t, client)
-	framework.MustEnsureClusterOperatorStatusIsSet(t, client)
+	framework.MustEnsureClusterOperatorStatusIsNormal(t, client)
 
 	deployment, err := client.Deployments(imageregistryapiv1.ImageRegistryOperatorNamespace).Get("image-registry", metav1.GetOptions{})
 	if err != nil {
@@ -159,7 +159,7 @@ func TestRouteConfiguration(t *testing.T) {
 	}
 	framework.MustDeployImageRegistry(t, client, cr)
 	framework.MustEnsureImageRegistryIsAvailable(t, client)
-	framework.MustEnsureClusterOperatorStatusIsSet(t, client)
+	framework.MustEnsureClusterOperatorStatusIsNormal(t, client)
 	framework.MustEnsureDefaultExternalRegistryHostnameIsSet(t, client)
 	framework.EnsureExternalRegistryHostnamesAreSet(t, client, []string{hostname})
 	framework.MustEnsureDefaultExternalRouteExists(t, client)
@@ -189,7 +189,7 @@ func TestVersionReporting(t *testing.T) {
 	}
 	framework.MustDeployImageRegistry(t, client, cr)
 	framework.MustEnsureImageRegistryIsAvailable(t, client)
-	framework.MustEnsureClusterOperatorStatusIsSet(t, client)
+	framework.MustEnsureClusterOperatorStatusIsNormal(t, client)
 
 	if _, err := client.Deployments(framework.OperatorDeploymentNamespace).Patch(framework.OperatorDeploymentName, types.StrategicMergePatchType, []byte(`{"spec": {"template": {"spec": {"containers": [{"name":"cluster-image-registry-operator","env":[{"name":"RELEASE_VERSION","value":"test-v2"}]}]}}}}`)); err != nil {
 		t.Fatalf("failed to patch operator to new version: %v", err)

--- a/test/e2e/emptydir_test.go
+++ b/test/e2e/emptydir_test.go
@@ -36,7 +36,7 @@ func TestBasicEmptyDir(t *testing.T) {
 	framework.MustDeployImageRegistry(t, client, cr)
 	framework.MustEnsureImageRegistryIsAvailable(t, client)
 	framework.MustEnsureInternalRegistryHostnameIsSet(t, client)
-	framework.MustEnsureClusterOperatorStatusIsSet(t, client)
+	framework.MustEnsureClusterOperatorStatusIsNormal(t, client)
 	framework.MustEnsureOperatorIsNotHotLooping(t, client)
 
 	deploy, err := client.Deployments(imageregistryv1.ImageRegistryOperatorNamespace).Get(imageregistryv1.ImageRegistryName, metav1.GetOptions{})

--- a/test/e2e/pvc_test.go
+++ b/test/e2e/pvc_test.go
@@ -152,7 +152,7 @@ func createPVC(t *testing.T, name string) error {
 func checkTestResult(t *testing.T, client *framework.Clientset) {
 	framework.MustEnsureImageRegistryIsAvailable(t, client)
 	framework.MustEnsureInternalRegistryHostnameIsSet(t, client)
-	framework.MustEnsureClusterOperatorStatusIsSet(t, client)
+	framework.MustEnsureClusterOperatorStatusIsNormal(t, client)
 	framework.MustEnsureOperatorIsNotHotLooping(t, client)
 
 	deploy, err := client.Deployments(imageregistryv1.ImageRegistryOperatorNamespace).Get(imageregistryv1.ImageRegistryName, metav1.GetOptions{})

--- a/test/e2e/readonly_test.go
+++ b/test/e2e/readonly_test.go
@@ -36,7 +36,7 @@ func TestReadOnly(t *testing.T) {
 	framework.MustDeployImageRegistry(t, client, cr)
 	framework.MustEnsureImageRegistryIsAvailable(t, client)
 	framework.MustEnsureInternalRegistryHostnameIsSet(t, client)
-	framework.MustEnsureClusterOperatorStatusIsSet(t, client)
+	framework.MustEnsureClusterOperatorStatusIsNormal(t, client)
 	framework.MustEnsureOperatorIsNotHotLooping(t, client)
 
 	deploy, err := client.Deployments(imageregistryv1.ImageRegistryOperatorNamespace).Get(imageregistryv1.ImageRegistryName, metav1.GetOptions{})


### PR DESCRIPTION
@dmage This is to merely verify https://bugzilla.redhat.com/show_bug.cgi?id=1704590. If the registry operator is running, it should always create a `ClusterOperator` object and report its status.

Feel free to fork my branch and update the operator to make the tests green.