### PR TITLE
OpenStack: generate different container names

### DIFF
--- a/cmd/cluster-image-registry-operator/main.go
+++ b/cmd/cluster-image-registry-operator/main.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"flag"
+	"math/rand"
 	"runtime"
+	"time"
 
 	"github.com/golang/glog"
 
@@ -25,6 +27,8 @@ func main() {
 	flag.Lookup("logtostderr").Value.Set("true")
 
 	printVersion()
+
+	rand.Seed(time.Now().UnixNano())
 
 	cfg, err := regopclient.GetConfig()
 	if err != nil {

--- a/pkg/storage/swift/swift.go
+++ b/pkg/storage/swift/swift.go
@@ -179,6 +179,14 @@ func (d *driver) StorageChanged(cr *imageregistryv1.Config) bool {
 	return false
 }
 
+func generateContainerName(prefix string) string {
+	bytes := make([]byte, 16)
+	for i := 0; i < 16; i++ {
+		bytes[i] = byte(65 + rand.Intn(25)) // A=65 and Z=65+25
+	}
+	return prefix + string(bytes)
+}
+
 func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 	client, err := d.getSwiftClient(cr)
 	if err != nil {
@@ -190,11 +198,7 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 	// The name has a prefix "image_registry_", which is complemented by 16 capital latin letters
 	// Example of a generated name: image_registry_FHEIBGDDGBLWPXFR
 	if cr.Spec.Storage.Swift.Container == "" {
-		bytes := make([]byte, 16)
-		for i := 0; i < 16; i++ {
-			bytes[i] = byte(65 + rand.Intn(25)) // A=65 and Z=65+25
-		}
-		cr.Spec.Storage.Swift.Container = "image_registry_" + string(bytes)
+		cr.Spec.Storage.Swift.Container = generateContainerName("image_registry_")
 	}
 
 	_, err = containers.Create(client, cr.Spec.Storage.Swift.Container, containers.CreateOpts{}).Extract()

--- a/pkg/storage/swift/swift_test.go
+++ b/pkg/storage/swift/swift_test.go
@@ -593,3 +593,10 @@ func TestSwiftEndpointTypeObjectStore(t *testing.T) {
 	th.AssertEquals(t, operatorapi.ConditionTrue, installConfig.Status.Conditions[0].Status)
 	th.AssertEquals(t, container, installConfig.Status.Storage.Swift.Container)
 }
+
+func TestSwiftGenerateContainerName(t *testing.T) {
+	name1 := generateContainerName("image_registry_")
+	name2 := generateContainerName("image_registry_")
+
+	th.AssertEquals(t, false, name1 == name2)
+}


### PR DESCRIPTION
This patch prevents the same container name from being generated.