### PR TITLE
OpenStack: allow to explicitly specify keystone auth version

### DIFF
--- a/manifests/00-crd.yaml
+++ b/manifests/00-crd.yaml
@@ -211,6 +211,8 @@ spec:
                   properties:
                     authURL:
                       type: string
+                    authVersion:
+                      type: string
                     container:
                       type: string
                     domain:
@@ -367,6 +369,8 @@ spec:
                     to change without notice.
                   properties:
                     authURL:
+                      type: string
+                    authVersion:
                       type: string
                     container:
                       type: string

--- a/pkg/apis/imageregistry/v1/types.go
+++ b/pkg/apis/imageregistry/v1/types.go
@@ -200,13 +200,14 @@ type ImageRegistryConfigStorageGCS struct {
 // the registry to use the OpenStack Swift service for backend storage
 // https://docs.docker.com/registry/storage-drivers/swift/
 type ImageRegistryConfigStorageSwift struct {
-	AuthURL    string `json:"authURL"`
-	Container  string `json:"container"`
-	Domain     string `json:"domain"`
-	DomainID   string `json:"domainID"`
-	Tenant     string `json:"tenant"`
-	TenantID   string `json:"tenantID"`
-	RegionName string `json:"regionName"`
+	AuthURL     string `json:"authURL"`
+	AuthVersion string `json:"authVersion"`
+	Container   string `json:"container"`
+	Domain      string `json:"domain"`
+	DomainID    string `json:"domainID"`
+	Tenant      string `json:"tenant"`
+	TenantID    string `json:"tenantID"`
+	RegionName  string `json:"regionName"`
 }
 
 type ImageRegistryConfigStoragePVC struct {

--- a/pkg/clusterconfig/clusterconfig.go
+++ b/pkg/clusterconfig/clusterconfig.go
@@ -45,14 +45,15 @@ type S3 struct {
 }
 
 type Swift struct {
-	AuthURL    string
-	Username   string
-	Password   string
-	Tenant     string
-	TenantID   string
-	Domain     string
-	DomainID   string
-	RegionName string
+	AuthURL            string
+	Username           string
+	Password           string
+	Tenant             string
+	TenantID           string
+	Domain             string
+	DomainID           string
+	RegionName         string
+	IdentityAPIVersion string
 }
 
 type Storage struct {
@@ -205,6 +206,7 @@ func GetSwiftConfig(listers *regopclient.Listers) (*Config, error) {
 					cfg.Storage.Swift.DomainID = cloud.AuthInfo.UserDomainID
 				}
 				cfg.Storage.Swift.RegionName = cloud.RegionName
+				cfg.Storage.Swift.IdentityAPIVersion = cloud.IdentityAPIVersion
 			} else {
 				return nil, fmt.Errorf("clouds.yaml does not contain required cloud \"openstack\"")
 			}

--- a/pkg/storage/swift/swift_test.go
+++ b/pkg/storage/swift/swift_test.go
@@ -547,6 +547,87 @@ func TestSwiftConfigEnvCloudConfig(t *testing.T) {
 	th.AssertEquals(t, true, res[7].ValueFrom != nil)
 	th.AssertEquals(t, "REGISTRY_STORAGE_SWIFT_PASSWORD", res[8].Name)
 	th.AssertEquals(t, true, res[8].ValueFrom != nil)
+	th.AssertEquals(t, "REGISTRY_STORAGE_SWIFT_REGION", res[9].Name)
+	th.AssertEquals(t, "RegionOne", res[9].Value)
+	th.AssertEquals(t, "REGISTRY_STORAGE_SWIFT_AUTHVERSION", res[10].Name)
+	th.AssertEquals(t, "3", res[10].Value)
+}
+
+func TestSwiftEnsureAuthURLHasAPIVersion(t *testing.T) {
+	config := imageregistryv1.ImageRegistryConfigStorageSwift{
+		AuthURL:     "http://v1v2v3.com:5000/v3",
+		AuthVersion: "3",
+	}
+	d := driver{
+		Config: &config,
+	}
+	err := d.ensureAuthURLHasAPIVersion()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "http://v1v2v3.com:5000/v3", d.Config.AuthURL)
+
+	config = imageregistryv1.ImageRegistryConfigStorageSwift{
+		AuthURL:     "http://v1v2v3.com:5000/",
+		AuthVersion: "3",
+	}
+	d = driver{
+		Config: &config,
+	}
+	err = d.ensureAuthURLHasAPIVersion()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "http://v1v2v3.com:5000/v3", d.Config.AuthURL)
+
+	config = imageregistryv1.ImageRegistryConfigStorageSwift{
+		AuthURL:     "http://v1v2v3.com:5000/v3/",
+		AuthVersion: "3",
+	}
+	d = driver{
+		Config: &config,
+	}
+	err = d.ensureAuthURLHasAPIVersion()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "http://v1v2v3.com:5000/v3/", d.Config.AuthURL)
+
+	config = imageregistryv1.ImageRegistryConfigStorageSwift{
+		AuthURL:     "http://v1v2v3.com:5000",
+		AuthVersion: "2",
+	}
+	d = driver{
+		Config: &config,
+	}
+	err = d.ensureAuthURLHasAPIVersion()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "http://v1v2v3.com:5000/v2", d.Config.AuthURL)
+
+	config = imageregistryv1.ImageRegistryConfigStorageSwift{
+		AuthURL:     "http://v1v2v3.com:5000/v2.0",
+		AuthVersion: "3",
+	}
+	d = driver{
+		Config: &config,
+	}
+	err = d.ensureAuthURLHasAPIVersion()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "http://v1v2v3.com:5000/v2.0", d.Config.AuthURL)
+
+	config = imageregistryv1.ImageRegistryConfigStorageSwift{
+		AuthURL:     "INVALID_URL",
+		AuthVersion: "3",
+	}
+	d = driver{
+		Config: &config,
+	}
+	err = d.ensureAuthURLHasAPIVersion()
+	th.AssertEquals(t, true, err != nil)
+
+	config = imageregistryv1.ImageRegistryConfigStorageSwift{
+		AuthURL:     "http://v1v2v3.com:5000/abracadabra",
+		AuthVersion: "3",
+	}
+	d = driver{
+		Config: &config,
+	}
+	err = d.ensureAuthURLHasAPIVersion()
+	th.AssertEquals(t, true, err != nil)
 }
 
 func TestSwiftEndpointTypeObjectStore(t *testing.T) {


### PR DESCRIPTION
Docker registry uses ncw/swift library to interact with Swift, which determines Auth Version from the Auth URL:
https://github.com/ncw/swift/blob/24e3012fc8a71f004a6455bce2088031d50bf2b6/auth.go#L56-L65.

But since Keystone supports autodetection, often this parameter is not present in the URL, and because of this the code above fails with 500.

This patch allows to specify auth version in the config, and defaults it to 3, which is the only supported version.

It is also important from the viewpoint of stability because that code in ncw/swift simply checks for the presence of a substring in the Auth URL. It means that with AuthURL https://zxcv1.com/ v1 authentication will be used, which is wrong.