### PR TITLE
Block public access to S3 bucket and its objects by default

### DIFF
--- a/manifests/01-registry-credentials-request.yaml
+++ b/manifests/01-registry-credentials-request.yaml
@@ -19,6 +19,8 @@ spec:
       - s3:DeleteBucket
       - s3:PutBucketTagging
       - s3:GetBucketTagging
+      - s3:PutBucketPublicAccessBlock
+      - s3:GetBucketPublicAccessBlock
       - s3:PutEncryptionConfiguration
       - s3:GetEncryptionConfiguration
       - s3:PutLifecycleConfiguration

--- a/pkg/apis/imageregistry/v1/types.go
+++ b/pkg/apis/imageregistry/v1/types.go
@@ -59,7 +59,11 @@ const (
 	// that we created has encryption enabled
 	StorageEncrypted = "StorageEncrypted"
 
-	// StorageIncompleteUploadCleanupEnabled denotes whethere or not the registry storage
+	// StoragePublicAccessBlocked denotes whether or not the registry storage medium
+	// that we created has had public access to itself and its objects blocked
+	StoragePublicAccessBlocked = "StoragePublicAccessBlocked"
+
+	// StorageIncompleteUploadCleanupEnabled denotes whether or not the registry storage
 	// medium is configured to automatically cleanup incomplete uploads
 	StorageIncompleteUploadCleanupEnabled = "StorageIncompleteUploadCleanupEnabled"
 


### PR DESCRIPTION
Blocks public access to the S3 bucket that we create and the objects that it contains along with tests to verify
https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html