### PR TITLE
Bug 1701422: Use port 443 for registry service

### DIFF
--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -76,6 +76,7 @@ func NewController(kubeconfig *restclient.Config) (*Controller, error) {
 	p.Healthz.TimeoutSeconds = 5
 
 	p.Service.Name = imageregistryv1.ImageRegistryName
+	p.Service.Ports = []int{443, 5000}
 	p.ImageConfig.Name = "cluster"
 	p.CAConfig.Name = imageregistryv1.ImageRegistryCertificatesName
 	p.ServiceCA.Name = "serviceca"

--- a/pkg/parameters/parameters.go
+++ b/pkg/parameters/parameters.go
@@ -25,7 +25,8 @@ type Globals struct {
 		TimeoutSeconds int
 	}
 	Service struct {
-		Name string
+		Name  string
+		Ports []int
 	}
 	ImageConfig struct {
 		Name string

--- a/pkg/resource/imageconfig.go
+++ b/pkg/resource/imageconfig.go
@@ -198,13 +198,15 @@ func getServiceHostnames(serviceLister kcorelisters.ServiceNamespaceLister, serv
 	if err != nil {
 		return nil, err
 	}
-
-	port := ""
-	if svc.Spec.Ports[0].Port != 443 {
-		port = fmt.Sprintf(":%d", svc.Spec.Ports[0].Port)
+	hostnames := []string{}
+	for _, svcPort := range svc.Spec.Ports {
+		port := ""
+		if svcPort.Port != 443 {
+			port = fmt.Sprintf(":%d", svcPort.Port)
+		}
+		hostnames = append(hostnames,
+			fmt.Sprintf("%s.%s.svc%s", svc.Name, svc.Namespace, port),
+			fmt.Sprintf("%s.%s.svc.cluster.local%s", svc.Name, svc.Namespace, port))
 	}
-	return []string{
-		fmt.Sprintf("%s.%s.svc%s", svc.Name, svc.Namespace, port),
-		fmt.Sprintf("%s.%s.svc.cluster.local%s", svc.Name, svc.Namespace, port),
-	}, nil
+	return hostnames, nil
 }

--- a/pkg/resource/imageconfig_test.go
+++ b/pkg/resource/imageconfig_test.go
@@ -1,0 +1,56 @@
+package resource
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestGetServiceHostnames(t *testing.T) {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "image-registry-service",
+			Namespace: "image-registry",
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Port:       443,
+					TargetPort: intstr.FromInt(5000),
+				},
+				{
+					Port:       5000,
+					TargetPort: intstr.FromInt(5000),
+				},
+			},
+		},
+	}
+	expectedHosts := []string{}
+	for _, svcPort := range svc.Spec.Ports {
+		expectedPort := ""
+		if svcPort.Port != 443 {
+			expectedPort = fmt.Sprintf(":%d", svcPort.Port)
+		}
+		expectedHosts = append(expectedHosts, fmt.Sprintf("%s.%s.svc%s", svc.Name, svc.Namespace, expectedPort),
+			fmt.Sprintf("%s.%s.svc.cluster.local%s", svc.Name, svc.Namespace, expectedPort))
+	}
+
+	fakeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	fakeIndexer.Add(svc)
+	fakeLister := corelisters.NewServiceLister(fakeIndexer)
+	hostnames, err := getServiceHostnames(fakeLister.Services("image-registry"), "image-registry-service")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(expectedHosts, hostnames) {
+		t.Errorf("expected hostnames %v, got %v", expectedHosts, hostnames)
+	}
+
+}

--- a/pkg/resource/service_test.go
+++ b/pkg/resource/service_test.go
@@ -1,0 +1,58 @@
+package resource
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"k8s.io/client-go/kubernetes/fake"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
+)
+
+func TestExpectedService(t *testing.T) {
+	params := parameters.Globals{}
+
+	params.Deployment.Namespace = "image-registry"
+	params.Deployment.Labels = map[string]string{"docker-registry": "default"}
+
+	params.Container.Port = 5000
+
+	params.Service.Name = imageregistryv1.ImageRegistryName
+	params.Service.Ports = []int{443, 5000}
+
+	fakeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	fakeLister := corelisters.NewServiceLister(fakeIndexer)
+	fakeClient := fake.NewSimpleClientset()
+
+	generator := newGeneratorService(fakeLister.Services("image-registry"), fakeClient.CoreV1(), &params, nil)
+	svcGenerated := generator.expected()
+	if svcGenerated.Name != generator.GetName() {
+		t.Errorf("expected service name to be %s, got %s", generator.GetName(), svcGenerated.Name)
+	}
+	if svcGenerated.Namespace != generator.GetNamespace() {
+		t.Errorf("expected service namespace to be %s, got %s", generator.GetName(), svcGenerated.Name)
+	}
+	if !reflect.DeepEqual(svcGenerated.Labels, params.Deployment.Labels) {
+		t.Errorf("expected service to have labels %v, got %v", params.Deployment.Labels, svcGenerated.Labels)
+	}
+	if !reflect.DeepEqual(svcGenerated.Spec.Selector, params.Deployment.Labels) {
+		t.Errorf("expected service selector to be %v, got %v", params.Deployment.Labels, svcGenerated.Spec.Selector)
+	}
+	for i, svcPort := range params.Service.Ports {
+		actualSvcPort := svcGenerated.Spec.Ports[i]
+		if actualSvcPort.TargetPort != intstr.FromInt(params.Container.Port) {
+			t.Errorf("expected port %s target port to be %d, got %s", actualSvcPort.Name, params.Container.Port, actualSvcPort.TargetPort.StrVal)
+		}
+		if actualSvcPort.Port != int32(svcPort) {
+			t.Errorf("expected port %s to be %d, got %d", actualSvcPort.Name, svcPort, actualSvcPort.Port)
+		}
+		if actualSvcPort.Protocol != "TCP" {
+			t.Errorf("expected port %s to use protocol %s, got %s", actualSvcPort.Name, "TCP", actualSvcPort.Protocol)
+		}
+	}
+}

--- a/test/framework/imageregistry.go
+++ b/test/framework/imageregistry.go
@@ -271,7 +271,7 @@ func ensureInternalRegistryHostnameIsSet(logger Logger, client *Clientset) error
 		} else if err != nil {
 			return false, err
 		}
-		if cfg == nil || cfg.Status.InternalRegistryHostname != "image-registry.openshift-image-registry.svc:5000" {
+		if cfg == nil || cfg.Status.InternalRegistryHostname != "image-registry.openshift-image-registry.svc" {
 			return false, nil
 		}
 		return true, nil


### PR DESCRIPTION
* Adds port 443 as the primary serving port on the registry service
* Maintain port 5000 for backwards-compatibility
* Drops port number on internal registry hostname