### PR TITLE
DEVEXP-403: Mount cluster trusted CA to image registry operator

### DIFF
--- a/manifests/04-ca-trusted.yaml
+++ b/manifests/04-ca-trusted.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    release.openshift.io/create-only: "true"
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: trusted-ca
+  namespace: openshift-image-registry

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -56,6 +56,9 @@ spec:
               value: "cluster-image-registry-operator"
             - name: IMAGE
               value: docker.io/openshift/origin-docker-registry:latest
+          volumeMounts:
+            - name: trusted-ca
+              mountPath: /etc/pki/ca-trust/extracted/pem/
         - name: cluster-image-registry-operator-watch
           image: docker.io/openshift/origin-cluster-image-registry-operator:latest
           command:
@@ -81,3 +84,14 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.namespace
+          volumeMounts:
+            - name: trusted-ca
+              mountPath: /etc/pki/ca-trust/extracted/pem/
+      volumes:
+        - name: trusted-ca
+          configMap:
+            name: trusted-ca
+            optional: true
+            items:
+            - key: ca-bundle.crt
+              path: tls-ca-bundle.pem


### PR DESCRIPTION
Injects the cluster proxy CA into `/etc/pki/ca-trust/source/ca-bundle.crt`