### PR TITLE
Bug 1734564: Remove Service CA ConfigMap from CVO management

### DIFF
--- a/manifests/04-ca-config.yaml
+++ b/manifests/04-ca-config.yaml
@@ -1,8 +1,0 @@
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  annotations:
-    service.alpha.openshift.io/inject-cabundle: "true"
-  name: serviceca
-  namespace: openshift-image-registry

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -57,12 +57,15 @@ func TestAWSDefaults(t *testing.T) {
 
 	client := framework.MustNewClientset(t, nil)
 
+	// TODO: Move these checks to a conformance test run on all providers
 	defer framework.MustRemoveImageRegistry(t, client)
 	framework.MustDeployImageRegistry(t, client, nil)
 	framework.MustEnsureImageRegistryIsAvailable(t, client)
 	framework.MustEnsureInternalRegistryHostnameIsSet(t, client)
 	framework.MustEnsureClusterOperatorStatusIsNormal(t, client)
 	framework.MustEnsureOperatorIsNotHotLooping(t, client)
+	framework.MustEnsureServiceCAConfigMap(t, client)
+	framework.MustEnsureNodeCADaemonSetIsAvailable(t, client)
 
 	cfg, err := storages3.GetConfig(kcfg, mockLister)
 	if err != nil {

--- a/test/framework/configmap.go
+++ b/test/framework/configmap.go
@@ -1,0 +1,51 @@
+package framework
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+)
+
+func MustEnsureServiceCAConfigMap(t *testing.T, client *Clientset) {
+	expectedAnnotations := map[string]string{
+		"service.beta.openshift.io/inject-cabundle": "true",
+	}
+	err := ensureConfigMap("serviceca", expectedAnnotations, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func ensureConfigMap(name string, annotations map[string]string, client *Clientset) error {
+	var configMap *corev1.ConfigMap
+	err := wait.Poll(1*time.Second, AsyncOperationTimeout, func() (stop bool, err error) {
+		configMap, err = client.ConfigMaps(imageregistryv1.ImageRegistryOperatorNamespace).Get(name, metav1.GetOptions{})
+		if err == nil {
+			return true, nil
+		}
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	})
+	if err != nil {
+		return err
+	}
+	for k, expected := range annotations {
+		actual, ok := configMap.Annotations[k]
+		if !ok {
+			return fmt.Errorf("expected annotation %s was not found on ConfigMap %s/%s", k, imageregistryv1.ImageRegistryOperatorNamespace, name)
+		}
+		if expected != actual {
+			return fmt.Errorf("expected annotation %s on ConfigMap %s/%s to have value %s, got %s", k, imageregistryv1.ImageRegistryOperatorNamespace, name, expected, actual)
+		}
+	}
+	return nil
+}

--- a/test/framework/daemonset.go
+++ b/test/framework/daemonset.go
@@ -1,0 +1,47 @@
+package framework
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+)
+
+func MustEnsureNodeCADaemonSetIsAvailable(t *testing.T, client *Clientset) {
+	err := ensureNodeCADaemonSetIsAvailable(client)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func ensureNodeCADaemonSetIsAvailable(client *Clientset) error {
+	_, err := WaitForNodeCADaemonSet(client)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func WaitForNodeCADaemonSet(client *Clientset) (*appsv1.DaemonSet, error) {
+	var ds *appsv1.DaemonSet
+	err := wait.Poll(1*time.Second, AsyncOperationTimeout, func() (stop bool, err error) {
+		ds, err = client.DaemonSets(imageregistryv1.ImageRegistryOperatorNamespace).Get("node-ca", metav1.GetOptions{})
+		if err == nil {
+			if ds.Status.NumberAvailable > 0 {
+				return true, nil
+			}
+			return false, nil
+		}
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	})
+	return ds, err
+}


### PR DESCRIPTION
The serviceca ConfigMap is used by operand components.
CVO should not be responsible for creating it or managing its content.