### PR TITLE
Do not hardcode GOOS/GOARCH

### DIFF
--- a/hack/build/build.sh
+++ b/hack/build/build.sh
@@ -17,4 +17,4 @@ BUILD_PATH="${REPO_PATH}/cmd/${PROJECT_NAME}"
 VERSION="$(git describe --tags --always --dirty)"
 GO_LDFLAGS="-X ${REPO_PATH}/version.Version=${VERSION}"
 echo "building ${PROJECT_NAME}..."
-GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o ${BIN_DIR}/${PROJECT_NAME} -ldflags "${GO_LDFLAGS}" ${BUILD_PATH}
+CGO_ENABLED=0 go build -o ${BIN_DIR}/${PROJECT_NAME} -ldflags "${GO_LDFLAGS}" ${BUILD_PATH}


### PR DESCRIPTION
This change is necessary to allow building on other architectures.