### PR TITLE
OpenStack: set container metadata

### DIFF
--- a/pkg/storage/swift/swift_test.go
+++ b/pkg/storage/swift/swift_test.go
@@ -158,7 +158,8 @@ func fakeInfrastructureLister(cloudName string) configlisters.InfrastructureList
 			Name: "cluster",
 		},
 		Status: configv1.InfrastructureStatus{
-			Platform: configv1.OpenStackPlatformType,
+			InfrastructureName: "user-j45xj",
+			Platform:           configv1.OpenStackPlatformType,
 			PlatformStatus: &configv1.PlatformStatus{
 				Type: configv1.OpenStackPlatformType,
 				OpenStack: &configv1.OpenStackPlatformStatus{


### PR DESCRIPTION
This commit adds metadata to the generated Swift image registry container to allow Terraform to delete it at the time the cluster is destroyed.

Also it changes the format of container naming in Swift:
<clusterID>-image-registry-<8_random_letters>, which is common for all resources created by Terraform.

Fixes: #317 