### PR TITLE
WIP - Mount trusted CA to the registry operand

### DIFF
--- a/manifests/04-ca-proxy.yaml
+++ b/manifests/04-ca-proxy.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   annotations:
-    config.openshift.io/inject-proxy-cabundle: "true"
+    config.openshift.io/inject-trusted-cabundle: "true"
     release.openshift.io/create-only: "true"
-  name: proxyca
+  name: trusted-ca
   namespace: openshift-image-registry

--- a/manifests/04-ca-proxy.yaml
+++ b/manifests/04-ca-proxy.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    config.openshift.io/inject-proxy-cabundle: "true"
+    release.openshift.io/create-only: "true"
+  name: proxyca
+  namespace: openshift-image-registry

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -55,7 +55,7 @@ spec:
               value: docker.io/openshift/origin-docker-registry:latest
           volumeMounts:
             - name: proxyca
-              mountPath: /etc/pki/ca-trust/source/
+              mountPath: /etc/pki/ca-trust/extracted/pem/
       volumes:
         - name: proxyca
           configMap:

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -53,3 +53,10 @@ spec:
               value: "cluster-image-registry-operator"
             - name: IMAGE
               value: docker.io/openshift/origin-docker-registry:latest
+          volumeMounts:
+            - name: proxyca
+              mountPath: /etc/pki/ca-trust/source/
+      volumes:
+        - name: proxyca
+          configMap:
+            name: proxyca

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -53,10 +53,10 @@ spec:
               value: "cluster-image-registry-operator"
             - name: IMAGE
               value: docker.io/openshift/origin-docker-registry:latest
-          volumeMounts:
-            - name: proxyca
-              mountPath: /etc/pki/ca-trust/extracted/pem/
-      volumes:
-        - name: proxyca
-          configMap:
-            name: proxyca
+          # volumeMounts:
+          #   - name: trusted-ca
+          #     mountPath: /etc/pki/ca-trust/extracted/pem/
+      # volumes:
+      #   - name: trusted-ca
+      #     configMap:
+      #       name: trusted-ca

--- a/pkg/client/fake/fixtures.go
+++ b/pkg/client/fake/fixtures.go
@@ -1,0 +1,224 @@
+package fake
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kfake "k8s.io/client-go/kubernetes/fake"
+	appsv1listers "k8s.io/client-go/listers/apps/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	rbacv1listers "k8s.io/client-go/listers/rbac/v1"
+	"k8s.io/client-go/tools/cache"
+
+	configv1 "github.com/openshift/api/config/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
+	routev1listers "github.com/openshift/client-go/route/listers/route/v1"
+
+	regopv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	"github.com/openshift/cluster-image-registry-operator/pkg/client"
+	regopv1listers "github.com/openshift/cluster-image-registry-operator/pkg/generated/listers/imageregistry/v1"
+)
+
+// FixturesBuilder helps create an in-memory version of client.Listers.
+type FixturesBuilder struct {
+	deploymentIndexer          cache.Indexer
+	dsIndexer                  cache.Indexer
+	servicesIndexer            cache.Indexer
+	secretsIndexer             cache.Indexer
+	configMapsIndexer          cache.Indexer
+	serviceAcctIndexer         cache.Indexer
+	routesIndexer              cache.Indexer
+	clusterRolesIndexer        cache.Indexer
+	clusterRoleBindingsIndexer cache.Indexer
+	imageConfigsIndexer        cache.Indexer
+	clusterOperatorsIndexer    cache.Indexer
+	registryConfigsIndexer     cache.Indexer
+	proxyConfigsIndexer        cache.Indexer
+	infraIndexer               cache.Indexer
+
+	kClientSet []runtime.Object
+}
+
+// Fixtures holds fixtures for unit testing, in forms that are easily consumed by k8s
+// and OpenShift interfaces.
+type Fixtures struct {
+	Listers    *client.Listers
+	KubeClient *kfake.Clientset
+}
+
+// NewFixturesBuilder initializes a new instance of FakeListersFactory
+func NewFixturesBuilder() *FixturesBuilder {
+	factory := &FixturesBuilder{
+		deploymentIndexer:          cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}),
+		dsIndexer:                  cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}),
+		servicesIndexer:            cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}),
+		secretsIndexer:             cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}),
+		configMapsIndexer:          cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}),
+		serviceAcctIndexer:         cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}),
+		routesIndexer:              cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}),
+		clusterRolesIndexer:        cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}),
+		clusterRoleBindingsIndexer: cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}),
+		imageConfigsIndexer:        cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}),
+		clusterOperatorsIndexer:    cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}),
+		registryConfigsIndexer:     cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}),
+		proxyConfigsIndexer:        cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}),
+		infraIndexer:               cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}),
+		kClientSet:                 []runtime.Object{},
+	}
+	return factory
+}
+
+// AddDaemonSets adds appsv1.DaemonSets to the lister cache
+func (f *FixturesBuilder) AddDaemonSets(objs ...*appsv1.DaemonSet) *FixturesBuilder {
+	for _, v := range objs {
+		f.dsIndexer.Add(v)
+		f.kClientSet = append(f.kClientSet, v)
+	}
+	return f
+}
+
+// AddDeployments adds appsv1.Deployments to the lister cache
+func (f *FixturesBuilder) AddDeployments(objs ...*appsv1.Deployment) *FixturesBuilder {
+	for _, v := range objs {
+		f.deploymentIndexer.Add(v)
+		f.kClientSet = append(f.kClientSet, v)
+	}
+	return f
+}
+
+// AddNamespaces adds corev1.Namespaces to the fixture
+func (f *FixturesBuilder) AddNamespaces(objs ...*corev1.Namespace) *FixturesBuilder {
+	for _, v := range objs {
+		f.kClientSet = append(f.kClientSet, v)
+	}
+	return f
+}
+
+// AddServices adds corev1.Services to the lister cache
+func (f *FixturesBuilder) AddServices(objs ...*corev1.Service) *FixturesBuilder {
+	for _, v := range objs {
+		f.servicesIndexer.Add(v)
+		f.kClientSet = append(f.kClientSet, v)
+	}
+	return f
+}
+
+// AddSecrets adds corev1.Secrets to the lister cache
+func (f *FixturesBuilder) AddSecrets(objs ...*corev1.Secret) *FixturesBuilder {
+	for _, v := range objs {
+		f.secretsIndexer.Add(v)
+		f.kClientSet = append(f.kClientSet, v)
+	}
+	return f
+}
+
+// AddConfigMaps adds corev1.ConfigMaps to the lister cache
+func (f *FixturesBuilder) AddConfigMaps(objs ...*corev1.ConfigMap) *FixturesBuilder {
+	for _, v := range objs {
+		f.configMapsIndexer.Add(v)
+		f.kClientSet = append(f.kClientSet, v)
+	}
+	return f
+}
+
+// AddServiceAccounts adds corev1.ServiceAccounts to the lister cache
+func (f *FixturesBuilder) AddServiceAccounts(objs ...*corev1.ServiceAccount) *FixturesBuilder {
+	for _, v := range objs {
+		f.serviceAcctIndexer.Add(v)
+		f.kClientSet = append(f.kClientSet, v)
+	}
+	return f
+}
+
+// AddRoutes adds route.openshift.io/v1 Routes to the lister cahce
+func (f *FixturesBuilder) AddRoutes(objs ...*routev1.Route) *FixturesBuilder {
+	for _, v := range objs {
+		f.routesIndexer.Add(v)
+		f.kClientSet = append(f.kClientSet, v)
+	}
+	return f
+}
+
+// AddClusterRoles adds rbacv1.ClusterRoles to the lister cache
+func (f *FixturesBuilder) AddClusterRoles(objs ...*rbacv1.ClusterRole) *FixturesBuilder {
+	for _, v := range objs {
+		f.clusterRolesIndexer.Add(v)
+		f.kClientSet = append(f.kClientSet, v)
+	}
+	return f
+}
+
+// AddClusterRoleBindings adds rbacv1.ClusterRoleBindings to the lister cache
+func (f *FixturesBuilder) AddClusterRoleBindings(objs ...*rbacv1.ClusterRoleBinding) *FixturesBuilder {
+	for _, v := range objs {
+		f.clusterRoleBindingsIndexer.Add(v)
+		f.kClientSet = append(f.kClientSet, v)
+	}
+	return f
+}
+
+// AddImageConfig adds cluster-wide config.openshift.io/v1 Image to the lister cache
+func (f *FixturesBuilder) AddImageConfig(config *configv1.Image) *FixturesBuilder {
+	f.imageConfigsIndexer.Add(config)
+	return f
+}
+
+// AddClusterOperators adds config.openshift.io/v1 ClusterOperators to the lister cache
+func (f *FixturesBuilder) AddClusterOperators(objs ...*configv1.ClusterOperator) *FixturesBuilder {
+	for _, v := range objs {
+		f.clusterOperatorsIndexer.Add(v)
+	}
+	return f
+}
+
+// AddRegistryOperatorConfig adds imageregistry.operator.openshift.io/v1 Config to the lister cache
+func (f *FixturesBuilder) AddRegistryOperatorConfig(config *regopv1.Config) *FixturesBuilder {
+	f.registryConfigsIndexer.Add(config)
+	return f
+}
+
+// AddProxyConfig adds cluster-wide config.openshift.io/v1 Proxy to the lister cache
+func (f *FixturesBuilder) AddProxyConfig(config *configv1.Proxy) *FixturesBuilder {
+	f.proxyConfigsIndexer.Add(config)
+	return f
+}
+
+// AddInfraConfig adds cluster-wide config.openshift.io/v1 Infrastructure to the lister cache
+func (f *FixturesBuilder) AddInfraConfig(config *configv1.Infrastructure) *FixturesBuilder {
+	f.infraIndexer.Add(config)
+	return f
+}
+
+// Build creates the fixtures from the provided objects.
+func (f *FixturesBuilder) Build() *Fixtures {
+	fixtures := &Fixtures{
+		Listers:    f.BuildListers(),
+		KubeClient: kfake.NewSimpleClientset(f.kClientSet...),
+	}
+	return fixtures
+}
+
+// BuildListers creates an in-memory instance of client.Listers
+func (f *FixturesBuilder) BuildListers() *client.Listers {
+	listers := &client.Listers{
+		Deployments:         appsv1listers.NewDeploymentLister(f.deploymentIndexer).Deployments("openshift-image-registry"),
+		DaemonSets:          appsv1listers.NewDaemonSetLister(f.dsIndexer).DaemonSets("openshift-image-registry"),
+		Services:            corev1listers.NewServiceLister(f.servicesIndexer).Services("openshift-image-registry"),
+		Secrets:             corev1listers.NewSecretLister(f.secretsIndexer).Secrets("openshift-image-registry"),
+		ConfigMaps:          corev1listers.NewConfigMapLister(f.configMapsIndexer).ConfigMaps("openshift-image-registry"),
+		ServiceAccounts:     corev1listers.NewServiceAccountLister(f.serviceAcctIndexer).ServiceAccounts("openshift-image-registry"),
+		Routes:              routev1listers.NewRouteLister(f.routesIndexer).Routes("openshift-image-registry"),
+		ClusterRoles:        rbacv1listers.NewClusterRoleLister(f.clusterRolesIndexer),
+		ClusterRoleBindings: rbacv1listers.NewClusterRoleBindingLister(f.clusterRoleBindingsIndexer),
+		OpenShiftConfig:     corev1listers.NewConfigMapLister(f.configMapsIndexer).ConfigMaps("openshift-config"),
+		ImageConfigs:        configv1listers.NewImageLister(f.imageConfigsIndexer),
+		ClusterOperators:    configv1listers.NewClusterOperatorLister(f.clusterOperatorsIndexer),
+		RegistryConfigs:     regopv1listers.NewConfigLister(f.registryConfigsIndexer),
+		InstallerConfigMaps: corev1listers.NewConfigMapLister(f.configMapsIndexer).ConfigMaps("kube-system"),
+		ProxyConfigs:        configv1listers.NewProxyLister(f.proxyConfigsIndexer),
+		Infrastructures:     configv1listers.NewInfrastructureLister(f.infraIndexer),
+	}
+	return listers
+}

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -79,6 +79,7 @@ func NewController(kubeconfig *restclient.Config) (*Controller, error) {
 	p.ImageConfig.Name = "cluster"
 	p.CAConfig.Name = imageregistryv1.ImageRegistryCertificatesName
 	p.ServiceCA.Name = "serviceca"
+	p.TrustedCA.Name = "trusted-ca"
 
 	listers := &regopclient.Listers{}
 	c := &Controller{

--- a/pkg/parameters/parameters.go
+++ b/pkg/parameters/parameters.go
@@ -36,4 +36,7 @@ type Globals struct {
 	ServiceCA struct {
 		Name string
 	}
+	TrustedCA struct {
+		Name string
+	}
 }

--- a/pkg/resource/podtemplatespec_test.go
+++ b/pkg/resource/podtemplatespec_test.go
@@ -1,0 +1,114 @@
+package resource
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	cirofake "github.com/openshift/cluster-image-registry-operator/pkg/client/fake"
+	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
+	"github.com/openshift/cluster-image-registry-operator/pkg/storage/emptydir"
+)
+
+func TestMakePodTemplateSpec(t *testing.T) {
+	// TODO: Make this table-driven to verify all storage drivers
+	params := &parameters.Globals{}
+	params.Deployment.Namespace = "openshift-image-registry"
+	params.TrustedCA.Name = "trusted-ca"
+
+	testBuilder := cirofake.NewFixturesBuilder()
+	config := &v1.Config{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: v1.ImageRegistrySpec{
+			Storage: v1.ImageRegistryConfigStorage{
+				EmptyDir: &v1.ImageRegistryConfigStorageEmptyDir{},
+			},
+		},
+	}
+	testBuilder.AddRegistryOperatorConfig(config)
+
+	imageRegNs := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "openshift-image-registry",
+			Annotations: map[string]string{
+				"openshift.io/node-selector":              "",
+				"openshift.io/sa.scc.supplemental-groups": "1000430000/10000",
+			},
+			Labels: map[string]string{
+				"openshift.io/cluster-monitoring": "true",
+			},
+		},
+		Spec: corev1.NamespaceSpec{
+			Finalizers: []corev1.FinalizerName{
+				corev1.FinalizerKubernetes,
+			},
+		},
+	}
+	testBuilder.AddNamespaces(imageRegNs)
+
+	fixture := testBuilder.Build()
+	emptyDirStorage := emptydir.NewDriver(config.Spec.Storage.EmptyDir, fixture.Listers)
+	pod, deps, err := makePodTemplateSpec(fixture.KubeClient.CoreV1(), fixture.Listers.ProxyConfigs, emptyDirStorage, params, config)
+	if err != nil {
+		t.Fatalf("error creating pod template: %v", err)
+	}
+
+	expectedVolumes := map[string]bool{
+		"registry-tls":          false,
+		"registry-certificates": false,
+		"trusted-ca":            false,
+	}
+	// emptyDir adds an additional volume
+	expectedVolumes["registry-storage"] = false
+	// Verify volume mounts
+	for _, v := range pod.Spec.Volumes {
+		if _, ok := expectedVolumes[v.Name]; !ok {
+			t.Errorf("volume %s was not expected", v.Name)
+		} else {
+			expectedVolumes[v.Name] = true
+		}
+	}
+	for vol, found := range expectedVolumes {
+		if !found {
+			t.Errorf("volume %s was not found", vol)
+		}
+	}
+
+	// Verify dependencies
+	expectedConfigMaps := map[string]bool{
+		"trusted-ca":                  false,
+		"image-registry-certificates": false,
+	}
+	expectedSecrets := map[string]bool{
+		"image-registry-tls": false,
+	}
+	for cm := range deps.configMaps {
+		if _, ok := expectedConfigMaps[cm]; !ok {
+			t.Errorf("unexpected dependent ConfigMap %s", cm)
+		} else {
+			expectedConfigMaps[cm] = true
+		}
+	}
+	for secret := range deps.secrets {
+		if _, ok := expectedSecrets[secret]; !ok {
+			t.Errorf("unexpected dependent Secret %s", secret)
+		} else {
+			expectedSecrets[secret] = true
+		}
+	}
+	for cm, found := range expectedConfigMaps {
+		if !found {
+			t.Errorf("ConfigMap %s was not listed as a dependency", cm)
+		}
+	}
+	for secret, found := range expectedSecrets {
+		if !found {
+			t.Errorf("Secret %s was not listed as a dependency", secret)
+		}
+	}
+
+}


### PR DESCRIPTION
Building on top of #340 - mounting the cluster trusted CA to the "low-priority" trust source at `/usr/share/pki/ca-trust-source/` within the registry.

The registry calls `update-ca-trust extract` to create the combined CA bundle, which includes the CA for the internal registry and other externally trusted registries.