### PR TITLE
Use common generateName for storage

### DIFF
--- a/pkg/storage/swift/swift.go
+++ b/pkg/storage/swift/swift.go
@@ -367,7 +367,7 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 		if err != nil {
 			// If the error is not ErrResourceNotFound
 			// return the error
-			if _, ok := err.(*gophercloud.ErrResourceNotFound); !ok {
+			if _, ok := err.(gophercloud.ErrDefault404); !ok {
 				util.UpdateCondition(cr, imageregistryv1.StorageExists, operatorapi.ConditionFalse, "Unable to check if container exists", fmt.Sprintf("Error occurred checking if container exists: %v", err))
 				return err
 			}

--- a/pkg/storage/swift/swift.go
+++ b/pkg/storage/swift/swift.go
@@ -2,7 +2,6 @@ package swift
 
 import (
 	"fmt"
-	"math/rand"
 	"reflect"
 	"strings"
 
@@ -302,6 +301,16 @@ func (d *driver) ensureAuthURLHasAPIVersion() error {
 	return nil
 }
 
+func (d *driver) containerExists(client *gophercloud.ServiceClient, containerName string) error {
+	if len(containerName) == 0 {
+		return nil
+	}
+	_, err := containers.Get(client, containerName, containers.GetOpts{}).Extract()
+
+	return err
+
+}
+
 func (d *driver) StorageExists(cr *imageregistryv1.Config) (bool, error) {
 	client, err := d.getSwiftClient(cr)
 	if err != nil {
@@ -309,9 +318,13 @@ func (d *driver) StorageExists(cr *imageregistryv1.Config) (bool, error) {
 		return false, err
 	}
 
-	_, err = containers.Get(client, cr.Spec.Storage.Swift.Container, containers.GetOpts{}).Extract()
+	err = d.containerExists(client, cr.Spec.Storage.Swift.Container)
 	if err != nil {
-		util.UpdateCondition(cr, imageregistryv1.StorageExists, operatorapi.ConditionFalse, "Storage does not exist", err.Error())
+		if serr, ok := err.(*gophercloud.ErrResourceNotFound); ok {
+			util.UpdateCondition(cr, imageregistryv1.StorageExists, operatorapi.ConditionFalse, "Storage does not exist", serr.Error())
+			return false, nil
+		}
+		util.UpdateCondition(cr, imageregistryv1.StorageExists, operatorapi.ConditionUnknown, "Unknown error occurred", err.Error())
 		return false, err
 	}
 
@@ -328,14 +341,6 @@ func (d *driver) StorageChanged(cr *imageregistryv1.Config) bool {
 	return false
 }
 
-func generateContainerName(clusterID string) string {
-	bytes := make([]byte, 8)
-	for i := 0; i < 8; i++ {
-		bytes[i] = byte(65 + rand.Intn(25)) // A=65 and Z=65+25
-	}
-	return clusterID + "-image-registry-" + string(bytes)
-}
-
 func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 	client, err := d.getSwiftClient(cr)
 	if err != nil {
@@ -348,33 +353,62 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 		return fmt.Errorf("failed to get cluster infrastructure info: %v", err)
 	}
 
-	// Generate new container name if it wasn't provided.
-	// The name has cluster ID as a prefix plus "image-registry" suffix, which is complemented
-	// by 8 capital latin letters
-	// Example of a generated name: user-298xw-image-registry-FHEIBGDD
-	if cr.Spec.Storage.Swift.Container == "" {
-		cr.Spec.Storage.Swift.Container = generateContainerName(infra.Status.InfrastructureName)
+	generatedName := false
+	const numRetries = 5000
+	for i := 0; i < numRetries; i++ {
+		if len(cr.Spec.Storage.Swift.Container) == 0 {
+			if cr.Spec.Storage.Swift.Container, err = util.GenerateStorageName(d.Listers, ""); err != nil {
+				return err
+			}
+			generatedName = true
+		}
+
+		err = d.containerExists(client, cr.Spec.Storage.Swift.Container)
+		if err != nil {
+			// If the error is not ErrResourceNotFound
+			// return the error
+			if _, ok := err.(*gophercloud.ErrResourceNotFound); !ok {
+				util.UpdateCondition(cr, imageregistryv1.StorageExists, operatorapi.ConditionFalse, "Unable to check if container exists", fmt.Sprintf("Error occurred checking if container exists: %v", err))
+				return err
+			}
+			// If the error is ErrResourceNotFound
+			// fall through to the container creation
+		}
+		// If we were supplied a container name and it exists
+		// we can skip the create
+		if !generatedName && err == nil {
+			util.UpdateCondition(cr, imageregistryv1.StorageExists, operatorapi.ConditionTrue, "Container exists", "User supplied container already exists")
+			break
+		}
+		// If we generated a container name and it exists
+		// let's try again
+		if generatedName && err == nil {
+			cr.Spec.Storage.Swift.Container = ""
+			continue
+		}
+
+		createOps := containers.CreateOpts{
+			Metadata: map[string]string{
+				"Openshiftclusterid": infra.Status.InfrastructureName,
+				"Name":               cr.Spec.Storage.Swift.Container,
+			},
+		}
+
+		_, err = containers.Create(client, cr.Spec.Storage.Swift.Container, createOps).Extract()
+		if err != nil {
+			util.UpdateCondition(cr, imageregistryv1.StorageExists, operatorapi.ConditionFalse, "Creation Failed", err.Error())
+			cr.Status.StorageManaged = false
+			return err
+		}
+
+		util.UpdateCondition(cr, imageregistryv1.StorageExists, operatorapi.ConditionTrue, "Swift Container Created", "")
+
+		cr.Status.StorageManaged = true
+		cr.Status.Storage.Swift = d.Config.DeepCopy()
+		cr.Spec.Storage.Swift = d.Config.DeepCopy()
+
+		break
 	}
-
-	createOps := containers.CreateOpts{
-		Metadata: map[string]string{
-			"Openshiftclusterid": infra.Status.InfrastructureName,
-			"Name":               cr.Spec.Storage.Swift.Container,
-		},
-	}
-
-	_, err = containers.Create(client, cr.Spec.Storage.Swift.Container, createOps).Extract()
-	if err != nil {
-		util.UpdateCondition(cr, imageregistryv1.StorageExists, operatorapi.ConditionFalse, "Creation Failed", err.Error())
-		cr.Status.StorageManaged = false
-		return err
-	}
-
-	util.UpdateCondition(cr, imageregistryv1.StorageExists, operatorapi.ConditionTrue, "Swift Container Created", "")
-
-	cr.Status.StorageManaged = true
-	cr.Status.Storage.Swift = d.Config.DeepCopy()
-	cr.Spec.Storage.Swift = d.Config.DeepCopy()
 
 	return nil
 }

--- a/pkg/storage/swift/swift_test.go
+++ b/pkg/storage/swift/swift_test.go
@@ -219,20 +219,20 @@ func TestSwiftCreateStorageNativeSecret(t *testing.T) {
 		// to check if container with name exists
 		if numRequests == 0 {
 			th.TestMethod(t, r, "HEAD")
+			th.TestHeader(t, r, "Accept", "application/json")
+			w.WriteHeader(http.StatusNotFound)
 			numRequests++
 		} else {
 			// Second request should be the actual create
 			th.TestMethod(t, r, "PUT")
+			th.TestHeader(t, r, "Accept", "application/json")
+
+			w.Header().Set("Content-Length", "0")
+			w.Header().Set("Content-Type", "text/html; charset=UTF-8")
+			w.Header().Set("Date", "Wed, 17 Aug 2016 19:25:43 GMT")
+			w.Header().Set("X-Trans-Id", "tx554ed59667a64c61866f1-0058b4ba37")
+			w.WriteHeader(http.StatusNoContent)
 		}
-
-		th.TestHeader(t, r, "Accept", "application/json")
-
-		w.Header().Set("Content-Length", "0")
-		w.Header().Set("Content-Type", "text/html; charset=UTF-8")
-		w.Header().Set("Date", "Wed, 17 Aug 2016 19:25:43 GMT")
-		w.Header().Set("X-Trans-Id", "tx554ed59667a64c61866f1-0058b4ba37")
-		w.WriteHeader(http.StatusNoContent)
-
 	})
 
 	d, installConfig := mockConfig(false, th.Endpoint()+"v3", MockUPISecretNamespaceLister{})
@@ -370,18 +370,19 @@ func TestSwiftCreateStorageCloudConfig(t *testing.T) {
 	th.Mux.HandleFunc("/"+container, func(w http.ResponseWriter, r *http.Request) {
 		if numRequests == 0 {
 			th.TestMethod(t, r, "HEAD")
+			th.TestHeader(t, r, "Accept", "application/json")
+			w.WriteHeader(http.StatusNotFound)
 			numRequests++
 		} else {
 			th.TestMethod(t, r, "PUT")
+			th.TestHeader(t, r, "Accept", "application/json")
+
+			w.Header().Set("Content-Length", "0")
+			w.Header().Set("Content-Type", "text/html; charset=UTF-8")
+			w.Header().Set("Date", "Wed, 17 Aug 2016 19:25:43 GMT")
+			w.Header().Set("X-Trans-Id", "tx554ed59667a64c61866f1-0058b4ba37")
+			w.WriteHeader(http.StatusNoContent)
 		}
-
-		th.TestHeader(t, r, "Accept", "application/json")
-
-		w.Header().Set("Content-Length", "0")
-		w.Header().Set("Content-Type", "text/html; charset=UTF-8")
-		w.Header().Set("Date", "Wed, 17 Aug 2016 19:25:43 GMT")
-		w.Header().Set("X-Trans-Id", "tx554ed59667a64c61866f1-0058b4ba37")
-		w.WriteHeader(http.StatusNoContent)
 	})
 
 	d, installConfig := mockConfig(false, th.Endpoint()+"v3", MockIPISecretNamespaceLister{})
@@ -581,30 +582,26 @@ func TestSwiftEndpointTypeObjectStore(t *testing.T) {
 	defer th.TeardownHTTP()
 	handleAuthentication(t, "object-store")
 
-	numRequests := 0
-
 	th.Mux.HandleFunc("/"+container, func(w http.ResponseWriter, r *http.Request) {
-		if numRequests == 0 {
-			th.TestMethod(t, r, "HEAD")
-			numRequests++
-		} else {
-			th.TestMethod(t, r, "PUT")
-		}
+		th.TestMethod(t, r, "HEAD")
 		th.TestHeader(t, r, "Accept", "application/json")
-
-		w.Header().Set("Content-Length", "0")
-		w.Header().Set("Content-Type", "text/html; charset=UTF-8")
+		w.Header().Set("Accept-Ranges", "bytes")
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.Header().Set("Date", "Wed, 17 Aug 2016 19:25:43 GMT")
-		w.Header().Set("X-Trans-Id", "tx554ed59667a64c61866f1-0058b4ba37")
+		w.Header().Set("X-Container-Bytes-Used", "100")
+		w.Header().Set("X-Container-Object-Count", "4")
+		w.Header().Set("X-Container-Read", "test")
+		w.Header().Set("X-Container-Write", "test2,user4")
+		w.Header().Set("X-Timestamp", "1471298837.95721")
+		w.Header().Set("X-Trans-Id", "tx554ed59667a64c61866f1-0057b4ba37")
+		w.Header().Set("X-Storage-Policy", "test_policy")
 		w.WriteHeader(http.StatusNoContent)
 	})
 
 	d, installConfig := mockConfig(false, th.Endpoint()+"v3", MockUPISecretNamespaceLister{})
 
-	d.CreateStorage(&installConfig)
+	res, err := d.StorageExists(&installConfig)
 
-	th.AssertEquals(t, true, installConfig.Status.StorageManaged)
-	th.AssertEquals(t, "StorageExists", installConfig.Status.Conditions[0].Type)
-	th.AssertEquals(t, operatorapi.ConditionTrue, installConfig.Status.Conditions[0].Status)
-	th.AssertEquals(t, container, installConfig.Status.Storage.Swift.Container)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, true, res)
 }

--- a/pkg/storage/util/util_test.go
+++ b/pkg/storage/util/util_test.go
@@ -1,0 +1,86 @@
+package util
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	configv1 "github.com/openshift/api/config/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
+)
+
+var (
+	infrastructureName = "jsmith-xhv4"
+	prefix             = fmt.Sprintf("%s-%s", infrastructureName, imageregistryv1.ImageRegistryName)
+)
+
+type MockInfrastructureLister struct {
+}
+
+func (m MockInfrastructureLister) Get(name string) (*configv1.Infrastructure, error) {
+	return &configv1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Status: configv1.InfrastructureStatus{
+			InfrastructureName: infrastructureName,
+			PlatformStatus:     &configv1.PlatformStatus{},
+		},
+	}, nil
+}
+
+func (m MockInfrastructureLister) List(selector labels.Selector) ([]*configv1.Infrastructure, error) {
+	var list []*configv1.Infrastructure
+	return list, nil
+}
+
+func TestGenerateStorageName(t *testing.T) {
+	l := regopclient.Listers{Infrastructures: MockInfrastructureLister{}}
+	tests := [][]string{
+		// test with nil
+		nil,
+		// test with no additionals
+		{},
+		// test with two empty strings
+		{"", ""},
+		// test one additional
+		{"test1"},
+		// test two additionals
+		{"test1", "test2"},
+		// test really long additionals
+		{"abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyz"},
+	}
+
+	multiDash := regexp.MustCompile(`-{2,}`)
+	replaceMultiDash := regexp.MustCompile(`-{1,}`)
+	for _, test := range tests {
+		n, err := GenerateStorageName(&l, test...)
+		if err != nil {
+			t.Errorf("%v", err)
+		}
+		wantedPrefix := replaceMultiDash.ReplaceAllString(fmt.Sprintf("%s-%s", prefix, strings.Join(test, "-")), "-")
+		if len(wantedPrefix) > 62 {
+			wantedPrefix = wantedPrefix[0:62]
+		}
+
+		// Name should have the wanted prefix
+		if !strings.HasPrefix(n, wantedPrefix) {
+			t.Errorf("name should have the prefix %s, but was %s instead", wantedPrefix, n)
+		}
+
+		// Name should be exactly 62 characters long
+		if len(n) != 62 {
+			t.Errorf("name should be exactly 62 characters long, but was %d instead: %s", len(n), n)
+		}
+
+		// Name should not have multiple dashes together
+		if multiDash.MatchString(n) {
+			t.Errorf("name should not include a double dash: %s", n)
+		}
+	}
+}


### PR DESCRIPTION
- Use a commont generateName function to generate storage name
- Wrap the swift storage creation in a loop that checks for an existing container
- Swift test fixes donated by @Fedosin, thanks!

Fixes #358