### PR TITLE
[release-4.1] Bug 1714168: Properly setting "maxWaitTime" environment…

### DIFF
--- a/pkg/resource/podtemplatespec.go
+++ b/pkg/resource/podtemplatespec.go
@@ -151,7 +151,7 @@ func makePodTemplateSpec(coreClient coreset.CoreV1Interface, driver storage.Driv
 		env = append(env,
 			corev1.EnvVar{Name: "REGISTRY_OPENSHIFT_REQUESTS_READ_MAXRUNNING", Value: fmt.Sprintf("%d", cr.Spec.Requests.Read.MaxRunning)},
 			corev1.EnvVar{Name: "REGISTRY_OPENSHIFT_REQUESTS_READ_MAXINQUEUE", Value: fmt.Sprintf("%d", cr.Spec.Requests.Read.MaxInQueue)},
-			corev1.EnvVar{Name: "REGISTRY_OPENSHIFT_REQUESTS_READ_MAXWAITINQUEUE", Value: fmt.Sprintf("%s", cr.Spec.Requests.Read.MaxWaitInQueue)},
+			corev1.EnvVar{Name: "REGISTRY_OPENSHIFT_REQUESTS_READ_MAXWAITINQUEUE", Value: fmt.Sprintf("%s", cr.Spec.Requests.Read.MaxWaitInQueue.Duration)},
 		)
 	}
 
@@ -165,7 +165,7 @@ func makePodTemplateSpec(coreClient coreset.CoreV1Interface, driver storage.Driv
 		env = append(env,
 			corev1.EnvVar{Name: "REGISTRY_OPENSHIFT_REQUESTS_WRITE_MAXRUNNING", Value: fmt.Sprintf("%d", cr.Spec.Requests.Write.MaxRunning)},
 			corev1.EnvVar{Name: "REGISTRY_OPENSHIFT_REQUESTS_WRITE_MAXINQUEUE", Value: fmt.Sprintf("%d", cr.Spec.Requests.Write.MaxInQueue)},
-			corev1.EnvVar{Name: "REGISTRY_OPENSHIFT_REQUESTS_WRITE_MAXWAITINQUEUE", Value: fmt.Sprintf("%s", cr.Spec.Requests.Write.MaxWaitInQueue)},
+			corev1.EnvVar{Name: "REGISTRY_OPENSHIFT_REQUESTS_WRITE_MAXWAITINQUEUE", Value: fmt.Sprintf("%s", cr.Spec.Requests.Write.MaxWaitInQueue.Duration)},
 		)
 	}
 

--- a/test/e2e/configuration_test.go
+++ b/test/e2e/configuration_test.go
@@ -217,3 +217,63 @@ func TestVersionReporting(t *testing.T) {
 		t.Fatalf("failed to observe updated version reported in clusteroperator status: %v", err)
 	}
 }
+
+func TestRequests(t *testing.T) {
+	client := framework.MustNewClientset(t, nil)
+
+	defer framework.MustRemoveImageRegistry(t, client)
+
+	cr := &imageregistryapiv1.Config{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: imageregistryapiv1.SchemeGroupVersion.String(),
+			Kind:       "Config",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: imageregistryapiv1.ImageRegistryResourceName,
+		},
+		Spec: imageregistryapiv1.ImageRegistrySpec{
+			ManagementState: operatorapiv1.Managed,
+			Storage: imageregistryapiv1.ImageRegistryConfigStorage{
+				EmptyDir: &imageregistryapiv1.ImageRegistryConfigStorageEmptyDir{},
+			},
+			Requests: imageregistryapiv1.ImageRegistryConfigRequests{
+				Read: imageregistryapiv1.ImageRegistryConfigRequestsLimits{
+					MaxRunning: 1,
+					MaxInQueue: 2,
+					MaxWaitInQueue: metav1.Duration{
+						Duration: 3 * time.Second,
+					},
+				},
+				Write: imageregistryapiv1.ImageRegistryConfigRequestsLimits{
+					MaxRunning: 4,
+					MaxInQueue: 5,
+					MaxWaitInQueue: metav1.Duration{
+						Duration: 6 * time.Hour,
+					},
+				},
+			},
+			Replicas: 1,
+		},
+	}
+
+	framework.MustDeployImageRegistry(t, client, cr)
+	framework.MustEnsureImageRegistryIsAvailable(t, client)
+
+	deploy, err := client.Deployments(imageregistryapiv1.ImageRegistryOperatorNamespace).Get(imageregistryapiv1.ImageRegistryName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedEnvVars := []corev1.EnvVar{
+		{Name: "REGISTRY_OPENSHIFT_REQUESTS_READ_MAXRUNNING", Value: "1", ValueFrom: nil},
+		{Name: "REGISTRY_OPENSHIFT_REQUESTS_READ_MAXINQUEUE", Value: "2", ValueFrom: nil},
+		{Name: "REGISTRY_OPENSHIFT_REQUESTS_READ_MAXWAITINQUEUE", Value: "3s", ValueFrom: nil},
+		{Name: "REGISTRY_OPENSHIFT_REQUESTS_WRITE_MAXRUNNING", Value: "4", ValueFrom: nil},
+		{Name: "REGISTRY_OPENSHIFT_REQUESTS_WRITE_MAXINQUEUE", Value: "5", ValueFrom: nil},
+		{Name: "REGISTRY_OPENSHIFT_REQUESTS_WRITE_MAXWAITINQUEUE", Value: "6h0m0s", ValueFrom: nil},
+	}
+
+	for _, err = range framework.CheckEnvVars(expectedEnvVars, deploy.Spec.Template.Spec.Containers[0].Env) {
+		t.Errorf("%v", err)
+	}
+}

--- a/test/framework/util.go
+++ b/test/framework/util.go
@@ -1,0 +1,29 @@
+package framework
+
+import (
+	"fmt"
+	"reflect"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func CheckEnvVars(want []corev1.EnvVar, have []corev1.EnvVar) []error {
+	var errs []error
+
+	for _, val := range want {
+		found := false
+		for _, v := range have {
+			if v.Name == val.Name {
+				found = true
+				if !reflect.DeepEqual(v, val) {
+					errs = append(errs, fmt.Errorf("environment variable contains incorrect data: expected %#v, got %#v", val, v))
+				}
+			}
+		}
+		if !found {
+			errs = append(errs, fmt.Errorf("unable to find environment variable: wanted %s", val.Name))
+		}
+	}
+
+	return errs
+}


### PR DESCRIPTION
Image registry expects REGISTRY_OPENSHIFT_REQUESTS_READ_MAXWAITINQUEUE
and REGISTRY_OPENSHIFT_REQUESTS_WRITE_MAXWAITINQUEUE to be of type
time.Duration. This patch renders only the Duration property of a metav1.Duration
struct.