### PR TITLE
Set default role for minted credentials to Contributor

### DIFF
--- a/manifests/01-registry-credentials-request-azure.yaml
+++ b/manifests/01-registry-credentials-request-azure.yaml
@@ -12,3 +12,5 @@ spec:
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: AzureProviderSpec
+    roleBindings:
+    - role: Contributor


### PR DESCRIPTION
After cloud credential operator starts supporting resource group
scoped credential minting for Azure, all CCO will be required to set
at least one role in role bindings. If a CCO failed to do so,
no secret with azure credential will be minted.

Contributor role permissions should be sufficient. If not, please extend the list of role bindings with additional roles.

PR adding the support for resource group scoped credentials: https://github.com/openshift/cloud-credential-operator/pull/95