### PR TITLE
DEVEXP-404: Added implementation for operator metrics/alerts.

### DIFF
--- a/cmd/cluster-image-registry-operator/main.go
+++ b/cmd/cluster-image-registry-operator/main.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/klog"
 
 	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
+	"github.com/openshift/cluster-image-registry-operator/pkg/metrics"
 	"github.com/openshift/cluster-image-registry-operator/pkg/operator"
 	"github.com/openshift/cluster-image-registry-operator/pkg/signals"
 	"github.com/openshift/cluster-image-registry-operator/version"
@@ -18,6 +19,8 @@ import (
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
+
+const metricsPort = 60000
 
 func printVersion() {
 	klog.Infof("Cluster Image Registry Operator Version: %s", version.Version)
@@ -66,6 +69,7 @@ func runOperator(cmd *cobra.Command, args []string) {
 		klog.Fatal(err)
 	}
 
+	go metrics.RunServer(metricsPort, stopCh)
 	err = controller.Run(stopCh)
 	if err != nil {
 		klog.Fatal(err)

--- a/manifests/0000_90_cluster-image-registry-operator_02_operator-servicemonitor.yaml
+++ b/manifests/0000_90_cluster-image-registry-operator_02_operator-servicemonitor.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: image-registry-operator
+  namespace: openshift-image-registry
+spec:
+  endpoints:
+  - targetPort: 60000
+    interval: 60s
+    scheme: https
+    path: /metrics
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: image-registry-operator.openshift-image-registry.svc
+  selector:
+    name: image-registry-operator

--- a/manifests/07-operator-service.yaml
+++ b/manifests/07-operator-service.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: image-registry-operator-tls
+  labels:
+    name: image-registry-operator
+  name: image-registry-operator
+  namespace: openshift-image-registry
+spec:
+  clusterIP: None
+  ports:
+  - port: 60000
+    protocol: TCP
+    targetPort: 60000
+  selector:
+    name: cluster-image-registry-operator

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -57,6 +57,8 @@ spec:
           volumeMounts:
             - name: trusted-ca
               mountPath: /var/run/configmaps/trusted-ca/
+            - name: image-registry-operator-tls
+              mountPath: /etc/secrets
         - name: cluster-image-registry-operator-watch
           image: docker.io/openshift/origin-cluster-image-registry-operator:latest
           command:
@@ -67,6 +69,8 @@ spec:
           - --process-name=cluster-image-registry-operator
           - --termination-grace-period=30s
           - --files=/var/run/configmaps/trusted-ca/tls-ca-bundle.pem
+          - --files=/etc/secrets/tls.crt
+          - --files=/etc/secrets/tls.key
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -83,6 +87,9 @@ spec:
                 apiVersion: v1
                 fieldPath: metadata.namespace
       volumes:
+        - name: image-registry-operator-tls
+          secret:
+            secretName: image-registry-operator-tls
         - name: trusted-ca
           configMap:
             name: trusted-ca

--- a/manifests/09-prometheus-rules.yaml
+++ b/manifests/09-prometheus-rules.yaml
@@ -1,0 +1,37 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    name: image-registry-operator-alerts
+  name: image-registry-operator-alerts
+  namespace: openshift-image-registry
+spec:
+  groups:
+  - name: ImageRegistryOperator
+    rules:
+    - alert: ImageRegistryMissingStorageConfiguration
+      expr: increase(image_registry_operator_status_degraded_total{reason="StorageNotConfigured"}[5m]) > 0
+      for: 48h
+      labels:
+        severity: warning
+      annotations:
+        message: |
+          Image Registry is missing a backend storage configuration. This alert
+          will auto resolve once Image Registry is provided with a valid
+          backend configuration.
+    - alert: ImageRegistryDegraded
+      expr: increase(image_registry_operator_status_degraded_total{reason!="StorageNotConfigured"}[5m]) > 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        message: |
+          Image Registry could not be deployed and is in Degraded status.
+    - alert: ImageRegistryStorageReconfigured
+      expr: increase(image_registry_operator_storage_reconfigured_total[30m]) > 0
+      labels:
+        severity: info
+      annotations:
+        message: |
+          Image Registry Storage configuration has changed in the last 30
+          minutes. This change may have caused data loss.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,26 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	registry            = prometheus.NewRegistry()
+	storageReconfigured = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "image_registry_operator",
+		Subsystem: "storage",
+		Name:      "reconfigured_total",
+		Help:      "Total times the image registry's storage was reconfigured.",
+	})
+	degraded = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "image_registry_operator",
+		Subsystem: "status",
+		Name:      "degraded_total",
+		Help:      "Total times the image registry operator reported itself `Degraded`, per reason.",
+	}, []string{"reason"})
+)
+
+func init() {
+	registry.MustRegister(
+		storageReconfigured,
+		degraded,
+	)
+}

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -1,0 +1,69 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"k8s.io/klog"
+)
+
+var (
+	tlsCRT = "/etc/secrets/tls.crt"
+	tlsKey = "/etc/secrets/tls.key"
+)
+
+// RunServer starts the metrics server.
+func RunServer(port int, stopCh <-chan struct{}) {
+	if port <= 0 {
+		klog.Error("invalid port for metric server")
+		return
+	}
+
+	handler := promhttp.HandlerFor(
+		registry,
+		promhttp.HandlerOpts{
+			ErrorHandling: promhttp.HTTPErrorOnError,
+		},
+	)
+
+	bindAddr := fmt.Sprintf(":%d", port)
+	router := http.NewServeMux()
+	router.Handle("/metrics", handler)
+	srv := &http.Server{
+		Addr:    bindAddr,
+		Handler: router,
+	}
+
+	go func() {
+		err := srv.ListenAndServeTLS(tlsCRT, tlsKey)
+		if err != nil && err != http.ErrServerClosed {
+			klog.Errorf("error starting metrics server: %v", err)
+		}
+	}()
+
+	<-stopCh
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := srv.Shutdown(ctx); err != nil {
+		klog.Errorf("error closing metrics server: %v", err)
+	}
+}
+
+// Degraded increases the degraded counter for provided reason.
+func Degraded(reason string) {
+	if reason == "" {
+		return
+	}
+	degraded.WithLabelValues(reason).Inc()
+}
+
+// StorageReconfigured keeps track of the number of times the operator got its
+// underlying storage reconfigured.
+func StorageReconfigured() {
+	storageReconfigured.Inc()
+}

--- a/pkg/metrics/server_test.go
+++ b/pkg/metrics/server_test.go
@@ -1,0 +1,234 @@
+package metrics
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"io"
+	"io/ioutil"
+	"math/big"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	io_prometheus_client "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+)
+
+func TestMain(m *testing.M) {
+	var err error
+
+	tlsKey, tlsCRT, err = generateTempCertificates()
+	if err != nil {
+		panic(err)
+	}
+
+	// sets the default http client to skip certificate check.
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: true,
+	}
+
+	ch := make(chan struct{})
+	go RunServer(5000, ch)
+
+	// give http handlers/server some time to process certificates and
+	// get online before running tests.
+	time.Sleep(time.Second)
+
+	code := m.Run()
+	os.Remove(tlsKey)
+	os.Remove(tlsCRT)
+	close(ch)
+	os.Exit(code)
+}
+
+func generateTempCertificates() (string, string, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		return "", "", err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+	}
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, key.Public(), key)
+	if err != nil {
+		return "", "", err
+	}
+
+	cert, err := ioutil.TempFile("", "testcert-")
+	if err != nil {
+		return "", "", err
+	}
+	defer cert.Close()
+	pem.Encode(cert, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: derBytes,
+	})
+
+	keyPath, err := ioutil.TempFile("", "testkey-")
+	if err != nil {
+		return "", "", err
+	}
+	defer keyPath.Close()
+	pem.Encode(keyPath, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+
+	return keyPath.Name(), cert.Name(), nil
+}
+
+func TestRun(t *testing.T) {
+	resp, err := http.Get("https://localhost:5000/metrics")
+	if err != nil {
+		t.Fatalf("error requesting metrics server: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, received %d instead.", resp.StatusCode)
+	}
+}
+
+func TestDegraded(t *testing.T) {
+	metricName := "image_registry_operator_status_degraded_total"
+	for _, tt := range []struct {
+		name     string
+		reason   string
+		expected float64
+		exists   bool
+	}{
+		{
+			name:     "storage not configured",
+			reason:   "StorageNotConfigured",
+			expected: 1,
+			exists:   true,
+		},
+		{
+			name:     "other reason",
+			reason:   "OtherReason",
+			expected: 1,
+			exists:   true,
+		},
+		{
+			name:     "storage not configured again",
+			reason:   "StorageNotConfigured",
+			expected: 2,
+			exists:   true,
+		},
+		{
+			name:     "other reason again",
+			reason:   "OtherReason",
+			expected: 2,
+			exists:   true,
+		},
+		{
+			name:   "empty reason",
+			reason: "",
+			exists: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			Degraded(tt.reason)
+
+			resp, err := http.Get("https://localhost:5000/metrics")
+			if err != nil {
+				t.Fatalf("error requesting metrics server: %v", err)
+			}
+
+			metrics := findMetricsByCounter(resp.Body, metricName)
+			if len(metrics) == 0 {
+				t.Fatal("unable to locate metric", metricName)
+			}
+
+			var counter *io_prometheus_client.Counter
+			for _, m := range metrics {
+				label := *m.Label[0].Value
+				if label != tt.reason {
+					continue
+				}
+				counter = m.Counter
+				break
+			}
+
+			if counter == nil {
+				if tt.exists {
+					t.Errorf("unable to locate counter for %q", tt.reason)
+				}
+				return
+			} else if !tt.exists {
+				t.Errorf("counter for %q should not exist", tt.reason)
+				return
+			}
+
+			val := *counter.Value
+			if val != tt.expected {
+				t.Errorf(
+					"expected %.0f, found %.0f, reason %s",
+					tt.expected, val, tt.reason,
+				)
+			}
+		})
+	}
+}
+
+func TestStorageReconfigured(t *testing.T) {
+	metricName := "image_registry_operator_storage_reconfigured_total"
+	for _, tt := range []struct {
+		name string
+		iter int
+		expt float64
+	}{
+		{
+			name: "zeroed",
+			iter: 0,
+			expt: 0,
+		},
+		{
+			name: "increase to five",
+			iter: 5,
+			expt: 5,
+		},
+		{
+			name: "increase to ten",
+			iter: 5,
+			expt: 10,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			for i := 0; i < tt.iter; i++ {
+				StorageReconfigured()
+			}
+
+			resp, err := http.Get("https://localhost:5000/metrics")
+			if err != nil {
+				t.Fatalf("error requesting metrics server: %v", err)
+			}
+
+			metrics := findMetricsByCounter(resp.Body, metricName)
+			if len(metrics) == 0 {
+				t.Fatal("unable to locate metric", metricName)
+			}
+
+			val := *metrics[0].Counter.Value
+			if val != tt.expt {
+				t.Errorf("expected %.0f, found %.0f", tt.expt, val)
+			}
+		})
+	}
+}
+
+func findMetricsByCounter(buf io.ReadCloser, name string) []*io_prometheus_client.Metric {
+	defer buf.Close()
+	mf := io_prometheus_client.MetricFamily{}
+	decoder := expfmt.NewDecoder(buf, "text/plain")
+	for err := decoder.Decode(&mf); err == nil; err = decoder.Decode(&mf) {
+		if *mf.Name == name {
+			return mf.Metric
+		}
+	}
+	return nil
+}

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -8,6 +8,7 @@ import (
 
 	operatorapiv1 "github.com/openshift/api/operator/v1"
 	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	"github.com/openshift/cluster-image-registry-operator/pkg/metrics"
 )
 
 func updateCondition(cr *imageregistryv1.Config, condtype string, condstate operatorapiv1.OperatorCondition) {
@@ -44,6 +45,19 @@ func updateCondition(cr *imageregistryv1.Config, condtype string, condstate oper
 	}
 
 	cr.Status.Conditions = conditions
+	updateDegradedMetric(condtype, condstate)
+}
+
+// updateDegradedMetric updates prometheus metric that indicates if we are
+// operating in Degraded mode.
+func updateDegradedMetric(condtype string, condstate operatorapiv1.OperatorCondition) {
+	if condtype != operatorapiv1.OperatorStatusTypeDegraded {
+		return
+	}
+	if condstate.Status == operatorapiv1.ConditionFalse {
+		return
+	}
+	metrics.Degraded(condstate.Reason)
 }
 
 func isDeploymentStatusAvailable(deploy *appsapi.Deployment) bool {

--- a/pkg/storage/azure/azure.go
+++ b/pkg/storage/azure/azure.go
@@ -535,11 +535,6 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 			util.UpdateCondition(cr, imageregistryv1.StorageExists, operatorapiv1.ConditionTrue, storageExistsReasonContainerExists, "Storage container exists")
 
 			break
-
-			if len(d.Config.Container) == 0 {
-				util.UpdateCondition(cr, imageregistryv1.StorageExists, operatorapiv1.ConditionFalse, "CreateStorageFailed", "Unable to generate a unique container name")
-				return fmt.Errorf("unable to generate a unique azure container name")
-			}
 		}
 	}
 	return nil
@@ -605,4 +600,10 @@ func (d *driver) RemoveStorage(cr *imageregistryv1.Config) (retry bool, err erro
 	util.UpdateCondition(cr, imageregistryv1.StorageExists, operatorapiv1.ConditionFalse, storageExistsReasonAccountDeleted, "Storage account has been deleted")
 
 	return false, nil
+}
+
+// ID return the underlying storage identificator, on this case the Azure
+// container name.
+func (d *driver) ID() string {
+	return d.Config.Container
 }

--- a/pkg/storage/emptydir/emptydir.go
+++ b/pkg/storage/emptydir/emptydir.go
@@ -84,3 +84,9 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 func (d *driver) RemoveStorage(cr *imageregistryv1.Config) (bool, error) {
 	return false, nil
 }
+
+// ID return the underlying storage identificator, on this case as we don't
+// have any id we always return an empty string.
+func (d *driver) ID() string {
+	return ""
+}

--- a/pkg/storage/gcs/gcs.go
+++ b/pkg/storage/gcs/gcs.go
@@ -341,3 +341,8 @@ func (d *driver) RemoveStorage(cr *imageregistryv1.Config) (bool, error) {
 
 	return true, nil
 }
+
+// ID return the underlying storage identificator, on this case the bucket name.
+func (d *driver) ID() string {
+	return d.Config.Bucket
+}

--- a/pkg/storage/pvc/pvc.go
+++ b/pkg/storage/pvc/pvc.go
@@ -209,3 +209,8 @@ func pvcIsCreatedByOperator(claim *corev1.PersistentVolumeClaim) (exist bool) {
 	_, exist = claim.Annotations[pvcOwnerAnnotation]
 	return
 }
+
+// ID return the underlying storage identificator, on this case the claim name.
+func (d *driver) ID() string {
+	return d.Config.Claim
+}

--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -619,3 +619,8 @@ func (d *driver) RemoveStorage(cr *imageregistryv1.Config) (bool, error) {
 
 	return false, nil
 }
+
+// ID return the underlying storage identificator, on this case the bucket name.
+func (d *driver) ID() string {
+	return d.Config.Bucket
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -48,6 +48,7 @@ type Driver interface {
 	StorageExists(*imageregistryv1.Config) (bool, error)
 	RemoveStorage(*imageregistryv1.Config) (bool, error)
 	StorageChanged(*imageregistryv1.Config) bool
+	ID() string
 }
 
 func newDriver(cfg *imageregistryv1.ImageRegistryConfigStorage, kubeconfig *rest.Config, listers *regopclient.Listers) (Driver, error) {

--- a/pkg/storage/swift/swift.go
+++ b/pkg/storage/swift/swift.go
@@ -448,3 +448,9 @@ func (d *driver) RemoveStorage(cr *imageregistryv1.Config) (bool, error) {
 func (d *driver) Volumes() ([]corev1.Volume, []corev1.VolumeMount, error) {
 	return nil, nil, nil
 }
+
+// ID return the underlying storage identificator, on this case the Swift
+// container name.
+func (d *driver) ID() string {
+	return d.Config.Container
+}


### PR DESCRIPTION
This commits adds a Prometheus endpoint, exposing three metrics
indicating the following:

- Wether we have storage backend configured for the registry.
- How many times we had to change the storage backend(buckets and such).
- If we are in Degraded mode.

Metric for Degraded does not consider the lack of storage backend
configuration.

Rules for alerting are also created by this commit.