### PR TITLE
Removed CA volume mount from watch container.

### DIFF
--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -63,8 +63,8 @@ spec:
           image: docker.io/openshift/origin-cluster-image-registry-operator:latest
           command:
           - cluster-image-registry-operator-watch
-          - file-watcher-watchdog
           args:
+          - file-watcher-watchdog
           - --namespace=$(POD_NAMESPACE)
           - --process-name=cluster-image-registry-operator
           - --termination-grace-period=30s
@@ -84,9 +84,6 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.namespace
-          volumeMounts:
-            - name: trusted-ca
-              mountPath: /etc/pki/ca-trust/extracted/pem/
       volumes:
         - name: trusted-ca
           configMap:


### PR DESCRIPTION
We don't need to mount the same volume on the watcher, as long as it is
mounted on the operator we are ok as the watcher does not monitor the
file directly but a link from /proc/_operator-pid_/root/... instead.