### PR TITLE
Report HasTrustedCA Status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ test-unit: verify
 .PHONY: test-unit
 
 test-e2e:
-	./hack/test-go.sh -count 1 -timeout 30m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/
+	./hack/test-go.sh -count 1 -timeout 2h -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/
 .PHONY: test-e2e
 
 verify: verify-crd verify-fmt verify-sec

--- a/pkg/apis/imageregistry/v1/types.go
+++ b/pkg/apis/imageregistry/v1/types.go
@@ -77,6 +77,10 @@ const (
 	// medium is configured to automatically cleanup incomplete uploads
 	StorageIncompleteUploadCleanupEnabled = "StorageIncompleteUploadCleanupEnabled"
 
+	// HasTrustedCA denotes if the CA trust bundle for the registry and registry operator
+	// has been injected.
+	HasTrustedCA = "HasTrustedCA"
+
 	// VersionAnnotation reflects the version of the registry that this deployment
 	// is running.
 	VersionAnnotation = "release.openshift.io/version"

--- a/pkg/operator/controller_test.go
+++ b/pkg/operator/controller_test.go
@@ -1,0 +1,73 @@
+package operator
+
+import (
+	"testing"
+	"time"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	imageregistryv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDegradedTimeoutExceeded(t *testing.T) {
+	cases := []struct {
+		name     string
+		config   *imageregistryv1.Config
+		timeout  time.Duration
+		expected bool
+	}{
+		{
+			name: "null",
+		},
+		{
+			name:   "empty",
+			config: &imageregistryv1.Config{},
+		},
+		{
+			name:    "does not exceed",
+			timeout: 1 * time.Hour,
+			config: &imageregistryv1.Config{
+				Status: imageregistryv1.ImageRegistryStatus{
+					OperatorStatus: operatorv1.OperatorStatus{
+						Conditions: []operatorv1.OperatorCondition{
+							{
+								Type:               operatorv1.OperatorStatusTypeDegraded,
+								Status:             operatorv1.ConditionTrue,
+								LastTransitionTime: metav1.Now(),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:    "does exceed",
+			timeout: 1 * time.Second,
+			config: &imageregistryv1.Config{
+				Status: imageregistryv1.ImageRegistryStatus{
+					OperatorStatus: operatorv1.OperatorStatus{
+						Conditions: []operatorv1.OperatorCondition{
+							{
+								Type:               operatorv1.OperatorStatusTypeDegraded,
+								Status:             operatorv1.ConditionTrue,
+								LastTransitionTime: metav1.NewTime(time.Now().Add(-1 * time.Minute)),
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			controller := &Controller{
+				degradedTimeout: tc.timeout,
+			}
+			exceeded := controller.degradedTimeoutExceeded(tc.config, operatorv1.OperatorStatusTypeDegraded)
+			if tc.expected != exceeded {
+				t.Errorf("expected degraded exceeded=%t, got %t", tc.expected, exceeded)
+			}
+		})
+	}
+}

--- a/test/framework/cvo.go
+++ b/test/framework/cvo.go
@@ -44,6 +44,12 @@ func DisableCVOForOperator(logger Logger, client *Clientset) error {
 		Name:      OperatorDeploymentName,
 		Unmanaged: true,
 	})
+	cv.Spec.Overrides, changed = addCompomentOverride(cv.Spec.Overrides, configv1.ComponentOverride{
+		Group:     "",
+		Kind:      "ConfigMap",
+		Namespace: OperatorDeploymentNamespace,
+		Name:      "trusted-ca",
+	})
 	// Disable the kube and openshift apiserver operators so the kube+openshift apiservers don't get
 	// restarted while we're running our tests.
 	cv.Spec.Overrides, changed = addCompomentOverride(cv.Spec.Overrides, configv1.ComponentOverride{

--- a/test/framework/imageregistry.go
+++ b/test/framework/imageregistry.go
@@ -369,6 +369,26 @@ func MustEnsureClusterOperatorStatusIsNormal(t *testing.T, client *Clientset) {
 	}
 }
 
+func CheckClusterOperatorCondition(t *testing.T, client *Clientset, condType configapiv1.ClusterStatusConditionType, status configapiv1.ConditionStatus, reason string) {
+	clusterOperator := MustEnsureClusterOperatorStatusIsSet(t, client)
+	found := false
+	for _, cond := range clusterOperator.Status.Conditions {
+		if cond.Type == condType {
+			found = true
+			if cond.Status != status {
+				t.Errorf("Expected clusteroperator %s=%s, got %s", cond.Type, status, cond.Status)
+			}
+			if cond.Reason != reason {
+				t.Errorf("Expected clusteroperator %s reason=%s, got %s", cond.Type, reason, cond.Reason)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Could not find clusteroperator condition %s", condType)
+	}
+}
+
 func MustEnsureOperatorIsNotHotLooping(t *testing.T, client *Clientset) {
 	// Allow the operator a few seconds to stabilize
 	time.Sleep(15 * time.Second)


### PR DESCRIPTION
Report the operator at level if the trusted CA bundle has not been injected yet.
This will allow upgrades to proceed while the networking operator rolls out.