### PR TITLE
DEVEXP-403: Using hard link when creating watcher binary.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN make build
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/openshift/cluster-image-registry-operator/tmp/_output/bin/cluster-image-registry-operator /usr/bin/
-RUN ln -s /usr/bin/cluster-image-registry-operator /usr/bin/cluster-image-registry-operator-watch
+RUN ln /usr/bin/cluster-image-registry-operator /usr/bin/cluster-image-registry-operator-watch
 RUN useradd cluster-image-registry-operator
 USER cluster-image-registry-operator
 COPY manifests/image-references manifests/0* /manifests/


### PR DESCRIPTION
Watcher, on library-go, reports the same binary name when using symlink
as it searchs for the executable name by looking at /proc/pid/exe link.

/proc/pid/exe points to the same destination as the symlink points to,
this causes both process to have the same "name".