### PR TITLE
Bug 1746155: Revert mount of trusted CA bundle

### DIFF
--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -56,9 +56,9 @@ spec:
               value: "cluster-image-registry-operator"
             - name: IMAGE
               value: docker.io/openshift/origin-docker-registry:latest
-          volumeMounts:
-            - name: trusted-ca
-              mountPath: /etc/pki/ca-trust/extracted/pem/
+          # volumeMounts:
+          #   - name: trusted-ca
+          #     mountPath: /etc/pki/ca-trust/extracted/pem/
         - name: cluster-image-registry-operator-watch
           image: docker.io/openshift/origin-cluster-image-registry-operator:latest
           command:
@@ -84,11 +84,11 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.namespace
-      volumes:
-        - name: trusted-ca
-          configMap:
-            name: trusted-ca
-            optional: true
-            items:
-            - key: ca-bundle.crt
-              path: tls-ca-bundle.pem
+      # volumes:
+        # - name: trusted-ca
+        #   configMap:
+        #     name: trusted-ca
+        #     optional: true
+        #     items:
+        #     - key: ca-bundle.crt
+        #       path: tls-ca-bundle.pem


### PR DESCRIPTION
Undo mounting of the cluster trusted CA so that we unblock upgrade.