### PR TITLE
Overwrite CA trust bundle only on 4.2 clusters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,12 @@ COPY . .
 RUN make build
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
-COPY --from=builder /go/src/github.com/openshift/cluster-image-registry-operator/tmp/_output/bin/cluster-image-registry-operator /usr/bin/
-RUN ln /usr/bin/cluster-image-registry-operator /usr/bin/cluster-image-registry-operator-watch
-RUN useradd cluster-image-registry-operator
-USER cluster-image-registry-operator
+COPY images/bin/entrypoint.sh /usr/bin/
 COPY manifests/image-references manifests/0* /manifests/
+COPY --from=builder /go/src/github.com/openshift/cluster-image-registry-operator/tmp/_output/bin/cluster-image-registry-operator /usr/bin/
+RUN ln /usr/bin/cluster-image-registry-operator /usr/bin/cluster-image-registry-operator-watch && \
+    chmod -R g+w /etc/pki/ca-trust/extracted/pem/
+
+ENTRYPOINT ["/usr/bin/entrypoint.sh"]
+
 LABEL io.openshift.release.operator true

--- a/images/bin/entrypoint.sh
+++ b/images/bin/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# When upgrading from 4.1 -> 4.2, the trust bundle may not be immediately present.
+# If trust bundle is not present, assume the cluster is not at 4.2 yet
+trustedCA="/var/run/configmaps/trusted-ca/tls-ca-bundle.pem"
+
+if [ -e "$trustedCA" ]; then
+    echo "Overwriting root TLS certificate authority trust store"
+    cp -f "$trustedCA" /etc/pki/ca-trust/extracted/pem/
+fi
+
+exec /usr/bin/cluster-image-registry-operator

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -56,9 +56,9 @@ spec:
               value: "cluster-image-registry-operator"
             - name: IMAGE
               value: docker.io/openshift/origin-docker-registry:latest
-          volumeMounts:
-            - name: trusted-ca
-              mountPath: /etc/pki/ca-trust/extracted/pem/
+          # volumeMounts:
+          #   - name: trusted-ca
+          #     mountPath: /etc/pki/ca-trust/extracted/pem/
         - name: cluster-image-registry-operator-watch
           image: docker.io/openshift/origin-cluster-image-registry-operator:latest
           command:
@@ -84,11 +84,11 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.namespace
-      volumes:
-        - name: trusted-ca
-          configMap:
-            name: trusted-ca
-            optional: true
-            items:
-            - key: ca-bundle.crt
-              path: tls-ca-bundle.pem
+      # volumes:
+        # - name: trusted-ca
+        #   configMap:
+        #     name: trusted-ca
+        #     optional: true
+        #     items:
+        #     - key: ca-bundle.crt
+        #       path: tls-ca-bundle.pem

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -39,8 +39,6 @@ spec:
           ports:
           - containerPort: 60000
             name: metrics
-          command:
-          - cluster-image-registry-operator
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -56,9 +54,9 @@ spec:
               value: "cluster-image-registry-operator"
             - name: IMAGE
               value: docker.io/openshift/origin-docker-registry:latest
-          # volumeMounts:
-          #   - name: trusted-ca
-          #     mountPath: /etc/pki/ca-trust/extracted/pem/
+          volumeMounts:
+            - name: trusted-ca
+              mountPath: /var/run/configmaps/trusted-ca/
         - name: cluster-image-registry-operator-watch
           image: docker.io/openshift/origin-cluster-image-registry-operator:latest
           command:
@@ -68,7 +66,7 @@ spec:
           - --namespace=$(POD_NAMESPACE)
           - --process-name=cluster-image-registry-operator
           - --termination-grace-period=30s
-          - --files=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+          - --files=/var/run/configmaps/trusted-ca/tls-ca-bundle.pem
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -84,11 +82,11 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.namespace
-      # volumes:
-        # - name: trusted-ca
-        #   configMap:
-        #     name: trusted-ca
-        #     optional: true
-        #     items:
-        #     - key: ca-bundle.crt
-        #       path: tls-ca-bundle.pem
+      volumes:
+        - name: trusted-ca
+          configMap:
+            name: trusted-ca
+            optional: true
+            items:
+            - key: ca-bundle.crt
+              path: tls-ca-bundle.pem


### PR DESCRIPTION
* Mount cluster trust bundle in non-system location
* Added entrypoint to copy trust bundle
* Updated perms of /etc/pki/ca-trust/extracted files to allow overwrites

Builds on #376 