### PR TITLE
Bug 1748436: Add namespace to related objects

### DIFF
--- a/pkg/resource/clusteroperator.go
+++ b/pkg/resource/clusteroperator.go
@@ -243,6 +243,12 @@ func (gco *generatorClusterOperator) syncVersions(op *configapi.ClusterOperator)
 func (gco *generatorClusterOperator) syncRelatedObjects(op *configapi.ClusterOperator) (modified bool) {
 	var relatedObjects []configapi.ObjectReference
 
+	// Always sync the openshift-image-registry namespace
+	relatedObjects = append(relatedObjects, configapi.ObjectReference{
+		Resource: "namespaces",
+		Name:     imageregistryv1.ImageRegistryOperatorNamespace,
+	})
+
 	for _, gen := range gco.mutators {
 		relatedObjects = append(relatedObjects, configapi.ObjectReference{
 			Group:     gen.GetGroup(),

--- a/test/framework/imageregistry.go
+++ b/test/framework/imageregistry.go
@@ -2,6 +2,7 @@ package framework
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -366,6 +367,19 @@ func MustEnsureClusterOperatorStatusIsNormal(t *testing.T, client *Clientset) {
 				t.Errorf("Expected clusteroperator Degraded=%s, got %s", configapiv1.ConditionFalse, cond.Status)
 			}
 		}
+	}
+
+	namespaceFound := false
+	for _, obj := range clusterOperator.Status.RelatedObjects {
+		if strings.ToLower(obj.Resource) == "namespaces" {
+			namespaceFound = true
+			if obj.Name != imageregistryapiv1.ImageRegistryOperatorNamespace {
+				t.Errorf("expected related namespaces resource to have name %q, got %q", imageregistryapiv1.ImageRegistryOperatorNamespace, obj.Name)
+			}
+		}
+	}
+	if !namespaceFound {
+		t.Error("could not find related object namespaces")
 	}
 }
 


### PR DESCRIPTION
Ensure that `openshift-image-registry` namespace is always referenced as a related object for must-gather.