### PR TITLE
OpenStack: quote passwords

### DIFF
--- a/pkg/storage/swift/swift.go
+++ b/pkg/storage/swift/swift.go
@@ -3,6 +3,7 @@ package swift
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/gophercloud/gophercloud"
@@ -89,7 +90,7 @@ func GetConfig(listers *regopclient.Listers) (*Swift, error) {
 			if cloud, ok := clouds.Clouds[cloudName]; ok {
 				cfg.AuthURL = cloud.AuthInfo.AuthURL
 				cfg.Username = cloud.AuthInfo.Username
-				cfg.Password = cloud.AuthInfo.Password
+				cfg.Password = strconv.Quote(cloud.AuthInfo.Password)
 				cfg.Tenant = cloud.AuthInfo.ProjectName
 				cfg.TenantID = cloud.AuthInfo.ProjectID
 				cfg.Domain = cloud.AuthInfo.DomainName


### PR DESCRIPTION
OpenStack passwords can contain special characters and therefore must be quoted to prevent yaml parsing errors.

Fixes: https://github.com/openshift/installer/issues/2392