### PR TITLE
DEVEXP-419: Bootstrapping operator as Removed on BareMetal.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ test-unit: verify
 .PHONY: test-unit
 
 test-e2e:
-	./hack/test-go.sh -count 1 -timeout 30m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/
+	./hack/test-go.sh -count 1 -timeout 2h -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/
 .PHONY: test-e2e
 
 verify: verify-crd verify-fmt verify-sec

--- a/manifests/09-prometheus-rules.yaml
+++ b/manifests/09-prometheus-rules.yaml
@@ -17,3 +17,14 @@ spec:
         message: |
           Image Registry Storage configuration has changed in the last 30
           minutes. This change may have caused data loss.
+    - alert: ImageRegistryRemoved
+      expr: cluster_operator_conditions{name="image-registry",condition="Available",reason="Removed"} > 0
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        message: |
+          Image Registry has been removed. ImageStreamTags, BuildConfigs and
+          DeploymentConfigs which reference ImageStreamTags may not work as
+          expected. Please configure storage and update the config to Managed
+          state by editing configs.imageregistry.operator.openshift.io.

--- a/pkg/resource/clusteroperator.go
+++ b/pkg/resource/clusteroperator.go
@@ -28,13 +28,19 @@ type generatorClusterOperator struct {
 	configClient configset.ConfigV1Interface
 }
 
-func newGeneratorClusterOperator(deployLister appslisters.DeploymentNamespaceLister, configLister configlisters.ClusterOperatorLister, configClient configset.ConfigV1Interface, cr *imageregistryv1.Config, mutators []Mutator) *generatorClusterOperator {
+func newGeneratorClusterOperator(
+	deployLister appslisters.DeploymentNamespaceLister,
+	configLister configlisters.ClusterOperatorLister,
+	configClient configset.ConfigV1Interface,
+	cr *imageregistryv1.Config,
+	mutators []Mutator,
+) *generatorClusterOperator {
 	return &generatorClusterOperator{
-		mutators:     mutators,
-		cr:           cr,
 		deployLister: deployLister,
 		configLister: configLister,
 		configClient: configClient,
+		cr:           cr,
+		mutators:     mutators,
 	}
 }
 

--- a/pkg/resource/generator.go
+++ b/pkg/resource/generator.go
@@ -296,7 +296,13 @@ func (g *Generator) Remove(cr *imageregistryv1.Config) error {
 }
 
 func (g *Generator) ApplyClusterOperator(cr *imageregistryv1.Config) error {
-	gen := newGeneratorClusterOperator(g.listers.Deployments, g.listers.ClusterOperators, g.clients.Config, cr, nil)
+	gen := newGeneratorClusterOperator(
+		g.listers.Deployments,
+		g.listers.ClusterOperators,
+		g.clients.Config,
+		cr,
+		nil,
+	)
 
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		o, err := gen.Get()

--- a/test/e2e/baremetal_test.go
+++ b/test/e2e/baremetal_test.go
@@ -23,30 +23,19 @@ func TestBaremetalDefaults(t *testing.T) {
 
 	// Start of the meaningful part
 	defer framework.MustRemoveImageRegistry(t, client)
+
 	framework.MustDeployImageRegistry(t, client, nil)
 	cr := framework.MustEnsureImageRegistryIsProcessed(t, client)
-	conds := framework.GetImageRegistryConditions(cr)
-	if !conds.Degraded.IsTrue() {
-		t.Errorf("the operator is expected to be degraded, got: %s", conds)
-	}
-	if want := "StorageNotConfigured"; conds.Degraded.Reason() != want {
-		t.Errorf("degraded reason: got %q, want %q", conds.Degraded.Reason(), want)
-	}
+	framework.MustEnsureClusterOperatorStatusIsNormal(t, client)
 
-	clusterOperator := framework.MustEnsureClusterOperatorStatusIsSet(t, client)
-	for _, cond := range clusterOperator.Status.Conditions {
-		switch cond.Type {
-		case configapiv1.OperatorAvailable:
-			if cond.Status != configapiv1.ConditionFalse {
-				t.Errorf("expected clusteroperator to report Available=%s, got %s", configapiv1.ConditionFalse, cond.Status)
-			}
-		case configapiv1.OperatorDegraded:
-			if cond.Status != configapiv1.ConditionTrue {
-				t.Errorf("expected clusteroperator to report Degraded=%s, got %s", configapiv1.ConditionTrue, cond.Status)
-			}
-			if cond.Reason != "StorageNotConfigured" {
-				t.Errorf("expected clusteroprator degraded status reason to be %s, got %s", "StorageNotConfigured", cond.Reason)
-			}
-		}
+	conds := framework.GetImageRegistryConditions(cr)
+	if conds.Available.Reason() != "Removed" {
+		t.Errorf("exp Available reason: Removed, got %s", conds.Available.Reason())
+	}
+	if conds.Degraded.Reason() != "Removed" {
+		t.Errorf("exp Degraded reason: Removed, got %s", conds.Degraded.Reason())
+	}
+	if conds.Progressing.Reason() != "Removed" {
+		t.Errorf("exp Progressing reason: Removed, got %s", conds.Progressing.Reason())
 	}
 }


### PR DESCRIPTION
If we detect that the platform we are bootstrapping on is bare metal we
set management state to "Removed". We still report ourselves as "Available"
but with "Reason" set to "Removed".