### PR TITLE
Remove CGO_ENABLED=0 from build script

### DIFF
--- a/hack/build/build.sh
+++ b/hack/build/build.sh
@@ -17,4 +17,4 @@ BUILD_PATH="${REPO_PATH}/cmd/${PROJECT_NAME}"
 VERSION="$(git describe --tags --always --dirty)"
 GO_LDFLAGS="-X ${REPO_PATH}/version.Version=${VERSION}"
 echo "building ${PROJECT_NAME}..."
-CGO_ENABLED=0 go build -o ${BIN_DIR}/${PROJECT_NAME} -ldflags "${GO_LDFLAGS}" ${BUILD_PATH}
+go build -o ${BIN_DIR}/${PROJECT_NAME} -ldflags "${GO_LDFLAGS}" ${BUILD_PATH}


### PR DESCRIPTION
Similarly to openshift/console#2353, cluster-image-registry-operator has
`CGO_ENABLED=0` passed to `go build`. This is most likely a leftover
from time when image was based on alpine. As this is no longer the case,
this commit removes it.

The context of this change is a try to enable kuryr-kubernetes as SDN
for OpenShift clusters. To do so, DNS resolvers of pods running on the
cluster should support `use-vc` option in `resolv.conf`. `CGO_ENABLED=0`
forces usage of golang's internal implementation of a resolver that
doesn't support that option until golang 1.13. Removing it will make
image-registry-operator use libc resolver, which is honoring the option
and make sure that underlying OpenStack cloud URL is resolved correctly.

Deeper context of this is that OpenStack Octavia in version we're aiming
to support is not allowing UDP loadbalancer listeners, meaning that we
need to rely on TCP even for DNS. I know, that's quite crazy, but this
change should not have any effect for the image-registry-operator.