### PR TITLE
[4.2] Bug 1759159: Reset storage when swapping back end type

### DIFF
--- a/pkg/storage/azure/azure.go
+++ b/pkg/storage/azure/azure.go
@@ -419,7 +419,9 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 		}
 
 		cr.Status.StorageManaged = false
-		cr.Status.Storage.Azure = d.Config.DeepCopy()
+		cr.Status.Storage = imageregistryv1.ImageRegistryConfigStorage{
+			Azure: d.Config.DeepCopy(),
+		}
 		util.UpdateCondition(cr, imageregistryv1.StorageExists, operatorapiv1.ConditionTrue, storageExistsReasonUserManaged, "Storage is managed by the user")
 	} else {
 		// IPI
@@ -444,7 +446,9 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 					}
 					d.Config.AccountName = accountName
 					cr.Status.StorageManaged = true
-					cr.Status.Storage.Azure = d.Config.DeepCopy()
+					cr.Status.Storage = imageregistryv1.ImageRegistryConfigStorage{
+						Azure: d.Config.DeepCopy(),
+					}
 					cr.Spec.Storage.Azure = d.Config.DeepCopy()
 					break
 				}
@@ -465,7 +469,9 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 					return err
 				}
 				cr.Status.StorageManaged = true
-				cr.Status.Storage.Azure = d.Config.DeepCopy()
+				cr.Status.Storage = imageregistryv1.ImageRegistryConfigStorage{
+					Azure: d.Config.DeepCopy(),
+				}
 			}
 		}
 
@@ -477,7 +483,9 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 		}
 
 		if len(d.Config.Container) != 0 && containerExists {
-			cr.Status.Storage.Azure = d.Config.DeepCopy()
+			cr.Status.Storage = imageregistryv1.ImageRegistryConfigStorage{
+				Azure: d.Config.DeepCopy(),
+			}
 			util.UpdateCondition(cr, imageregistryv1.StorageExists, operatorapiv1.ConditionTrue, storageExistsReasonContainerExists, "Azure container exists")
 			return nil
 		}
@@ -520,7 +528,9 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 				}
 			}
 			cr.Status.StorageManaged = true
-			cr.Status.Storage.Azure = d.Config.DeepCopy()
+			cr.Status.Storage = imageregistryv1.ImageRegistryConfigStorage{
+				Azure: d.Config.DeepCopy(),
+			}
 			cr.Spec.Storage.Azure = d.Config.DeepCopy()
 			util.UpdateCondition(cr, imageregistryv1.StorageExists, operatorapiv1.ConditionTrue, storageExistsReasonContainerExists, "Storage container exists")
 

--- a/pkg/storage/emptydir/emptydir.go
+++ b/pkg/storage/emptydir/emptydir.go
@@ -72,7 +72,9 @@ func (d *driver) StorageChanged(cr *imageregistryv1.Config) bool {
 
 func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 	if !reflect.DeepEqual(cr.Status.Storage.EmptyDir, cr.Spec.Storage.EmptyDir) {
-		cr.Status.Storage.EmptyDir = d.Config.DeepCopy()
+		cr.Status.Storage = imageregistryv1.ImageRegistryConfigStorage{
+			EmptyDir: d.Config.DeepCopy(),
+		}
 		util.UpdateCondition(cr, imageregistryv1.StorageExists, operatorapi.ConditionTrue, "Creation Successful", "EmptyDir storage successfully created")
 	}
 

--- a/pkg/storage/gcs/gcs.go
+++ b/pkg/storage/gcs/gcs.go
@@ -229,7 +229,9 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 	}
 	if len(d.Config.Bucket) != 0 && bucketExists {
 		bucket = gclient.Bucket(d.Config.Bucket)
-		cr.Status.Storage.GCS = d.Config.DeepCopy()
+		cr.Status.Storage = imageregistryv1.ImageRegistryConfigStorage{
+			GCS: d.Config.DeepCopy(),
+		}
 		util.UpdateCondition(cr, imageregistryv1.StorageExists, operatorapi.ConditionTrue, "GCS Bucket Exists", "User supplied GCS bucket exists and is accessible")
 
 	} else {
@@ -255,7 +257,9 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 				}
 			}
 			cr.Status.StorageManaged = true
-			cr.Status.Storage.GCS = d.Config.DeepCopy()
+			cr.Status.Storage = imageregistryv1.ImageRegistryConfigStorage{
+				GCS: d.Config.DeepCopy(),
+			}
 			cr.Spec.Storage.GCS = d.Config.DeepCopy()
 
 			util.UpdateCondition(cr, imageregistryv1.StorageExists, operatorapi.ConditionTrue, "Creation Successful", "GCS bucket was successfully created")
@@ -290,13 +294,17 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 				}
 			} else {
 				util.UpdateCondition(cr, imageregistryv1.StorageEncrypted, operatorapi.ConditionTrue, "Encryption Successful", "KMS encryption was successfully enabled on the GCS bucket")
-				cr.Status.Storage.GCS = d.Config.DeepCopy()
+				cr.Status.Storage = imageregistryv1.ImageRegistryConfigStorage{
+					GCS: d.Config.DeepCopy(),
+				}
 				cr.Spec.Storage.GCS = d.Config.DeepCopy()
 			}
 		}
 	} else {
 		if !reflect.DeepEqual(cr.Status.Storage.GCS, d.Config) {
-			cr.Status.Storage.GCS = d.Config.DeepCopy()
+			cr.Status.Storage = imageregistryv1.ImageRegistryConfigStorage{
+				GCS: d.Config.DeepCopy(),
+			}
 		}
 	}
 
@@ -324,7 +332,9 @@ func (d *driver) RemoveStorage(cr *imageregistryv1.Config) (bool, error) {
 	d.Config.Bucket = ""
 
 	if !reflect.DeepEqual(cr.Status.Storage.GCS, d.Config) {
-		cr.Status.Storage.GCS = d.Config.DeepCopy()
+		cr.Status.Storage = imageregistryv1.ImageRegistryConfigStorage{
+			GCS: d.Config.DeepCopy(),
+		}
 	}
 
 	util.UpdateCondition(cr, imageregistryv1.StorageExists, operatorapi.ConditionFalse, "GCS Bucket Deleted", "The GCS bucket has been removed.")

--- a/pkg/storage/pvc/pvc.go
+++ b/pkg/storage/pvc/pvc.go
@@ -184,7 +184,9 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 	}
 
 	cr.Status.StorageManaged = storageManaged
-	cr.Status.Storage.PVC = d.Config.DeepCopy()
+	cr.Status.Storage = imageregistryv1.ImageRegistryConfigStorage{
+		PVC: d.Config.DeepCopy(),
+	}
 	cr.Spec.Storage.PVC = d.Config.DeepCopy()
 
 	return nil

--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -350,7 +350,9 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 
 	}
 	if len(d.Config.Bucket) != 0 && bucketExists {
-		cr.Status.Storage.S3 = d.Config.DeepCopy()
+		cr.Status.Storage = imageregistryv1.ImageRegistryConfigStorage{
+			S3: d.Config.DeepCopy(),
+		}
 		util.UpdateCondition(cr, imageregistryv1.StorageExists, operatorapi.ConditionTrue, "S3 Bucket Exists", "User supplied S3 bucket exists and is accessible")
 
 	} else {
@@ -386,7 +388,9 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 				}
 			}
 			cr.Status.StorageManaged = true
-			cr.Status.Storage.S3 = d.Config.DeepCopy()
+			cr.Status.Storage = imageregistryv1.ImageRegistryConfigStorage{
+				S3: d.Config.DeepCopy(),
+			}
 			cr.Spec.Storage.S3 = d.Config.DeepCopy()
 
 			util.UpdateCondition(cr, imageregistryv1.StorageExists, operatorapi.ConditionTrue, "Creation Successful", "S3 bucket was successfully created")
@@ -431,7 +435,9 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 			}
 		} else {
 			util.UpdateCondition(cr, imageregistryv1.StoragePublicAccessBlocked, operatorapi.ConditionTrue, "Public Access Block Successful", "Public access to the S3 bucket and its contents have been successfully blocked.")
-			cr.Status.Storage.S3 = d.Config.DeepCopy()
+			cr.Status.Storage = imageregistryv1.ImageRegistryConfigStorage{
+				S3: d.Config.DeepCopy(),
+			}
 			cr.Spec.Storage.S3 = d.Config.DeepCopy()
 		}
 	}
@@ -503,12 +509,16 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 		} else {
 			util.UpdateCondition(cr, imageregistryv1.StorageEncrypted, operatorapi.ConditionTrue, "Encryption Successful", fmt.Sprintf("Default %s encryption was successfully enabled on the S3 bucket", encryptionType))
 			d.Config.Encrypt = true
-			cr.Status.Storage.S3 = d.Config.DeepCopy()
+			cr.Status.Storage = imageregistryv1.ImageRegistryConfigStorage{
+				S3: d.Config.DeepCopy(),
+			}
 			cr.Spec.Storage.S3 = d.Config.DeepCopy()
 		}
 	} else {
 		if !reflect.DeepEqual(cr.Status.Storage.S3, d.Config) {
-			cr.Status.Storage.S3 = d.Config.DeepCopy()
+			cr.Status.Storage = imageregistryv1.ImageRegistryConfigStorage{
+				S3: d.Config.DeepCopy(),
+			}
 		}
 	}
 
@@ -600,7 +610,9 @@ func (d *driver) RemoveStorage(cr *imageregistryv1.Config) (bool, error) {
 	d.Config.Bucket = ""
 
 	if !reflect.DeepEqual(cr.Status.Storage.S3, d.Config) {
-		cr.Status.Storage.S3 = d.Config.DeepCopy()
+		cr.Status.Storage = imageregistryv1.ImageRegistryConfigStorage{
+			S3: d.Config.DeepCopy(),
+		}
 	}
 
 	util.UpdateCondition(cr, imageregistryv1.StorageExists, operatorapi.ConditionFalse, "S3 Bucket Deleted", "The S3 bucket has been removed.")

--- a/pkg/storage/swift/swift.go
+++ b/pkg/storage/swift/swift.go
@@ -404,7 +404,9 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 		util.UpdateCondition(cr, imageregistryv1.StorageExists, operatorapi.ConditionTrue, "Swift Container Created", "")
 
 		cr.Status.StorageManaged = true
-		cr.Status.Storage.Swift = d.Config.DeepCopy()
+		cr.Status.Storage = imageregistryv1.ImageRegistryConfigStorage{
+			Swift: d.Config.DeepCopy(),
+		}
 		cr.Spec.Storage.Swift = d.Config.DeepCopy()
 
 		break
@@ -433,7 +435,9 @@ func (d *driver) RemoveStorage(cr *imageregistryv1.Config) (bool, error) {
 	d.Config.Container = ""
 
 	if !reflect.DeepEqual(cr.Status.Storage.Swift, d.Config) {
-		cr.Status.Storage.Swift = d.Config.DeepCopy()
+		cr.Status.Storage = imageregistryv1.ImageRegistryConfigStorage{
+			Swift: d.Config.DeepCopy(),
+		}
 	}
 
 	util.UpdateCondition(cr, imageregistryv1.StorageExists, operatorapi.ConditionFalse, "Swift Container Deleted", "The swift container has been removed.")


### PR DESCRIPTION
When migrating from one storage to another configs/cluster Status ended up showing multiple storage configurations, for example:

```
    status:
      storage:
        emptyDir: {}
        s3:
          bucket: rmarasch-cluster-66-575tx-image-registry-us-east-1-porcoxpfplu
          encrypt: true
          keyID: ""
          region: us-east-1
          regionEndpoint: ""
 ```
  
This patch resets Storage property before running any DeepCopy(), making sure that if the storage is changed to another media we will update correctly.