### PR TITLE
WIP - Bug 1726976: Using PVC ResourceVersion when creating the deploy.

### DIFF
--- a/pkg/storage/pvc/pvc.go
+++ b/pkg/storage/pvc/pvc.go
@@ -57,8 +57,15 @@ func (d *driver) ConfigEnv() (envs []corev1.EnvVar, err error) {
 }
 
 func (d *driver) Volumes() ([]corev1.Volume, []corev1.VolumeMount, error) {
+	claim, err := d.Client.PersistentVolumeClaims(d.Namespace).Get(
+		d.Config.Claim, metav1.GetOptions{},
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	vol := corev1.Volume{
-		Name: "registry-storage",
+		Name: fmt.Sprintf("registry-storage-%s", claim.ResourceVersion),
 		VolumeSource: corev1.VolumeSource{
 			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 				ClaimName: d.Config.Claim,


### PR DESCRIPTION
If something has changed on the PVC we need to restart the deploy. This
patch makes use of PVC's resource version inside the deployment in such
a way that if the revision changes the deployment will be different.