### PR TITLE
Bug 1753778: Set Version on Operator status even if Removed.

### DIFF
--- a/pkg/resource/clusteroperator.go
+++ b/pkg/resource/clusteroperator.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 
 	appsapi "k8s.io/api/apps/v1"
@@ -217,33 +218,49 @@ func isDeploymentStatusAvailableAndUpdated(deploy *appsapi.Deployment) bool {
 		deploy.Status.UpdatedReplicas == deploy.Status.Replicas
 }
 
-func (gco *generatorClusterOperator) syncVersions(op *configapi.ClusterOperator) (modified bool, err error) {
-	deploy, err := gco.deployLister.Get(imageregistryv1.ImageRegistryName)
-	if err != nil {
-		if kerrors.IsNotFound(err) {
-			err = nil
-		}
-		return
+// syncVersions updates reported version.
+//
+// If in "Managed" state we use the version stored as a annotation on registry'
+// Deployment, if not we use RELEASE_VERSION environment variable.
+func (gco *generatorClusterOperator) syncVersions(op *configapi.ClusterOperator) (bool, error) {
+	if gco.cr == nil {
+		return false, fmt.Errorf("invalid nil configuration provided")
 	}
 
-	deploymentVersion := deploy.Annotations[imageregistryv1.VersionAnnotation]
-	if len(deploymentVersion) == 0 || !isDeploymentStatusAvailableAndUpdated(deploy) {
-		return
+	version := os.Getenv("RELEASE_VERSION")
+	if gco.cr.Spec.ManagementState == operatorapi.Managed {
+		deploy, err := gco.deployLister.Get(imageregistryv1.ImageRegistryName)
+		if err != nil {
+			if kerrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+
+		if !isDeploymentStatusAvailableAndUpdated(deploy) {
+			return false, nil
+		}
+
+		version = deploy.Annotations[imageregistryv1.VersionAnnotation]
+	}
+
+	if len(version) == 0 {
+		return false, nil
 	}
 
 	newVersions := []configapi.OperandVersion{
 		{
 			Name:    "operator",
-			Version: deploymentVersion,
+			Version: version,
 		},
 	}
 
-	if !reflect.DeepEqual(op.Status.Versions, newVersions) {
-		op.Status.Versions = newVersions
-		modified = true
+	if reflect.DeepEqual(op.Status.Versions, newVersions) {
+		return false, nil
 	}
 
-	return
+	op.Status.Versions = newVersions
+	return true, nil
 }
 
 func (gco *generatorClusterOperator) syncRelatedObjects(op *configapi.ClusterOperator) (modified bool) {

--- a/pkg/resource/clusteroperator_test.go
+++ b/pkg/resource/clusteroperator_test.go
@@ -1,0 +1,278 @@
+package resource
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	imregv1 "github.com/openshift/cluster-image-registry-operator/pkg/apis/imageregistry/v1"
+
+	cfgapi "github.com/openshift/api/config/v1"
+	operatorapi "github.com/openshift/api/operator/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	kerror "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	labels "k8s.io/apimachinery/pkg/labels"
+)
+
+type deployLister struct {
+	deploys   map[string]appsv1.Deployment
+	failOnGet bool
+}
+
+func (d deployLister) Get(name string) (*appsv1.Deployment, error) {
+	if d.failOnGet {
+		return nil, &kerror.StatusError{
+			ErrStatus: metav1.Status{
+				Reason: metav1.StatusReasonInternalError,
+			},
+		}
+	}
+
+	deploy, ok := d.deploys[name]
+	if !ok {
+		return nil, &kerror.StatusError{
+			ErrStatus: metav1.Status{
+				Reason: metav1.StatusReasonNotFound,
+			},
+		}
+	}
+	return &deploy, nil
+}
+
+func (d deployLister) List(selector labels.Selector) ([]*appsv1.Deployment, error) {
+	return nil, nil
+}
+
+func TestSyncVersions(t *testing.T) {
+	lister := deployLister{}
+	co := &cfgapi.ClusterOperator{}
+
+	for _, tt := range []struct {
+		name         string
+		environ      map[string]string
+		deploys      map[string]appsv1.Deployment
+		versions     []cfgapi.OperandVersion
+		modified     bool
+		expectsError bool
+		failOnGet    bool
+		config       *imregv1.Config
+	}{
+		{
+			name:         "no config",
+			modified:     false,
+			expectsError: true,
+		},
+		{
+			name:         "no env and no deployment",
+			modified:     false,
+			expectsError: false,
+			config:       &imregv1.Config{},
+		},
+		{
+			name:         "an api error",
+			modified:     false,
+			expectsError: true,
+			failOnGet:    true,
+			config: &imregv1.Config{
+				Spec: imregv1.ImageRegistrySpec{
+					ManagementState: operatorapi.Managed,
+				},
+			},
+		},
+		{
+			name:         "managed with no deployment",
+			modified:     false,
+			expectsError: false,
+			config: &imregv1.Config{
+				Spec: imregv1.ImageRegistrySpec{
+					ManagementState: operatorapi.Managed,
+				},
+			},
+		},
+		{
+			name:         "managed with a not ready yet deployment",
+			modified:     false,
+			expectsError: false,
+			deploys: map[string]appsv1.Deployment{
+				imregv1.ImageRegistryName: {
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							imregv1.VersionAnnotation: "1",
+						},
+					},
+				},
+			},
+			config: &imregv1.Config{
+				Spec: imregv1.ImageRegistrySpec{
+					ManagementState: operatorapi.Managed,
+				},
+			},
+		},
+		{
+			name:         "deployment rollout succeeded",
+			modified:     true,
+			expectsError: false,
+			environ: map[string]string{
+				"RELEASE_VERSION": "2",
+			},
+			deploys: map[string]appsv1.Deployment{
+				imregv1.ImageRegistryName: {
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							imregv1.VersionAnnotation: "1",
+						},
+					},
+					Status: appsv1.DeploymentStatus{
+						AvailableReplicas: 1,
+					},
+				},
+			},
+			versions: []cfgapi.OperandVersion{
+				{
+					Name:    "operator",
+					Version: "1",
+				},
+			},
+			config: &imregv1.Config{
+				Spec: imregv1.ImageRegistrySpec{
+					ManagementState: operatorapi.Managed,
+				},
+			},
+		},
+		{
+			name:         "update to the same version",
+			modified:     false,
+			expectsError: false,
+			environ: map[string]string{
+				"RELEASE_VERSION": "2",
+			},
+			deploys: map[string]appsv1.Deployment{
+				imregv1.ImageRegistryName: {
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							imregv1.VersionAnnotation: "1",
+						},
+					},
+					Status: appsv1.DeploymentStatus{
+						AvailableReplicas: 1,
+					},
+				},
+			},
+			versions: []cfgapi.OperandVersion{
+				{
+					Name:    "operator",
+					Version: "1",
+				},
+			},
+			config: &imregv1.Config{
+				Spec: imregv1.ImageRegistrySpec{
+					ManagementState: operatorapi.Managed,
+				},
+			},
+		},
+		{
+			name:         "removed management state",
+			modified:     true,
+			expectsError: false,
+			environ: map[string]string{
+				"RELEASE_VERSION": "3",
+			},
+			deploys: map[string]appsv1.Deployment{
+				imregv1.ImageRegistryName: {
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							imregv1.VersionAnnotation: "1",
+						},
+					},
+					Status: appsv1.DeploymentStatus{
+						AvailableReplicas: 1,
+					},
+				},
+			},
+			versions: []cfgapi.OperandVersion{
+				{
+					Name:    "operator",
+					Version: "3",
+				},
+			},
+			config: &imregv1.Config{
+				Spec: imregv1.ImageRegistrySpec{
+					ManagementState: operatorapi.Removed,
+				},
+			},
+		},
+		{
+			name:         "unmanaged management state",
+			modified:     true,
+			expectsError: false,
+			environ: map[string]string{
+				"RELEASE_VERSION": "4",
+			},
+			deploys: map[string]appsv1.Deployment{
+				imregv1.ImageRegistryName: {
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							imregv1.VersionAnnotation: "1",
+						},
+					},
+					Status: appsv1.DeploymentStatus{
+						AvailableReplicas: 1,
+					},
+				},
+			},
+			versions: []cfgapi.OperandVersion{
+				{
+					Name:    "operator",
+					Version: "4",
+				},
+			},
+			config: &imregv1.Config{
+				Spec: imregv1.ImageRegistrySpec{
+					ManagementState: operatorapi.Unmanaged,
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				for name := range tt.environ {
+					os.Unsetenv(name)
+				}
+			}()
+
+			for name, val := range tt.environ {
+				os.Setenv(name, val)
+			}
+
+			lister.deploys, lister.failOnGet = tt.deploys, tt.failOnGet
+			gen := newGeneratorClusterOperator(
+				lister, nil, nil, tt.config, nil,
+			)
+
+			modified, err := gen.syncVersions(co)
+			if err == nil && tt.expectsError {
+				t.Errorf("expecting error, nil received")
+				return
+			} else if err != nil && !tt.expectsError {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if modified != tt.modified {
+				t.Errorf(
+					"expected modified %v, received %v instead",
+					tt.modified, modified,
+				)
+				return
+			}
+
+			if !reflect.DeepEqual(co.Status.Versions, tt.versions) {
+				t.Errorf(
+					"versions mismatch, expected: %v, received: %v",
+					tt.versions, co.Status.Versions,
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This patch uses the environment variable RELEASE_VERSION to set Operator
version if ManagementState is not "Managed". This is introduced now as we
may, in some situations, bootstrap the Image Registry Operator with Removed
ManagementState.