### PR TITLE
Bug 1750675: Validating Azure container name.

### DIFF
--- a/manifests/00-crd.yaml
+++ b/manifests/00-crd.yaml
@@ -165,6 +165,9 @@ spec:
                     accountName:
                       type: string
                     container:
+                      maxLength: 63
+                      minLength: 3
+                      pattern: ^[0-9a-z]+(-[0-9a-z]+)*$
                       type: string
                   type: object
                 emptyDir:
@@ -410,6 +413,9 @@ spec:
                     accountName:
                       type: string
                     container:
+                      maxLength: 63
+                      minLength: 3
+                      pattern: ^[0-9a-z]+(-[0-9a-z]+)*$
                       type: string
                   type: object
                 emptyDir:

--- a/pkg/apis/imageregistry/v1/types.go
+++ b/pkg/apis/imageregistry/v1/types.go
@@ -282,6 +282,9 @@ type ImageRegistryConfigStorageAzure struct {
 	// +optional
 	AccountName string `json:"accountName"`
 	// +optional
+	// +kubebuilder:validation:Pattern=`^[0-9a-z]+(-[0-9a-z]+)*$`
+	// +kubebuilder:validation:MinLength=3
+	// +kubebuilder:validation:MaxLength=63
 	Container string `json:"container"`
 }
 


### PR DESCRIPTION
Added pattern, min and max length for a valid Azure container name.

According to Azure documentation, "a container name must be a valid DNS name, conforming to the following naming rules":

1. Container names must start with a letter or number, and can contain only letters, numbers, and the dash (-) character.
2. Every dash (-) character must be immediately preceded and followed by a letter or number; consecutive dashes are not permitted in container names.
3. All letters in a container name must be lowercase.
4. Container names must be from 3 through 63 characters long.

https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata