### PR TITLE
WIP - Bug 1785302: Setting preserveUnknownFields.

### DIFF
--- a/manifests/00-crd.yaml
+++ b/manifests/00-crd.yaml
@@ -11,6 +11,7 @@ spec:
     listKind: ConfigList
     plural: configs
     singular: config
+  preserveUnknownFields: false
   subresources:
     status: {}
   validation:


### PR DESCRIPTION
This patch adds the property preserveUnknownFields set to false on the
CRD definition. Without this field `oc explain` command does not present
the user with the documentation.