### PR TITLE
Start using rolloutStrategy parameter

### DIFF
--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -11,6 +11,7 @@ import (
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	operatorapi "github.com/openshift/api/operator/v1"
 	regopset "github.com/openshift/client-go/imageregistry/clientset/versioned/typed/imageregistry/v1"
+	appsapi "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
@@ -72,6 +73,7 @@ func (c *Controller) Bootstrap() error {
 			Storage:         imageregistryv1.ImageRegistryConfigStorage{},
 			Replicas:        1,
 			HTTPSecret:      fmt.Sprintf("%x", string(secretBytes[:])),
+			RolloutStrategy: string(appsapi.RollingUpdateDeploymentStrategyType),
 		},
 		Status: imageregistryv1.ImageRegistryStatus{},
 	}

--- a/pkg/resource/deployment.go
+++ b/pkg/resource/deployment.go
@@ -82,6 +82,12 @@ func (gd *generatorDeployment) expected() (runtime.Object, error) {
 	}
 	podTemplateSpec.Annotations[parameters.ChecksumOperatorDepsAnnotation] = depsChecksum
 
+	// Strategy defaults to RollingUpdate
+	strategy := gd.cr.Spec.RolloutStrategy
+	if strategy == "" {
+		strategy = string(appsapi.RollingUpdateDeploymentStrategyType)
+	}
+
 	deploy := &appsapi.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      gd.GetName(),
@@ -97,6 +103,9 @@ func (gd *generatorDeployment) expected() (runtime.Object, error) {
 				MatchLabels: gd.params.Deployment.Labels,
 			},
 			Template: podTemplateSpec,
+			Strategy: appsapi.DeploymentStrategy{
+				Type: appsapi.DeploymentStrategyType(strategy),
+			},
 		},
 	}
 


### PR DESCRIPTION
This parameter allows to define rollout strategy for the image registry deployment.
Now support two possible rollout strategies: RollingUpdate (default) and Recreate.

The parameter was introduced by https://github.com/openshift/api/pull/560