### PR TITLE
Add support for OpenStack clouds with self-signed certificates

### DIFF
--- a/pkg/resource/caconfig.go
+++ b/pkg/resource/caconfig.go
@@ -118,6 +118,17 @@ func (gcac *generatorCAConfig) expected() (runtime.Object, error) {
 		}
 	}
 
+	cp_ca, err := gcac.openshiftConfigLister.Get("cloud-provider-config")
+	if errors.IsNotFound(err) {
+		klog.Infof("missing the cloud-provider-config configmap: %s", err)
+	} else if err != nil {
+		return cm, err
+	} else {
+		if cert, ok := cp_ca.Data["ca-bundle.pem"]; ok {
+			cm.Data["cloud-provider-ca-bundle.pem"] = cert
+		}
+	}
+
 	return cm, nil
 }
 

--- a/pkg/storage/swift/swift.go
+++ b/pkg/storage/swift/swift.go
@@ -1,7 +1,10 @@
 package swift
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
+	"net/http"
 	"reflect"
 	"strconv"
 	"strings"
@@ -128,6 +131,14 @@ func GetConfig(listers *regopclient.Listers) (*Swift, error) {
 	return cfg, nil
 }
 
+func getCloudProviderCert(listers *regopclient.Listers) (string, error) {
+	cm, err := listers.OpenShiftConfig.Get("cloud-provider-config")
+	if err != nil {
+		return "", err
+	}
+	return string(cm.Data["ca-bundle.pem"]), nil
+}
+
 // getSwiftClient returns a client that allows to interact with the OpenStack Swift service
 func (d *driver) getSwiftClient(cr *imageregistryv1.Config) (*gophercloud.ServiceClient, error) {
 	cfg, err := GetConfig(d.Listers)
@@ -154,9 +165,35 @@ func (d *driver) getSwiftClient(cr *imageregistryv1.Config) (*gophercloud.Servic
 		TenantName:       d.Config.Tenant,
 	}
 
-	provider, err := openstack.AuthenticatedClient(*opts)
+	provider, err := openstack.NewClient(opts.IdentityEndpoint)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Create new provider client failed: %v", err)
+	}
+
+	cert, err := getCloudProviderCert(d.Listers)
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, fmt.Errorf("Failed to get cloud provider CA certificate: %v", err)
+	}
+
+	if cert != "" {
+		certPool, err := x509.SystemCertPool()
+		if err != nil {
+			return nil, fmt.Errorf("Create system cert pool failed: %v", err)
+		}
+		certPool.AppendCertsFromPEM([]byte(cert))
+		client := http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					RootCAs: certPool,
+				},
+			},
+		}
+		provider.HTTPClient = client
+	}
+
+	err = openstack.Authenticate(provider, *opts)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to authenticate provider client: %v", err)
 	}
 
 	endpointOpts := gophercloud.EndpointOpts{

--- a/pkg/storage/swift/swift_test.go
+++ b/pkg/storage/swift/swift_test.go
@@ -32,6 +32,8 @@ const (
 
 	upiSecretName = "image-registry-private-configuration-user"
 	ipiSecretName = "installer-cloud-credentials"
+
+	cloudProviderConfigMapName = "cloud-provider-config"
 )
 
 var (
@@ -40,7 +42,8 @@ var (
 		"REGISTRY_STORAGE_SWIFT_USERNAME": []byte(username),
 		"REGISTRY_STORAGE_SWIFT_PASSWORD": []byte(password),
 	}
-	fakeCloudsYAML map[string][]byte
+	fakeCloudsYAML             map[string][]byte
+	fakeCloudProviderConfigMap map[string]string
 )
 
 type MockSecretNamespaceLister interface {
@@ -95,6 +98,32 @@ func (m MockIPISecretNamespaceLister) List(selector labels.Selector) ([]*corev1.
 	return []*corev1.Secret{
 		{
 			Data: fakeCloudsYAML,
+		},
+	}, nil
+}
+
+type MockConfigMapNamespaceLister struct{}
+
+func (m MockConfigMapNamespaceLister) Get(name string) (*corev1.ConfigMap, error) {
+	if name == cloudProviderConfigMapName {
+		return &corev1.ConfigMap{
+			Data: fakeCloudProviderConfigMap,
+		}, nil
+	}
+
+	return nil, &k8serrors.StatusError{metav1.Status{
+		Status:  metav1.StatusFailure,
+		Code:    http.StatusNotFound,
+		Reason:  metav1.StatusReasonNotFound,
+		Details: &metav1.StatusDetails{},
+		Message: fmt.Sprintf("No config map with name %v was found", name),
+	}}
+}
+
+func (m MockConfigMapNamespaceLister) List(selector labels.Selector) ([]*corev1.ConfigMap, error) {
+	return []*corev1.ConfigMap{
+		{
+			Data: fakeCloudProviderConfigMap,
 		},
 	}, nil
 }
@@ -183,6 +212,7 @@ func mockConfig(includeStatus bool, endpoint string, secretLister MockSecretName
 		Listers: &regopclient.Listers{
 			Secrets:         secretLister,
 			Infrastructures: fakeInfrastructureLister(cloudName),
+			OpenShiftConfig: MockConfigMapNamespaceLister{},
 		},
 		Config: &config,
 	}
@@ -305,6 +335,7 @@ func TestSwiftSecrets(t *testing.T) {
 		Listers: &regopclient.Listers{
 			Secrets:         MockUPISecretNamespaceLister{},
 			Infrastructures: fakeInfrastructureLister(cloudName),
+			OpenShiftConfig: MockConfigMapNamespaceLister{},
 		},
 		Config: &config,
 	}
@@ -325,6 +356,7 @@ func TestSwiftSecrets(t *testing.T) {
 		Listers: &regopclient.Listers{
 			Secrets:         MockIPISecretNamespaceLister{},
 			Infrastructures: fakeInfrastructureLister(customCloud),
+			OpenShiftConfig: MockConfigMapNamespaceLister{},
 		},
 		Config: &config,
 	}


### PR DESCRIPTION
In the case where OpenStack in deployed with self-signed certificates, we need to initiate the connection to swift using a custom CA certificate.

Let's look for the `ca-bundle.pem` entry in the `openshift-config/cloud-provider-config` config map and use it to initiate the connection if it is provided.

Related to https://github.com/openshift/installer/pull/2932