### PR TITLE
Use Recreate strategy for operator's deployment

### DIFF
--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -8,6 +8,8 @@ metadata:
     config.openshift.io/inject-proxy: cluster-image-registry-operator 
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       name: cluster-image-registry-operator

--- a/test/framework/logs.go
+++ b/test/framework/logs.go
@@ -45,20 +45,13 @@ func (psl PodSetLogs) Contains(re *regexp.Regexp) bool {
 }
 
 func GetLogsByLabelSelector(client *Clientset, namespace string, labelSelector *metav1.LabelSelector) (PodSetLogs, error) {
-	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
-	if err != nil {
-		return nil, err
-	}
-
-	podList, err := client.Pods(namespace).List(metav1.ListOptions{
-		LabelSelector: selector.String(),
-	})
+	pods, err := getPodsByLabelSelector(client, namespace, labelSelector)
 	if err != nil {
 		return nil, err
 	}
 
 	podLogs := make(PodSetLogs)
-	for _, pod := range podList.Items {
+	for _, pod := range pods {
 		podLog := make(PodLog)
 		for _, container := range pod.Spec.Containers {
 			var containerLog ContainerLog

--- a/test/framework/operator.go
+++ b/test/framework/operator.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -44,6 +45,14 @@ func StopDeployment(logger Logger, client *Clientset, operatorDeploymentName, op
 			return false, err
 		}
 		return deploy.Status.Replicas == 0, nil
+	})
+}
+
+func getOperatorPods(client *Clientset) ([]corev1.Pod, error) {
+	return getPodsByLabelSelector(client, OperatorDeploymentNamespace, &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"name": "cluster-image-registry-operator",
+		},
 	})
 }
 

--- a/test/framework/pods.go
+++ b/test/framework/pods.go
@@ -1,0 +1,22 @@
+package framework
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func getPodsByLabelSelector(client *Clientset, namespace string, labelSelector *metav1.LabelSelector) ([]corev1.Pod, error) {
+	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
+	if err != nil {
+		return nil, err
+	}
+
+	podList, err := client.Pods(namespace).List(metav1.ListOptions{
+		LabelSelector: selector.String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return podList.Items, nil
+}


### PR DESCRIPTION
When the operator's deployment gets changed, we don't want to have two instances of the operator at the same time: 1 replica (old) -> 2 replicas (old and new) -> 1 replica (new). As we don't have leader election and we want to be more predictable behaviour in our e2e tests, it's better to upgrade through scaling down: 1 replica (old) -> 0 replicas -> 1 replica (new).