### PR TITLE
TestEnv wrapper around testing.T

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -286,6 +286,9 @@ func (c *Controller) syncStatus(cr *imageregistryv1.Config, deploy *appsapi.Depl
 		operatorDegraded.Status = operatorapiv1.ConditionTrue
 		operatorDegraded.Message = applyError.Error()
 		operatorDegraded.Reason = e.Reason
+	} else if cr.Spec.ManagementState == operatorapiv1.Removed {
+		operatorDegraded.Message = "The registry is removed"
+		operatorDegraded.Reason = "Removed"
 	}
 
 	updateCondition(cr, operatorapiv1.OperatorStatusTypeDegraded, operatorDegraded)

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -67,7 +67,7 @@ func TestAWSDefaults(t *testing.T) {
 
 	// TODO: Move these checks to a conformance test run on all providers
 	framework.DeployImageRegistry(te, nil)
-	framework.EnsureImageRegistryIsAvailable(te)
+	framework.WaitUntilImageRegistryIsAvailable(te)
 	framework.EnsureInternalRegistryHostnameIsSet(te)
 	framework.EnsureClusterOperatorStatusIsNormal(te)
 	framework.EnsureOperatorIsNotHotLooping(te)
@@ -354,7 +354,7 @@ func TestAWSUnableToCreateBucketOnStartup(t *testing.T) {
 	// Wait for the image registry resource to have an updated StorageExists condition
 	framework.ConditionExistsWithStatusAndReason(te, defaults.StorageExists, operatorapi.ConditionTrue, "S3 Bucket Exists")
 
-	framework.EnsureImageRegistryIsAvailable(te)
+	framework.WaitUntilImageRegistryIsAvailable(te)
 	framework.EnsureInternalRegistryHostnameIsSet(te)
 	framework.EnsureClusterOperatorStatusIsNormal(te)
 }
@@ -388,7 +388,7 @@ func TestAWSUpdateCredentials(t *testing.T) {
 	}
 
 	framework.DeployImageRegistry(te, nil)
-	framework.EnsureImageRegistryIsAvailable(te)
+	framework.WaitUntilImageRegistryIsAvailable(te)
 	framework.EnsureInternalRegistryHostnameIsSet(te)
 	framework.EnsureClusterOperatorStatusIsNormal(te)
 
@@ -425,7 +425,7 @@ func TestAWSUpdateCredentials(t *testing.T) {
 	// Wait for the image registry resource to have an updated StorageExists condition
 	framework.ConditionExistsWithStatusAndReason(te, defaults.StorageExists, operatorapi.ConditionTrue, "S3 Bucket Exists")
 
-	framework.EnsureImageRegistryIsAvailable(te)
+	framework.WaitUntilImageRegistryIsAvailable(te)
 	framework.EnsureInternalRegistryHostnameIsSet(te)
 	framework.EnsureClusterOperatorStatusIsNormal(te)
 }
@@ -459,7 +459,7 @@ func TestAWSChangeS3Encryption(t *testing.T) {
 	}
 
 	framework.DeployImageRegistry(te, nil)
-	framework.EnsureImageRegistryIsAvailable(te)
+	framework.WaitUntilImageRegistryIsAvailable(te)
 	framework.EnsureInternalRegistryHostnameIsSet(te)
 	framework.EnsureClusterOperatorStatusIsNormal(te)
 
@@ -653,7 +653,7 @@ func TestAWSFinalizerDeleteS3Bucket(t *testing.T) {
 	}
 
 	framework.DeployImageRegistry(te, nil)
-	framework.EnsureImageRegistryIsAvailable(te)
+	framework.WaitUntilImageRegistryIsAvailable(te)
 	framework.EnsureInternalRegistryHostnameIsSet(te)
 	framework.EnsureClusterOperatorStatusIsNormal(te)
 

--- a/test/e2e/baremetal_test.go
+++ b/test/e2e/baremetal_test.go
@@ -25,7 +25,7 @@ func TestBaremetalAndVSphereDefaults(t *testing.T) {
 	}
 
 	framework.DeployImageRegistry(te, nil)
-	cr := framework.EnsureImageRegistryIsProcessed(te)
+	cr := framework.WaitUntilImageRegistryConfigIsProcessed(te)
 	framework.EnsureClusterOperatorStatusIsNormal(te)
 
 	conds := framework.GetImageRegistryConditions(cr)

--- a/test/e2e/baremetal_test.go
+++ b/test/e2e/baremetal_test.go
@@ -11,9 +11,10 @@ import (
 )
 
 func TestBaremetalAndVSphereDefaults(t *testing.T) {
-	client := framework.MustNewClientset(t, nil)
+	te := framework.Setup(t)
+	defer framework.TeardownImageRegistry(te)
 
-	infrastructureConfig, err := client.Infrastructures().Get("cluster", metav1.GetOptions{})
+	infrastructureConfig, err := te.Client().Infrastructures().Get("cluster", metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,12 +24,9 @@ func TestBaremetalAndVSphereDefaults(t *testing.T) {
 		t.Skip("skipping on non-BareMetal non-VSphere platform")
 	}
 
-	// Start of the meaningful part
-	defer framework.MustRemoveImageRegistry(t, client)
-
-	framework.MustDeployImageRegistry(t, client, nil)
-	cr := framework.MustEnsureImageRegistryIsProcessed(t, client)
-	framework.MustEnsureClusterOperatorStatusIsNormal(t, client)
+	framework.DeployImageRegistry(te, nil)
+	cr := framework.EnsureImageRegistryIsProcessed(te)
+	framework.EnsureClusterOperatorStatusIsNormal(te)
 
 	conds := framework.GetImageRegistryConditions(cr)
 	if conds.Available.Reason() != "Removed" {

--- a/test/e2e/emptydir_test.go
+++ b/test/e2e/emptydir_test.go
@@ -14,17 +14,15 @@ import (
 )
 
 func TestBasicEmptyDir(t *testing.T) {
-	te := framework.Setup(t)
-	defer framework.TeardownImageRegistry(te)
-
-	framework.DeployImageRegistry(te, &imageregistryv1.ImageRegistrySpec{
+	te := framework.SetupAvailableImageRegistry(t, &imageregistryv1.ImageRegistrySpec{
 		ManagementState: operatorapi.Managed,
 		Storage: imageregistryv1.ImageRegistryConfigStorage{
 			EmptyDir: &imageregistryv1.ImageRegistryConfigStorageEmptyDir{},
 		},
 		Replicas: 1,
 	})
-	framework.EnsureImageRegistryIsAvailable(te)
+	defer framework.TeardownImageRegistry(te)
+
 	framework.EnsureInternalRegistryHostnameIsSet(te)
 	framework.EnsureClusterOperatorStatusIsNormal(te)
 	framework.EnsureOperatorIsNotHotLooping(te)

--- a/test/e2e/failing_test.go
+++ b/test/e2e/failing_test.go
@@ -21,7 +21,7 @@ func TestDegraded(t *testing.T) {
 		},
 		Replicas: -1,
 	})
-	cr := framework.EnsureImageRegistryIsProcessed(te)
+	cr := framework.WaitUntilImageRegistryConfigIsProcessed(te)
 
 	var degraded operatorapi.OperatorCondition
 	for _, cond := range cr.Status.Conditions {

--- a/test/e2e/gcs_test.go
+++ b/test/e2e/gcs_test.go
@@ -92,7 +92,7 @@ func TestGCSMinimal(t *testing.T) {
 		},
 		Replicas: 1,
 	})
-	framework.EnsureImageRegistryIsAvailable(te)
+	framework.WaitUntilImageRegistryIsAvailable(te)
 	framework.EnsureInternalRegistryHostnameIsSet(te)
 	framework.EnsureClusterOperatorStatusIsSet(te)
 	framework.EnsureOperatorIsNotHotLooping(te)

--- a/test/e2e/graceful_shutdown_test.go
+++ b/test/e2e/graceful_shutdown_test.go
@@ -13,10 +13,11 @@ import (
 )
 
 func TestNodeCAGracefulShutdown(t *testing.T) {
-	client := framework.MustNewClientset(t, nil)
-	framework.MustEnsureNodeCADaemonSetIsAvailable(t, client)
+	te := framework.Setup(t)
 
-	pods, err := client.Pods(defaults.ImageRegistryOperatorNamespace).List(
+	framework.EnsureNodeCADaemonSetIsAvailable(te)
+
+	pods, err := te.Client().Pods(defaults.ImageRegistryOperatorNamespace).List(
 		metav1.ListOptions{
 			LabelSelector: "name=node-ca",
 		},
@@ -38,7 +39,7 @@ func TestNodeCAGracefulShutdown(t *testing.T) {
 
 	logch, errch := framework.MustFollowPodLog(t, pod)
 
-	if err := client.Pods(defaults.ImageRegistryOperatorNamespace).Delete(
+	if err := te.Client().Pods(defaults.ImageRegistryOperatorNamespace).Delete(
 		pod.Name,
 		&metav1.DeleteOptions{},
 	); err != nil {
@@ -73,13 +74,14 @@ func TestNodeCAGracefulShutdown(t *testing.T) {
 }
 
 func TestImageRegistryGracefulShutdown(t *testing.T) {
-	client := framework.MustNewClientset(t, nil)
-	defer framework.MustRemoveImageRegistry(t, client)
-	framework.MustDeployImageRegistry(t, client, nil)
-	framework.MustEnsureImageRegistryIsAvailable(t, client)
-	framework.MustEnsureOperatorIsNotHotLooping(t, client)
+	te := framework.Setup(t)
+	defer framework.TeardownImageRegistry(te)
 
-	pods, err := client.Pods(defaults.ImageRegistryOperatorNamespace).List(
+	framework.DeployImageRegistry(te, nil)
+	framework.EnsureImageRegistryIsAvailable(te)
+	framework.EnsureOperatorIsNotHotLooping(te)
+
+	pods, err := te.Client().Pods(defaults.ImageRegistryOperatorNamespace).List(
 		metav1.ListOptions{
 			LabelSelector: "docker-registry=default",
 		},
@@ -101,7 +103,7 @@ func TestImageRegistryGracefulShutdown(t *testing.T) {
 
 	logch, errch := framework.MustFollowPodLog(t, pod)
 
-	if err := client.Pods(defaults.ImageRegistryOperatorNamespace).Delete(
+	if err := te.Client().Pods(defaults.ImageRegistryOperatorNamespace).Delete(
 		pod.Name,
 		&metav1.DeleteOptions{},
 	); err != nil {

--- a/test/e2e/graceful_shutdown_test.go
+++ b/test/e2e/graceful_shutdown_test.go
@@ -74,11 +74,9 @@ func TestNodeCAGracefulShutdown(t *testing.T) {
 }
 
 func TestImageRegistryGracefulShutdown(t *testing.T) {
-	te := framework.Setup(t)
+	te := framework.SetupAvailableImageRegistry(t, nil)
 	defer framework.TeardownImageRegistry(te)
 
-	framework.DeployImageRegistry(te, nil)
-	framework.EnsureImageRegistryIsAvailable(te)
 	framework.EnsureOperatorIsNotHotLooping(te)
 
 	pods, err := te.Client().Pods(defaults.ImageRegistryOperatorNamespace).List(

--- a/test/e2e/imageconfig_test.go
+++ b/test/e2e/imageconfig_test.go
@@ -67,7 +67,7 @@ func TestAdditionalTrustedCA(t *testing.T) {
 		},
 		Replicas: 1,
 	})
-	framework.EnsureImageRegistryIsAvailable(te)
+	framework.WaitUntilImageRegistryIsAvailable(te)
 	framework.EnsureInternalRegistryHostnameIsSet(te)
 	framework.EnsureClusterOperatorStatusIsSet(te)
 	framework.EnsureOperatorIsNotHotLooping(te)
@@ -95,11 +95,8 @@ func TestAdditionalTrustedCA(t *testing.T) {
 }
 
 func TestSwapStorage(t *testing.T) {
-	te := framework.Setup(t)
+	te := framework.SetupAvailableImageRegistry(t, nil)
 	defer framework.TeardownImageRegistry(te)
-
-	framework.DeployImageRegistry(te, nil)
-	framework.EnsureImageRegistryIsAvailable(te)
 
 	config, err := te.Client().Configs().Get(
 		defaults.ImageRegistryResourceName,
@@ -123,7 +120,7 @@ func TestSwapStorage(t *testing.T) {
 	}
 
 	// give some room for the operator to act.
-	framework.EnsureImageRegistryIsAvailable(te)
+	framework.WaitUntilImageRegistryIsAvailable(te)
 	framework.EnsureOperatorIsNotHotLooping(te)
 
 	if config, err = te.Client().Configs().Get(

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,15 +1,25 @@
 package e2e
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
 	"github.com/openshift/cluster-image-registry-operator/test/framework"
 )
 
-type devnullLogger struct{}
+type bootstrapTestEnv struct {
+	client *framework.Clientset
+}
 
-func (_ devnullLogger) Logf(string, ...interface{}) {}
+func (te *bootstrapTestEnv) Client() *framework.Clientset      { return te.client }
+func (te *bootstrapTestEnv) Failed() bool                      { return false }
+func (te *bootstrapTestEnv) Log(...interface{})                {}
+func (te *bootstrapTestEnv) Logf(string, ...interface{})       {}
+func (te *bootstrapTestEnv) Error(a ...interface{})            { panic(fmt.Sprint(a...)) }
+func (te *bootstrapTestEnv) Errorf(f string, a ...interface{}) { panic(fmt.Sprintf(f, a...)) }
+func (te *bootstrapTestEnv) Fatal(a ...interface{})            { panic(fmt.Sprint(a...)) }
+func (te *bootstrapTestEnv) Fatalf(f string, a ...interface{}) { panic(fmt.Sprintf(f, a...)) }
 
 func TestMain(m *testing.M) {
 	if os.Getenv("KUBERNETES_CONFIG") == "" {
@@ -25,13 +35,10 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 
-	if err := framework.DisableCVOForOperator(devnullLogger{}, client); err != nil {
-		panic(err)
-	}
+	te := &bootstrapTestEnv{client: client}
 
-	if err := framework.RemoveImageRegistry(devnullLogger{}, client); err != nil {
-		panic(err)
-	}
+	framework.DisableCVOForOperator(te)
+	framework.RemoveImageRegistry(te)
 
 	os.Exit(m.Run())
 }

--- a/test/e2e/managementstate_test.go
+++ b/test/e2e/managementstate_test.go
@@ -99,6 +99,10 @@ func TestRemovedToManagedTransition(t *testing.T) {
 	te := framework.Setup(t)
 	defer framework.TeardownImageRegistry(te)
 
+	if !framework.PlatformHasDefaultStorage(te) {
+		t.Skip("skipping because the current platform does not provide default storage configuration")
+	}
+
 	t.Log("creating config with ManagementState set to Removed")
 	framework.DeployImageRegistry(te, &imageregistryv1.ImageRegistrySpec{
 		ManagementState: operatorapi.Removed,

--- a/test/e2e/managementstate_test.go
+++ b/test/e2e/managementstate_test.go
@@ -6,8 +6,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/util/retry"
 
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	operatorapi "github.com/openshift/api/operator/v1"
@@ -17,43 +17,28 @@ import (
 )
 
 func TestManagementStateUnmanaged(t *testing.T) {
-	client := framework.MustNewClientset(t, nil)
+	te := framework.Setup(t)
+	defer framework.TeardownImageRegistry(te)
 
-	defer framework.MustRemoveImageRegistry(t, client)
+	framework.DeployImageRegistry(te, nil)
+	framework.EnsureImageRegistryIsAvailable(te)
 
-	framework.MustDeployImageRegistry(t, client, &imageregistryv1.Config{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: defaults.ImageRegistryResourceName,
-		},
-		Spec: imageregistryv1.ImageRegistrySpec{
-			ManagementState: operatorapi.Managed,
-			Replicas:        1,
-		},
-	})
-	framework.MustEnsureImageRegistryIsAvailable(t, client)
-
-	var cr *imageregistryv1.Config
-	var err error
-	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		cr, err = client.Configs().Get(defaults.ImageRegistryResourceName, metav1.GetOptions{})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		cr.Spec.ManagementState = operatorapi.Unmanaged
-
-		cr, err = client.Configs().Update(cr)
-		if err != nil {
-			return err
-		}
-		return nil
-	})
-	if err != nil {
-		t.Fatal(err)
+	if _, err := te.Client().Configs().Patch(
+		defaults.ImageRegistryResourceName,
+		types.JSONPatchType,
+		framework.MarshalJSON([]framework.JSONPatch{
+			{
+				Op:    "replace",
+				Path:  "/spec/managementState",
+				Value: operatorapi.Unmanaged,
+			},
+		}),
+	); err != nil {
+		t.Fatalf("unable to switch to unmanaged state: %s", err)
 	}
 
-	err = wait.Poll(1*time.Second, framework.AsyncOperationTimeout, func() (stop bool, err error) {
-		cr, err = client.Configs().Get(defaults.ImageRegistryResourceName, metav1.GetOptions{})
+	err := wait.Poll(1*time.Second, framework.AsyncOperationTimeout, func() (stop bool, err error) {
+		cr, err := te.Client().Configs().Get(defaults.ImageRegistryResourceName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -65,50 +50,33 @@ func TestManagementStateUnmanaged(t *testing.T) {
 			conds.Degraded.IsFalse() && conds.Degraded.Reason() == "Unmanaged", nil
 	})
 	if err != nil {
-		framework.DumpImageRegistryResource(t, client)
-		framework.DumpOperatorLogs(t, client)
 		t.Fatal(err)
 	}
 }
 
 func TestManagementStateRemoved(t *testing.T) {
-	client := framework.MustNewClientset(t, nil)
+	te := framework.Setup(t)
+	defer framework.TeardownImageRegistry(te)
 
-	defer framework.MustRemoveImageRegistry(t, client)
+	framework.DeployImageRegistry(te, nil)
+	framework.EnsureImageRegistryIsAvailable(te)
 
-	framework.MustDeployImageRegistry(t, client, &imageregistryv1.Config{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: defaults.ImageRegistryResourceName,
-		},
-		Spec: imageregistryv1.ImageRegistrySpec{
-			ManagementState: operatorapi.Managed,
-			Replicas:        1,
-		},
-	})
-	framework.MustEnsureImageRegistryIsAvailable(t, client)
-
-	var cr *imageregistryv1.Config
-	var err error
-	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		cr, err = client.Configs().Get(defaults.ImageRegistryResourceName, metav1.GetOptions{})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		cr.Spec.ManagementState = operatorapi.Removed
-
-		cr, err = client.Configs().Update(cr)
-		if err != nil {
-			return err
-		}
-		return nil
-	})
-	if err != nil {
-		t.Fatal(err)
+	if _, err := te.Client().Configs().Patch(
+		defaults.ImageRegistryResourceName,
+		types.JSONPatchType,
+		framework.MarshalJSON([]framework.JSONPatch{
+			{
+				Op:    "replace",
+				Path:  "/spec/managementState",
+				Value: operatorapi.Removed,
+			},
+		}),
+	); err != nil {
+		t.Fatalf("unable to switch to removed state: %s", err)
 	}
 
-	err = wait.Poll(1*time.Second, framework.AsyncOperationTimeout, func() (stop bool, err error) {
-		cr, err = client.Configs().Get(defaults.ImageRegistryResourceName, metav1.GetOptions{})
+	err := wait.Poll(1*time.Second, framework.AsyncOperationTimeout, func() (stop bool, err error) {
+		cr, err := te.Client().Configs().Get(defaults.ImageRegistryResourceName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -121,12 +89,10 @@ func TestManagementStateRemoved(t *testing.T) {
 			conds.Removed.IsTrue(), nil
 	})
 	if err != nil {
-		framework.DumpImageRegistryResource(t, client)
-		framework.DumpOperatorLogs(t, client)
 		t.Fatal(err)
 	}
 
-	d, err := client.Deployments(defaults.ImageRegistryOperatorNamespace).Get(defaults.ImageRegistryName, metav1.GetOptions{})
+	d, err := te.Client().Deployments(defaults.ImageRegistryOperatorNamespace).Get(defaults.ImageRegistryName, metav1.GetOptions{})
 	if !errors.IsNotFound(err) {
 		t.Fatalf("deployment is expected to be removed, got %v %v", d, err)
 	}
@@ -136,19 +102,13 @@ func TestRemovedToManagedTransition(t *testing.T) {
 	var cr *imageregistryv1.Config
 	var err error
 
-	client := framework.MustNewClientset(t, nil)
-
-	defer framework.MustRemoveImageRegistry(t, client)
+	te := framework.Setup(t)
+	defer framework.TeardownImageRegistry(te)
 
 	t.Log("creating config with ManagementState set to Removed")
-	framework.MustDeployImageRegistry(t, client, &imageregistryv1.Config{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: defaults.ImageRegistryResourceName,
-		},
-		Spec: imageregistryv1.ImageRegistrySpec{
-			ManagementState: operatorapi.Removed,
-			Replicas:        1,
-		},
+	framework.DeployImageRegistry(te, &imageregistryv1.ImageRegistrySpec{
+		ManagementState: operatorapi.Removed,
+		Replicas:        1,
 	})
 
 	t.Log("make sure operator is reporting itself as Removed")
@@ -156,7 +116,7 @@ func TestRemovedToManagedTransition(t *testing.T) {
 		time.Second,
 		framework.AsyncOperationTimeout,
 		func() (stop bool, err error) {
-			cr, err = client.Configs().Get(
+			cr, err = te.Client().Configs().Get(
 				defaults.ImageRegistryResourceName,
 				metav1.GetOptions{},
 			)
@@ -175,12 +135,12 @@ func TestRemovedToManagedTransition(t *testing.T) {
 	t.Log("updating ManagementState to Managed with no storage config")
 	cr.Spec.ManagementState = operatorapi.Managed
 	cr.Spec.Storage = imageregistryv1.ImageRegistryConfigStorage{}
-	if _, err = client.Configs().Update(cr); err != nil {
+	if _, err = te.Client().Configs().Update(cr); err != nil {
 		t.Fatal(err)
 	}
 
 	t.Log("making sure image registry is up and running")
-	framework.MustEnsureImageRegistryIsAvailable(t, client)
-	framework.MustEnsureInternalRegistryHostnameIsSet(t, client)
-	framework.MustEnsureClusterOperatorStatusIsNormal(t, client)
+	framework.EnsureImageRegistryIsAvailable(te)
+	framework.EnsureInternalRegistryHostnameIsSet(te)
+	framework.EnsureClusterOperatorStatusIsNormal(te)
 }

--- a/test/e2e/managementstate_test.go
+++ b/test/e2e/managementstate_test.go
@@ -17,11 +17,8 @@ import (
 )
 
 func TestManagementStateUnmanaged(t *testing.T) {
-	te := framework.Setup(t)
+	te := framework.SetupAvailableImageRegistry(t, nil)
 	defer framework.TeardownImageRegistry(te)
-
-	framework.DeployImageRegistry(te, nil)
-	framework.EnsureImageRegistryIsAvailable(te)
 
 	if _, err := te.Client().Configs().Patch(
 		defaults.ImageRegistryResourceName,
@@ -55,11 +52,8 @@ func TestManagementStateUnmanaged(t *testing.T) {
 }
 
 func TestManagementStateRemoved(t *testing.T) {
-	te := framework.Setup(t)
+	te := framework.SetupAvailableImageRegistry(t, nil)
 	defer framework.TeardownImageRegistry(te)
-
-	framework.DeployImageRegistry(te, nil)
-	framework.EnsureImageRegistryIsAvailable(te)
 
 	if _, err := te.Client().Configs().Patch(
 		defaults.ImageRegistryResourceName,
@@ -140,7 +134,7 @@ func TestRemovedToManagedTransition(t *testing.T) {
 	}
 
 	t.Log("making sure image registry is up and running")
-	framework.EnsureImageRegistryIsAvailable(te)
+	framework.WaitUntilImageRegistryIsAvailable(te)
 	framework.EnsureInternalRegistryHostnameIsSet(te)
 	framework.EnsureClusterOperatorStatusIsNormal(te)
 }

--- a/test/e2e/nodecadaemon_test.go
+++ b/test/e2e/nodecadaemon_test.go
@@ -23,7 +23,7 @@ func TestNodeCADaemonAlwaysDeployed(t *testing.T) {
 		ManagementState: operatorapiv1.Removed,
 		Replicas:        1,
 	})
-	framework.EnsureImageRegistryIsAvailable(te)
+	framework.WaitUntilImageRegistryIsAvailable(te)
 
 	t.Log("waiting until the node-ca daemon is deployed")
 	err := wait.Poll(time.Second, framework.AsyncOperationTimeout, func() (stop bool, err error) {

--- a/test/e2e/pruner_test.go
+++ b/test/e2e/pruner_test.go
@@ -18,14 +18,11 @@ import (
 // is set correctly based on the image registry's custom resources
 // Spec.ManagementState field
 func TestPruneRegistryFlag(t *testing.T) {
-	te := framework.Setup(t)
+	te := framework.SetupAvailableImageRegistry(t, nil)
 	defer framework.TeardownImageRegistry(te)
 
 	// TODO: Move these checks to a conformance test run on all providers
-	framework.DeployImageRegistry(te, nil)
-	framework.EnsureImageRegistryIsAvailable(te)
 	framework.EnsureInternalRegistryHostnameIsSet(te)
-	framework.EnsureClusterOperatorStatusIsNormal(te)
 	framework.EnsureOperatorIsNotHotLooping(te)
 	framework.EnsureServiceCAConfigMap(te)
 	framework.EnsureNodeCADaemonSetIsAvailable(te)
@@ -95,7 +92,7 @@ func TestPruneRegistryFlag(t *testing.T) {
 // TestPruner verifies that the pruner controller installs the cronjob and sets it's
 // conditions appropriately
 func TestPruner(t *testing.T) {
-	te := framework.Setup(t)
+	te := framework.SetupAvailableImageRegistry(t, nil)
 	defer framework.TeardownImageRegistry(te)
 
 	defer func() {
@@ -105,10 +102,7 @@ func TestPruner(t *testing.T) {
 	}()
 
 	// TODO: Move these checks to a conformance test run on all providers
-	framework.DeployImageRegistry(te, nil)
-	framework.EnsureImageRegistryIsAvailable(te)
 	framework.EnsureInternalRegistryHostnameIsSet(te)
-	framework.EnsureClusterOperatorStatusIsNormal(te)
 	framework.EnsureOperatorIsNotHotLooping(te)
 	framework.EnsureServiceCAConfigMap(te)
 	framework.EnsureNodeCADaemonSetIsAvailable(te)

--- a/test/e2e/pvc_test.go
+++ b/test/e2e/pvc_test.go
@@ -137,7 +137,7 @@ func createPVC(te framework.TestEnv, name string, accessMode corev1.PersistentVo
 }
 
 func checkTestResult(te framework.TestEnv) {
-	framework.EnsureImageRegistryIsAvailable(te)
+	framework.WaitUntilImageRegistryIsAvailable(te)
 	framework.EnsureInternalRegistryHostnameIsSet(te)
 	framework.EnsureClusterOperatorStatusIsNormal(te)
 	framework.EnsureOperatorIsNotHotLooping(te)

--- a/test/e2e/readonly_test.go
+++ b/test/e2e/readonly_test.go
@@ -13,10 +13,7 @@ import (
 )
 
 func TestReadOnly(t *testing.T) {
-	te := framework.Setup(t)
-	defer framework.TeardownImageRegistry(te)
-
-	framework.DeployImageRegistry(te, &imageregistryv1.ImageRegistrySpec{
+	te := framework.SetupAvailableImageRegistry(t, &imageregistryv1.ImageRegistrySpec{
 		ManagementState: operatorapi.Managed,
 		Storage: imageregistryv1.ImageRegistryConfigStorage{
 			EmptyDir: &imageregistryv1.ImageRegistryConfigStorageEmptyDir{},
@@ -24,9 +21,9 @@ func TestReadOnly(t *testing.T) {
 		ReadOnly: true,
 		Replicas: 1,
 	})
-	framework.EnsureImageRegistryIsAvailable(te)
+	defer framework.TeardownImageRegistry(te)
+
 	framework.EnsureInternalRegistryHostnameIsSet(te)
-	framework.EnsureClusterOperatorStatusIsNormal(te)
 	framework.EnsureOperatorIsNotHotLooping(te)
 
 	deploy, err := te.Client().Deployments(defaults.ImageRegistryOperatorNamespace).Get(defaults.ImageRegistryName, metav1.GetOptions{})

--- a/test/e2e/recreate_deployment_test.go
+++ b/test/e2e/recreate_deployment_test.go
@@ -16,17 +16,14 @@ import (
 )
 
 func TestRecreateDeployment(t *testing.T) {
-	te := framework.Setup(t)
-	defer framework.TeardownImageRegistry(te)
-
-	framework.DeployImageRegistry(te, &imageregistryv1.ImageRegistrySpec{
+	te := framework.SetupAvailableImageRegistry(t, &imageregistryv1.ImageRegistrySpec{
 		ManagementState: operatorapi.Managed,
 		Storage: imageregistryv1.ImageRegistryConfigStorage{
 			EmptyDir: &imageregistryv1.ImageRegistryConfigStorageEmptyDir{},
 		},
 		Replicas: 1,
 	})
-	framework.EnsureImageRegistryIsAvailable(te)
+	defer framework.TeardownImageRegistry(te)
 
 	t.Logf("deleting the image registry deployment...")
 	if err := framework.DeleteCompletely(
@@ -47,11 +44,8 @@ func TestRecreateDeployment(t *testing.T) {
 }
 
 func TestRestoreDeploymentAfterUserChanges(t *testing.T) {
-	te := framework.Setup(t)
+	te := framework.SetupAvailableImageRegistry(t, nil)
 	defer framework.TeardownImageRegistry(te)
-
-	framework.DeployImageRegistry(te, nil)
-	framework.EnsureImageRegistryIsAvailable(te)
 
 	// add a new environment variable and a host port to the deployment.
 	if _, err := te.Client().Deployments(framework.OperatorDeploymentNamespace).Patch(

--- a/test/e2e/recreate_deployment_test.go
+++ b/test/e2e/recreate_deployment_test.go
@@ -16,58 +16,45 @@ import (
 )
 
 func TestRecreateDeployment(t *testing.T) {
-	client := framework.MustNewClientset(t, nil)
+	te := framework.Setup(t)
+	defer framework.TeardownImageRegistry(te)
 
-	defer framework.MustRemoveImageRegistry(t, client)
-
-	cr := &imageregistryv1.Config{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: imageregistryv1.SchemeGroupVersion.String(),
-			Kind:       "Config",
+	framework.DeployImageRegistry(te, &imageregistryv1.ImageRegistrySpec{
+		ManagementState: operatorapi.Managed,
+		Storage: imageregistryv1.ImageRegistryConfigStorage{
+			EmptyDir: &imageregistryv1.ImageRegistryConfigStorageEmptyDir{},
 		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: defaults.ImageRegistryResourceName,
-		},
-		Spec: imageregistryv1.ImageRegistrySpec{
-			ManagementState: operatorapi.Managed,
-			Storage: imageregistryv1.ImageRegistryConfigStorage{
-				EmptyDir: &imageregistryv1.ImageRegistryConfigStorageEmptyDir{},
-			},
-			Replicas: 1,
-		},
-	}
-	framework.MustDeployImageRegistry(t, client, cr)
-	framework.MustEnsureImageRegistryIsAvailable(t, client)
+		Replicas: 1,
+	})
+	framework.EnsureImageRegistryIsAvailable(te)
 
 	t.Logf("deleting the image registry deployment...")
 	if err := framework.DeleteCompletely(
 		func() (metav1.Object, error) {
-			return client.Deployments(defaults.ImageRegistryOperatorNamespace).Get(defaults.ImageRegistryName, metav1.GetOptions{})
+			return te.Client().Deployments(defaults.ImageRegistryOperatorNamespace).Get(defaults.ImageRegistryName, metav1.GetOptions{})
 		},
 		func(deleteOptions *metav1.DeleteOptions) error {
-			return client.Deployments(defaults.ImageRegistryOperatorNamespace).Delete(defaults.ImageRegistryName, deleteOptions)
+			return te.Client().Deployments(defaults.ImageRegistryOperatorNamespace).Delete(defaults.ImageRegistryName, deleteOptions)
 		},
 	); err != nil {
 		t.Fatalf("unable to delete the deployment: %s", err)
 	}
 
 	t.Logf("waiting for the operator to recreate the deployment...")
-	if _, err := framework.WaitForRegistryDeployment(client); err != nil {
-		framework.DumpImageRegistryResource(t, client)
-		framework.DumpOperatorLogs(t, client)
+	if _, err := framework.WaitForRegistryDeployment(te.Client()); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestRestoreDeploymentAfterUserChanges(t *testing.T) {
-	client := framework.MustNewClientset(t, nil)
+	te := framework.Setup(t)
+	defer framework.TeardownImageRegistry(te)
 
-	defer framework.MustRemoveImageRegistry(t, client)
-	framework.MustDeployImageRegistry(t, client, nil)
-	framework.MustEnsureImageRegistryIsAvailable(t, client)
+	framework.DeployImageRegistry(te, nil)
+	framework.EnsureImageRegistryIsAvailable(te)
 
 	// add a new environment variable and a host port to the deployment.
-	if _, err := client.Deployments(framework.OperatorDeploymentNamespace).Patch(
+	if _, err := te.Client().Deployments(framework.OperatorDeploymentNamespace).Patch(
 		defaults.ImageRegistryName,
 		types.JSONPatchType,
 		[]byte(`[
@@ -91,7 +78,7 @@ func TestRestoreDeploymentAfterUserChanges(t *testing.T) {
 		time.Second,
 		time.Minute,
 		func() (stop bool, err error) {
-			deployment, err := client.Deployments(
+			deployment, err := te.Client().Deployments(
 				framework.OperatorDeploymentNamespace,
 			).Get("image-registry", metav1.GetOptions{})
 			if err != nil {

--- a/test/framework/condition.go
+++ b/test/framework/condition.go
@@ -13,7 +13,7 @@ import (
 	"github.com/openshift/cluster-image-registry-operator/pkg/defaults"
 )
 
-func ConditionExistsWithStatusAndReason(client *Clientset, conditionType string, conditionStatus operatorapi.ConditionStatus, conditionReason string) []error {
+func ConditionExistsWithStatusAndReason(te TestEnv, conditionType string, conditionStatus operatorapi.ConditionStatus, conditionReason string) {
 	var errs []error
 
 	// Wait for the image registry resource to have an updated condition
@@ -22,7 +22,7 @@ func ConditionExistsWithStatusAndReason(client *Clientset, conditionType string,
 		conditionExists := false
 
 		// Get a fresh version of the image registry resource
-		cr, err := client.Configs().Get(defaults.ImageRegistryResourceName, metav1.GetOptions{})
+		cr, err := te.Client().Configs().Get(defaults.ImageRegistryResourceName, metav1.GetOptions{})
 		if err != nil {
 			if errors.IsNotFound(err) {
 				errs = append(errs, err)
@@ -54,10 +54,12 @@ func ConditionExistsWithStatusAndReason(client *Clientset, conditionType string,
 		errs = append(errs, err)
 	}
 
-	return errs
+	for _, err := range errs {
+		te.Errorf("%#v", err)
+	}
 }
 
-func PrunerConditionExistsWithStatusAndReason(client *Clientset, conditionType string, conditionStatus operatorapi.ConditionStatus, conditionReason string) []error {
+func PrunerConditionExistsWithStatusAndReason(te TestEnv, conditionType string, conditionStatus operatorapi.ConditionStatus, conditionReason string) {
 	var errs []error
 
 	// Wait for the image registry resource to have an updated condition
@@ -66,7 +68,7 @@ func PrunerConditionExistsWithStatusAndReason(client *Clientset, conditionType s
 		conditionExists := false
 
 		// Get a fresh version of the image registry resource
-		cr, err := client.ImagePruners().Get(defaults.ImageRegistryImagePrunerResourceName, metav1.GetOptions{})
+		cr, err := te.Client().ImagePruners().Get(defaults.ImageRegistryImagePrunerResourceName, metav1.GetOptions{})
 		if err != nil {
 			if errors.IsNotFound(err) {
 				errs = append(errs, err)
@@ -96,5 +98,8 @@ func PrunerConditionExistsWithStatusAndReason(client *Clientset, conditionType s
 	if err != nil {
 		errs = append(errs, err)
 	}
-	return errs
+
+	for _, err := range errs {
+		te.Errorf("%#v", err)
+	}
 }

--- a/test/framework/configmap.go
+++ b/test/framework/configmap.go
@@ -2,7 +2,6 @@ package framework
 
 import (
 	"fmt"
-	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -13,13 +12,13 @@ import (
 	"github.com/openshift/cluster-image-registry-operator/pkg/defaults"
 )
 
-func MustEnsureServiceCAConfigMap(t *testing.T, client *Clientset) {
+func EnsureServiceCAConfigMap(te TestEnv) {
 	expectedAnnotations := map[string]string{
 		"service.beta.openshift.io/inject-cabundle": "true",
 	}
-	err := ensureConfigMap("serviceca", expectedAnnotations, client)
+	err := ensureConfigMap("serviceca", expectedAnnotations, te.Client())
 	if err != nil {
-		t.Fatal(err)
+		te.Fatal(err)
 	}
 }
 

--- a/test/framework/daemonset.go
+++ b/test/framework/daemonset.go
@@ -1,7 +1,6 @@
 package framework
 
 import (
-	"testing"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -12,19 +11,11 @@ import (
 	"github.com/openshift/cluster-image-registry-operator/pkg/defaults"
 )
 
-func MustEnsureNodeCADaemonSetIsAvailable(t *testing.T, client *Clientset) {
-	err := ensureNodeCADaemonSetIsAvailable(client)
+func EnsureNodeCADaemonSetIsAvailable(te TestEnv) {
+	_, err := WaitForNodeCADaemonSet(te.Client())
 	if err != nil {
-		t.Fatal(err)
+		te.Fatal(err)
 	}
-}
-
-func ensureNodeCADaemonSetIsAvailable(client *Clientset) error {
-	_, err := WaitForNodeCADaemonSet(client)
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 func WaitForNodeCADaemonSet(client *Clientset) (*appsv1.DaemonSet, error) {

--- a/test/framework/envvars.go
+++ b/test/framework/envvars.go
@@ -20,6 +20,19 @@ func FlagExistsWithValue(args []string, flag string, value string) error {
 	return fmt.Errorf("flag %q was not found in %#v", flag, args)
 }
 
+func CheckEnvVarsAreNotSet(te TestEnv, got []corev1.EnvVar, names []string) {
+	blacklist := map[string]bool{}
+	for _, name := range names {
+		blacklist[name] = true
+	}
+
+	for _, e := range got {
+		if blacklist[e.Name] {
+			te.Errorf("got the environment variable %s with the value %q, but want it to be absent", e.Name, e.Value)
+		}
+	}
+}
+
 func CheckEnvVars(te TestEnv, want []corev1.EnvVar, have []corev1.EnvVar, includes bool) {
 	for _, val := range want {
 		found := false

--- a/test/framework/hostname.go
+++ b/test/framework/hostname.go
@@ -2,7 +2,6 @@ package framework
 
 import (
 	"strings"
-	"testing"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -14,15 +13,15 @@ import (
 	"github.com/openshift/cluster-image-registry-operator/pkg/defaults"
 )
 
-func MustEnsureDefaultExternalRegistryHostnameIsSet(t *testing.T, client *Clientset) {
+func EnsureDefaultExternalRegistryHostnameIsSet(te TestEnv) {
 	var cfg *configapiv1.Image
 	var err error
 	externalHosts := []string{}
 	err = wait.Poll(1*time.Second, AsyncOperationTimeout, func() (bool, error) {
 		var err error
-		cfg, err = client.Images().Get("cluster", metav1.GetOptions{})
+		cfg, err = te.Client().Images().Get("cluster", metav1.GetOptions{})
 		if errors.IsNotFound(err) {
-			t.Logf("waiting for the image config resource: the resource does not exist")
+			te.Logf("waiting for the image config resource: the resource does not exist")
 			cfg = nil
 			return false, nil
 		} else if err != nil {
@@ -41,17 +40,17 @@ func MustEnsureDefaultExternalRegistryHostnameIsSet(t *testing.T, client *Client
 		return false, nil
 	})
 	if err != nil {
-		t.Fatalf("cluster image config resource was not updated with default external registry hostname: %v, err: %v", externalHosts, err)
+		te.Fatalf("cluster image config resource was not updated with default external registry hostname: %v, err: %v", externalHosts, err)
 	}
 }
 
-func EnsureExternalRegistryHostnamesAreSet(t *testing.T, client *Clientset, wantedHostnames []string) {
+func EnsureExternalRegistryHostnamesAreSet(te TestEnv, wantedHostnames []string) {
 	var cfg *configapiv1.Image
 	err := wait.Poll(1*time.Second, AsyncOperationTimeout, func() (bool, error) {
 		var err error
-		cfg, err = client.Images().Get("cluster", metav1.GetOptions{})
+		cfg, err = te.Client().Images().Get("cluster", metav1.GetOptions{})
 		if errors.IsNotFound(err) {
-			t.Logf("waiting for the image config resource: the resource does not exist")
+			te.Logf("waiting for the image config resource: the resource does not exist")
 			cfg = nil
 			return false, nil
 		} else if err != nil {
@@ -76,6 +75,6 @@ func EnsureExternalRegistryHostnamesAreSet(t *testing.T, client *Clientset, want
 		return true, nil
 	})
 	if err != nil {
-		t.Errorf("cluster image config resource was not updated with external registry hostnames: wanted: %#v, got: %#v,  err: %v", wantedHostnames, cfg.Status.ExternalRegistryHostnames, err)
+		te.Errorf("cluster image config resource was not updated with external registry hostnames: wanted: %#v, got: %#v,  err: %v", wantedHostnames, cfg.Status.ExternalRegistryHostnames, err)
 	}
 }

--- a/test/framework/imageregistry.go
+++ b/test/framework/imageregistry.go
@@ -3,7 +3,6 @@ package framework
 import (
 	"fmt"
 	"strings"
-	"testing"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -87,21 +86,21 @@ func (c ImageRegistryConditions) String() string {
 	)
 }
 
-func ensureImageRegistryToBeRemoved(logger Logger, client *Clientset) error {
-	if _, err := client.Configs().Patch(defaults.ImageRegistryResourceName, types.MergePatchType, []byte(`{"spec": {"managementState": "Removed"}}`)); err != nil {
+func ensureImageRegistryToBeRemoved(te TestEnv) {
+	if _, err := te.Client().Configs().Patch(defaults.ImageRegistryResourceName, types.MergePatchType, []byte(`{"spec": {"managementState": "Removed"}}`)); err != nil {
 		if errors.IsNotFound(err) {
 			// That's not exactly what we are asked for. And few seconds later
 			// the operator may bootstrap it. However, if the operator is
 			// disabled, it means the registry is not installed and we're
 			// already in the desired state.
-			return nil
+			return
 		}
-		return err
+		te.Fatalf("unable to uninstall the image registry: %s", err)
 	}
 
 	var cr *imageregistryapiv1.Config
 	err := wait.Poll(5*time.Second, AsyncOperationTimeout, func() (stop bool, err error) {
-		cr, err = client.Configs().Get(defaults.ImageRegistryResourceName, metav1.GetOptions{})
+		cr, err = te.Client().Configs().Get(defaults.ImageRegistryResourceName, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			cr = nil
 			return true, nil
@@ -110,100 +109,82 @@ func ensureImageRegistryToBeRemoved(logger Logger, client *Clientset) error {
 		}
 
 		conds := GetImageRegistryConditions(cr)
-		logger.Logf("waiting for the registry to be removed: %s", conds)
+		te.Logf("waiting for the registry to be removed: %s", conds)
 		return conds.Progressing.IsFalse() && conds.Removed.IsTrue(), nil
 	})
 	if err != nil {
-		DumpYAML(logger, "the latest observed state of the image registry resource", cr)
-		DumpOperatorLogs(logger, client)
-		return fmt.Errorf("failed to wait for the imageregistry resource to be removed: %s", err)
+		DumpYAML(te, "the latest observed state of the image registry resource", cr)
+		DumpOperatorLogs(te)
+		te.Fatalf("failed to wait for the imageregistry resource to be removed: %s", err)
 	}
-	return nil
 }
 
-func deleteImageRegistryResource(client *Clientset) error {
+func deleteImageRegistryResource(te TestEnv) {
 	// TODO(dmage): the finalizer should be removed by the operator
 	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		cr, err := client.Configs().Get(defaults.ImageRegistryResourceName, metav1.GetOptions{})
+		cr, err := te.Client().Configs().Get(defaults.ImageRegistryResourceName, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			return nil
 		} else if err != nil {
 			return err
 		}
 		cr.Finalizers = nil
-		_, err = client.Configs().Update(cr)
+		_, err = te.Client().Configs().Update(cr)
 		return err
 	}); err != nil {
-		return err
+		te.Fatalf("unable to delete the image registry resource: %s", err)
 	}
 
 	if err := DeleteCompletely(
 		func() (metav1.Object, error) {
-			return client.Configs().Get(defaults.ImageRegistryResourceName, metav1.GetOptions{})
+			return te.Client().Configs().Get(defaults.ImageRegistryResourceName, metav1.GetOptions{})
 		},
 		func(deleteOptions *metav1.DeleteOptions) error {
-			return client.Configs().Delete(defaults.ImageRegistryResourceName, deleteOptions)
+			return te.Client().Configs().Delete(defaults.ImageRegistryResourceName, deleteOptions)
 		},
-	); err != nil {
-		if errors.IsNotFound(err) {
-			return nil
+	); err != nil && !errors.IsNotFound(err) {
+		te.Fatalf("unable to delete the image registry resource: %s", err)
+	}
+}
+
+func RemoveImageRegistry(te TestEnv) {
+	te.Logf("uninstalling the image registry...")
+	ensureImageRegistryToBeRemoved(te)
+	te.Logf("stopping the operator...")
+	if err := StopDeployment(te, te.Client(), OperatorDeploymentName, OperatorDeploymentNamespace); err != nil {
+		te.Fatalf("unable to stop the operator: %s", err)
+	}
+	te.Logf("deleting the image registry resource...")
+	deleteImageRegistryResource(te)
+}
+
+func DeployImageRegistry(te TestEnv, spec *imageregistryapiv1.ImageRegistrySpec) {
+	if spec != nil {
+		te.Logf("creating the image registry resource...")
+		cr := &imageregistryapiv1.Config{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: defaults.ImageRegistryResourceName,
+			},
+			Spec: *spec,
 		}
-		return err
-	}
-	return nil
-}
-
-func RemoveImageRegistry(logger Logger, client *Clientset) error {
-	logger.Logf("uninstalling the image registry...")
-	if err := ensureImageRegistryToBeRemoved(logger, client); err != nil {
-		return fmt.Errorf("unable to uninstall the image registry: %s", err)
-	}
-	logger.Logf("stopping the operator...")
-	if err := StopDeployment(logger, client, OperatorDeploymentName, OperatorDeploymentNamespace); err != nil {
-		return fmt.Errorf("unable to stop the operator: %s", err)
-	}
-	logger.Logf("deleting the image registry resource...")
-	if err := deleteImageRegistryResource(client); err != nil {
-		return fmt.Errorf("unable to delete the image registry resource: %s", err)
-	}
-	return nil
-}
-
-func MustRemoveImageRegistry(t *testing.T, client *Clientset) {
-	if err := RemoveImageRegistry(t, client); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func DeployImageRegistry(logger Logger, client *Clientset, cr *imageregistryapiv1.Config) error {
-	if cr != nil {
-		logger.Logf("creating the image registry resource...")
-		if _, err := client.Configs().Create(cr); err != nil {
-			return fmt.Errorf("unable to create the image registry resource: %s", err)
+		if _, err := te.Client().Configs().Create(cr); err != nil {
+			te.Fatalf("unable to create the image registry resource: %s", err)
 		}
 	}
-	logger.Logf("starting the operator...")
-	if err := startOperator(client); err != nil {
-		return fmt.Errorf("unable to start the operator: %s", err)
-	}
-	return nil
-}
 
-func MustDeployImageRegistry(t *testing.T, client *Clientset, cr *imageregistryapiv1.Config) {
-	if err := DeployImageRegistry(t, client, cr); err != nil {
-		DumpOperatorDeployment(t, client)
-		DumpImageRegistryResource(t, client)
-		t.Fatal(err)
+	te.Logf("starting the operator...")
+	if err := startOperator(te.Client()); err != nil {
+		te.Fatalf("unable to start the operator: %s", err)
 	}
 }
 
-func DumpImageRegistryResource(logger Logger, client *Clientset) {
-	cr, err := client.Configs().Get(defaults.ImageRegistryResourceName, metav1.GetOptions{})
+func DumpImageRegistryResource(te TestEnv) {
+	cr, err := te.Client().Configs().Get(defaults.ImageRegistryResourceName, metav1.GetOptions{})
 	if err != nil {
-		logger.Logf("unable to dump the image registry resource: %s", err)
+		te.Logf("unable to dump the image registry resource: %s", err)
 		return
 	}
-	DumpYAML(logger, "the image registry resource", cr)
+	DumpYAML(te, "the image registry resource", cr)
 }
 
 func DumpImageRegistryDeployment(logger Logger, client *Clientset) {
@@ -215,12 +196,12 @@ func DumpImageRegistryDeployment(logger Logger, client *Clientset) {
 	DumpYAML(logger, "the image registry deployment", d)
 }
 
-func ensureImageRegistryIsProcessed(logger Logger, client *Clientset) (*imageregistryapiv1.Config, error) {
+func EnsureImageRegistryIsProcessed(te TestEnv) *imageregistryapiv1.Config {
 	var cr *imageregistryapiv1.Config
 	err := wait.Poll(5*time.Second, AsyncOperationTimeout, func() (stop bool, err error) {
-		cr, err = client.Configs().Get(defaults.ImageRegistryResourceName, metav1.GetOptions{})
+		cr, err = te.Client().Configs().Get(defaults.ImageRegistryResourceName, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
-			logger.Logf("waiting for the registry: the resource does not exist")
+			te.Logf("waiting for the registry: the resource does not exist")
 			cr = nil
 			return false, nil
 		} else if err != nil {
@@ -228,57 +209,36 @@ func ensureImageRegistryIsProcessed(logger Logger, client *Clientset) (*imagereg
 		}
 
 		conds := GetImageRegistryConditions(cr)
-		logger.Logf("waiting for the registry: %s", conds)
+		te.Logf("waiting for the registry: %s", conds)
 		return conds.Progressing.IsFalse() && conds.Available.IsTrue() || conds.Degraded.IsTrue(), nil
 	})
 	if err != nil {
-		DumpYAML(logger, "the latest observed state of the image registry resource", cr)
-		DumpOperatorLogs(logger, client)
-		return cr, fmt.Errorf("failed to wait for the imageregistry resource to be processed: %s", err)
-	}
-	return cr, nil
-}
-
-func MustEnsureImageRegistryIsProcessed(t *testing.T, client *Clientset) *imageregistryapiv1.Config {
-	cr, err := ensureImageRegistryIsProcessed(t, client)
-	if err != nil {
-		t.Fatal(err)
+		DumpYAML(te, "the latest observed state of the image registry resource", cr)
+		DumpOperatorLogs(te)
+		te.Fatalf("failed to wait for the imageregistry resource to be processed: %s", err)
 	}
 	return cr
 }
 
-func ensureImageRegistryIsAvailable(logger Logger, client *Clientset) error {
-	logger.Logf("waiting for the operator to deploy the registry...")
+func EnsureImageRegistryIsAvailable(te TestEnv) {
+	te.Logf("waiting for the operator to deploy the registry...")
 
-	cr, err := ensureImageRegistryIsProcessed(logger, client)
-	if err != nil {
-		return err
-	}
-
+	cr := EnsureImageRegistryIsProcessed(te)
 	conds := GetImageRegistryConditions(cr)
 	if conds.Progressing.IsTrue() || conds.Available.IsFalse() {
-		DumpYAML(logger, "the latest observed state of the image registry resource", cr)
-		DumpOperatorLogs(logger, client)
-		return fmt.Errorf("the imageregistry resource is processed, but the the image registry is not available")
+		DumpYAML(te, "the latest observed state of the image registry resource", cr)
+		DumpOperatorLogs(te)
+		te.Fatal("the imageregistry resource is processed, but the the image registry is not available")
 	}
 
-	logger.Logf("the image registry resource reports that the registry is deployed and available")
-	return nil
+	te.Logf("the image registry resource reports that the registry is deployed and available")
 }
 
-func MustEnsureImageRegistryIsAvailable(t *testing.T, client *Clientset) {
-	if err := ensureImageRegistryIsAvailable(t, client); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func ensureInternalRegistryHostnameIsSet(logger Logger, client *Clientset) error {
-	var cfg *configapiv1.Image
+func EnsureInternalRegistryHostnameIsSet(te TestEnv) {
 	err := wait.Poll(1*time.Second, AsyncOperationTimeout, func() (bool, error) {
-		var err error
-		cfg, err = client.Images().Get("cluster", metav1.GetOptions{})
+		cfg, err := te.Client().Images().Get("cluster", metav1.GetOptions{})
 		if errors.IsNotFound(err) {
-			logger.Logf("waiting for the image config resource: the resource does not exist")
+			te.Logf("waiting for the image config resource: the resource does not exist")
 			cfg = nil
 			return false, nil
 		} else if err != nil {
@@ -290,16 +250,8 @@ func ensureInternalRegistryHostnameIsSet(logger Logger, client *Clientset) error
 		return true, nil
 	})
 	if err != nil {
-		logger.Logf("cluster image config resource was not updated with internal registry hostname: %v", err)
+		te.Fatalf("cluster image config resource was not updated with internal registry hostname: %v", err)
 	}
-	return err
-}
-
-func MustEnsureInternalRegistryHostnameIsSet(t *testing.T, client *Clientset) {
-	if err := ensureInternalRegistryHostnameIsSet(t, client); err != nil {
-		t.Fatal(err)
-	}
-
 }
 
 func hasExpectedClusterOperatorConditions(status *configapiv1.ClusterOperator) bool {
@@ -320,12 +272,12 @@ func hasExpectedClusterOperatorConditions(status *configapiv1.ClusterOperator) b
 	return gotAvailable && gotProgressing && gotDegraded
 }
 
-func ensureClusterOperatorStatusIsSet(logger Logger, client *Clientset) (*configapiv1.ClusterOperator, error) {
+func EnsureClusterOperatorStatusIsSet(te TestEnv) *configapiv1.ClusterOperator {
 	var status *configapiv1.ClusterOperator
 	err := wait.Poll(1*time.Second, AsyncOperationTimeout, func() (stop bool, err error) {
-		status, err = client.ClusterOperators().Get(defaults.ImageRegistryClusterOperatorResourceName, metav1.GetOptions{})
+		status, err = te.Client().ClusterOperators().Get(defaults.ImageRegistryClusterOperatorResourceName, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
-			logger.Logf("waiting for the cluster operator resource: the resource does not exist")
+			te.Logf("waiting for the cluster operator resource: the resource does not exist")
 			return false, nil
 		} else if err != nil {
 			return false, err
@@ -336,38 +288,30 @@ func ensureClusterOperatorStatusIsSet(logger Logger, client *Clientset) (*config
 		return false, nil
 	})
 	if err != nil {
-		logger.Logf("clusteroperator status resource was not updated with the expected status: %v", err)
 		if status != nil {
-			logger.Logf("clusteroperator conditions are: %#v", status.Status.Conditions)
+			te.Logf("clusteroperator conditions are: %#v", status.Status.Conditions)
 		}
+		te.Fatalf("clusteroperator status resource was not updated with the expected status: %v", err)
 	}
-	return status, err
+	return status
 }
 
-func MustEnsureClusterOperatorStatusIsSet(t *testing.T, client *Clientset) *configapiv1.ClusterOperator {
-	clusterOperator, err := ensureClusterOperatorStatusIsSet(t, client)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return clusterOperator
-}
-
-func MustEnsureClusterOperatorStatusIsNormal(t *testing.T, client *Clientset) {
-	clusterOperator := MustEnsureClusterOperatorStatusIsSet(t, client)
+func EnsureClusterOperatorStatusIsNormal(te TestEnv) {
+	clusterOperator := EnsureClusterOperatorStatusIsSet(te)
 
 	for _, cond := range clusterOperator.Status.Conditions {
 		switch cond.Type {
 		case configapiv1.OperatorAvailable:
 			if cond.Status != configapiv1.ConditionTrue {
-				t.Errorf("Expected clusteroperator Available=%s, got %s", configapiv1.ConditionTrue, cond.Status)
+				te.Errorf("Expected clusteroperator Available=%s, got %s", configapiv1.ConditionTrue, cond.Status)
 			}
 		case configapiv1.OperatorProgressing:
 			if cond.Status != configapiv1.ConditionFalse {
-				t.Errorf("Expected clusteroperator Progressing=%s, got %s", configapiv1.ConditionFalse, cond.Status)
+				te.Errorf("Expected clusteroperator Progressing=%s, got %s", configapiv1.ConditionFalse, cond.Status)
 			}
 		case configapiv1.OperatorDegraded:
 			if cond.Status != configapiv1.ConditionFalse {
-				t.Errorf("Expected clusteroperator Degraded=%s, got %s", configapiv1.ConditionFalse, cond.Status)
+				te.Errorf("Expected clusteroperator Degraded=%s, got %s", configapiv1.ConditionFalse, cond.Status)
 			}
 		}
 	}
@@ -377,30 +321,30 @@ func MustEnsureClusterOperatorStatusIsNormal(t *testing.T, client *Clientset) {
 		if strings.ToLower(obj.Resource) == "namespaces" {
 			namespaceFound = true
 			if obj.Name != defaults.ImageRegistryOperatorNamespace {
-				t.Errorf("expected related namespaces resource to have name %q, got %q", defaults.ImageRegistryOperatorNamespace, obj.Name)
+				te.Errorf("expected related namespaces resource to have name %q, got %q", defaults.ImageRegistryOperatorNamespace, obj.Name)
 			}
 		}
 	}
 	if !namespaceFound {
-		t.Error("could not find related object namespaces")
+		te.Error("could not find related object namespaces")
 	}
 }
 
-func MustEnsureOperatorIsNotHotLooping(t *testing.T, client *Clientset) {
+func EnsureOperatorIsNotHotLooping(te TestEnv) {
 	// Allow the operator a few seconds to stabilize
 	time.Sleep(15 * time.Second)
 	var cfg *imageregistryapiv1.Config
 	var err error
 	err = wait.Poll(1*time.Second, 30*time.Second, func() (stop bool, err error) {
-		cfg, err = client.Configs().Get(defaults.ImageRegistryResourceName, metav1.GetOptions{})
+		cfg, err = te.Client().Configs().Get(defaults.ImageRegistryResourceName, metav1.GetOptions{})
 		if err != nil || cfg == nil {
-			t.Logf("failed to retrieve registry operator config: %v", err)
+			te.Logf("failed to retrieve registry operator config: %v", err)
 			return false, nil
 		}
 		return true, nil
 	})
 	if cfg == nil || err != nil {
-		t.Errorf("failed to retrieve registry operator config: %v", err)
+		te.Errorf("failed to retrieve registry operator config: %v", err)
 	}
 	oldVersion := cfg.ResourceVersion
 
@@ -408,17 +352,28 @@ func MustEnsureOperatorIsNotHotLooping(t *testing.T, client *Clientset) {
 	// is updating the registry config resource when we should be at steady state.
 	time.Sleep(15 * time.Second)
 	err = wait.Poll(1*time.Second, 30*time.Second, func() (stop bool, err error) {
-		cfg, err = client.Configs().Get(defaults.ImageRegistryResourceName, metav1.GetOptions{})
+		cfg, err = te.Client().Configs().Get(defaults.ImageRegistryResourceName, metav1.GetOptions{})
 		if err != nil || cfg == nil {
-			t.Logf("failed to retrieve registry operator config: %v", err)
+			te.Logf("failed to retrieve registry operator config: %v", err)
 			return false, nil
 		}
 		return true, nil
 	})
 	if cfg == nil || err != nil {
-		t.Errorf("failed to retrieve registry operator config: %v", err)
+		te.Errorf("failed to retrieve registry operator config: %v", err)
 	}
 	if oldVersion != cfg.ResourceVersion {
-		t.Errorf("registry config resource version was updated when it should have been stable, went from %s to %s", oldVersion, cfg.ResourceVersion)
+		te.Errorf("registry config resource version was updated when it should have been stable, went from %s to %s", oldVersion, cfg.ResourceVersion)
+	}
+}
+
+func TeardownImageRegistry(te TestEnv) {
+	defer func() {
+		RemoveImageRegistry(te)
+	}()
+	if te.Failed() {
+		DumpImageRegistryResource(te)
+		DumpOperatorDeployment(te)
+		DumpOperatorLogs(te)
 	}
 }

--- a/test/framework/intrastructure.go
+++ b/test/framework/intrastructure.go
@@ -1,0 +1,22 @@
+package framework
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func PlatformIsOneOf(te TestEnv, platforms []configv1.PlatformType) bool {
+	infrastructureConfig, err := te.Client().Infrastructures().Get("cluster", metav1.GetOptions{})
+	if err != nil {
+		te.Fatalf("unable to get infrastructure object: %v", err)
+	}
+
+	typ := infrastructureConfig.Status.PlatformStatus.Type
+	for _, p := range platforms {
+		if p == typ {
+			return true
+		}
+	}
+	return false
+}

--- a/test/framework/jsonpatch.go
+++ b/test/framework/jsonpatch.go
@@ -1,0 +1,19 @@
+package framework
+
+import "encoding/json"
+
+type JSONPatch struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value,omitempty"`
+}
+
+func MarshalJSON(patch []JSONPatch) []byte {
+	buf, err := json.Marshal(patch)
+	if err != nil {
+		// This function is expected to be used only in tests with known data
+		// that should always be marshable.
+		panic(err)
+	}
+	return buf
+}

--- a/test/framework/jsonpatch.go
+++ b/test/framework/jsonpatch.go
@@ -8,7 +8,7 @@ type JSONPatch struct {
 	Value interface{} `json:"value,omitempty"`
 }
 
-func MarshalJSON(patch []JSONPatch) []byte {
+func MarshalJSON(patch interface{}) []byte {
 	buf, err := json.Marshal(patch)
 	if err != nil {
 		// This function is expected to be used only in tests with known data

--- a/test/framework/operator.go
+++ b/test/framework/operator.go
@@ -16,12 +16,12 @@ func startOperator(client *Clientset) error {
 	return nil
 }
 
-func DumpOperatorDeployment(logger Logger, client *Clientset) {
-	deployment, err := client.Deployments(OperatorDeploymentNamespace).Get(OperatorDeploymentName, metav1.GetOptions{})
+func DumpOperatorDeployment(te TestEnv) {
+	deployment, err := te.Client().Deployments(OperatorDeploymentNamespace).Get(OperatorDeploymentName, metav1.GetOptions{})
 	if err != nil {
-		logger.Logf("failed to get the operator deployment %v", err)
+		te.Logf("failed to get the operator deployment %v", err)
 	}
-	DumpYAML(logger, "the operator deployment", deployment)
+	DumpYAML(te, "the operator deployment", deployment)
 }
 
 func StopDeployment(logger Logger, client *Clientset, operatorDeploymentName, operatorDeploymentNamespace string) error {
@@ -55,10 +55,11 @@ func GetOperatorLogs(client *Clientset) (PodSetLogs, error) {
 	})
 }
 
-func DumpOperatorLogs(logger Logger, client *Clientset) {
-	podLogs, err := GetOperatorLogs(client)
+func DumpOperatorLogs(te TestEnv) {
+	podLogs, err := GetOperatorLogs(te.Client())
 	if err != nil {
-		logger.Logf("failed to get the operator logs: %s", err)
+		te.Logf("failed to get the operator logs: %s", err)
+		return
 	}
-	DumpPodLogs(logger, podLogs)
+	DumpPodLogs(te, podLogs)
 }

--- a/test/framework/proxy.go
+++ b/test/framework/proxy.go
@@ -2,7 +2,6 @@ package framework
 
 import (
 	"fmt"
-	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -21,16 +20,10 @@ func SetResourceProxyConfig(proxyConfig imageregistryapiv1.ImageRegistryConfigPr
 }
 
 // ResetResourceProxyConfig patches the image registry resource to contain an empty proxy configuration
-func ResetResourceProxyConfig(client *Clientset) error {
-	_, err := client.Configs().Patch(defaults.ImageRegistryResourceName, types.MergePatchType, []byte(`{"spec": {"proxy": {"http": "", "https": "", "noProxy": ""}}}`))
-	return err
-}
-
-// MustResetResourceProxyConfig is like ResetResourceProxyConfig but calls
-// t.Fatal if it returns a non-nil error.
-func MustResetResourceProxyConfig(t *testing.T, client *Clientset) {
-	if err := ResetResourceProxyConfig(client); err != nil {
-		t.Fatal(err)
+func ResetResourceProxyConfig(te TestEnv) {
+	_, err := te.Client().Configs().Patch(defaults.ImageRegistryResourceName, types.MergePatchType, []byte(`{"spec": {"proxy": {"http": "", "https": "", "noProxy": ""}}}`))
+	if err != nil {
+		te.Fatal(err)
 	}
 }
 
@@ -41,16 +34,10 @@ func SetClusterProxyConfig(proxyConfig openshiftapiv1.ProxySpec, client *Clients
 }
 
 // ResetClusterProxyConfig patches the cluster proxy resource to contain an empty proxy configuration
-func ResetClusterProxyConfig(client *Clientset) error {
-	_, err := client.Proxies().Patch(defaults.ClusterProxyResourceName, types.MergePatchType, []byte(`{"spec": {"httpProxy": "", "httpsProxy": "", "noProxy": ""}}`))
-	return err
-}
-
-// MustResetClusterProxyConfig is like ResetClusterProxyConfig but calls
-// t.Fatal if it returns a non-nil error.
-func MustResetClusterProxyConfig(t *testing.T, client *Clientset) {
-	if err := ResetClusterProxyConfig(client); err != nil {
-		t.Fatal(err)
+func ResetClusterProxyConfig(te TestEnv) {
+	_, err := te.Client().Proxies().Patch(defaults.ClusterProxyResourceName, types.MergePatchType, []byte(`{"spec": {"httpProxy": "", "httpsProxy": "", "noProxy": ""}}`))
+	if err != nil {
+		te.Fatal(err)
 	}
 }
 

--- a/test/framework/proxy.go
+++ b/test/framework/proxy.go
@@ -13,10 +13,11 @@ import (
 )
 
 // SetResourceProxyConfig patches the image registry resource to contain the provided proxy configuration
-func SetResourceProxyConfig(proxyConfig imageregistryapiv1.ImageRegistryConfigProxy, client *Clientset) error {
-	_, err := client.Configs().Patch(defaults.ImageRegistryResourceName, types.MergePatchType, []byte(fmt.Sprintf(`{"spec": {"proxy": {"http": "%s", "https": "%s", "noProxy": "%s"}}}`, proxyConfig.HTTP, proxyConfig.HTTPS, proxyConfig.NoProxy)))
-
-	return err
+func SetResourceProxyConfig(te TestEnv, proxyConfig imageregistryapiv1.ImageRegistryConfigProxy) {
+	_, err := te.Client().Configs().Patch(defaults.ImageRegistryResourceName, types.MergePatchType, []byte(fmt.Sprintf(`{"spec": {"proxy": {"http": "%s", "https": "%s", "noProxy": "%s"}}}`, proxyConfig.HTTP, proxyConfig.HTTPS, proxyConfig.NoProxy)))
+	if err != nil {
+		te.Fatalf("unable to set resource proxy configuration: %v", err)
+	}
 }
 
 // ResetResourceProxyConfig patches the image registry resource to contain an empty proxy configuration
@@ -28,9 +29,11 @@ func ResetResourceProxyConfig(te TestEnv) {
 }
 
 // SetClusterProxyConfig patches the cluster proxy resource to contain the provided proxy configuration
-func SetClusterProxyConfig(proxyConfig openshiftapiv1.ProxySpec, client *Clientset) error {
-	_, err := client.Proxies().Patch(defaults.ClusterProxyResourceName, types.MergePatchType, []byte(fmt.Sprintf(`{"spec": {"httpProxy": "%s", "httpsProxy": "%s", "noProxy": "%s"}}`, proxyConfig.HTTPProxy, proxyConfig.HTTPSProxy, proxyConfig.NoProxy)))
-	return err
+func SetClusterProxyConfig(te TestEnv, proxyConfig openshiftapiv1.ProxySpec) {
+	_, err := te.Client().Proxies().Patch(defaults.ClusterProxyResourceName, types.MergePatchType, []byte(fmt.Sprintf(`{"spec": {"httpProxy": "%s", "httpsProxy": "%s", "noProxy": "%s"}}`, proxyConfig.HTTPProxy, proxyConfig.HTTPSProxy, proxyConfig.NoProxy)))
+	if err != nil {
+		te.Fatalf("unable to patch cluster proxy instance: %v", err)
+	}
 }
 
 // ResetClusterProxyConfig patches the cluster proxy resource to contain an empty proxy configuration

--- a/test/framework/route.go
+++ b/test/framework/route.go
@@ -13,16 +13,16 @@ import (
 	"github.com/openshift/cluster-image-registry-operator/pkg/defaults"
 )
 
-func MustEnsureDefaultExternalRouteExists(t *testing.T, client *Clientset) {
+func EnsureDefaultExternalRouteExists(te TestEnv) {
 	var err error
 	var routes *routeapiv1.RouteList
 	err = wait.Poll(1*time.Second, AsyncOperationTimeout, func() (bool, error) {
-		routes, err = client.Routes(defaults.ImageRegistryOperatorNamespace).List(metav1.ListOptions{})
+		routes, err = te.Client().Routes(defaults.ImageRegistryOperatorNamespace).List(metav1.ListOptions{})
 		if err != nil {
 			return false, err
 		}
 		if routes == nil || len(routes.Items) < 1 {
-			t.Logf("insuffient routes found: %#v", routes)
+			te.Logf("insuffient routes found: %#v", routes)
 			return false, nil
 		}
 
@@ -34,7 +34,7 @@ func MustEnsureDefaultExternalRouteExists(t *testing.T, client *Clientset) {
 		return false, nil
 	})
 	if err != nil {
-		t.Fatalf("did not find default external route: %#v, err: %v", routes, err)
+		te.Fatalf("did not find default external route: %#v, err: %v", routes, err)
 	}
 }
 

--- a/test/framework/testenv.go
+++ b/test/framework/testenv.go
@@ -1,0 +1,35 @@
+package framework
+
+import "testing"
+
+type TestEnv interface {
+	Client() *Clientset
+	Failed() bool
+	Log(a ...interface{})
+	Logf(format string, a ...interface{})
+	Error(a ...interface{})
+	Errorf(format string, a ...interface{})
+	Fatal(a ...interface{})
+	Fatalf(format string, a ...interface{})
+}
+
+type testEnv struct {
+	*testing.T
+	client *Clientset
+}
+
+func Setup(t *testing.T) TestEnv {
+	client, err := NewClientset(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return &testEnv{
+		T:      t,
+		client: client,
+	}
+}
+
+func (te *testEnv) Client() *Clientset {
+	return te.client
+}

--- a/test/framework/util.go
+++ b/test/framework/util.go
@@ -20,9 +20,7 @@ func FlagExistsWithValue(args []string, flag string, value string) error {
 	return fmt.Errorf("flag %q was not found in %#v", flag, args)
 }
 
-func CheckEnvVars(want []corev1.EnvVar, have []corev1.EnvVar, includes bool) []error {
-	var errs []error
-
+func CheckEnvVars(te TestEnv, want []corev1.EnvVar, have []corev1.EnvVar, includes bool) {
 	for _, val := range want {
 		found := false
 		for _, v := range have {
@@ -30,19 +28,17 @@ func CheckEnvVars(want []corev1.EnvVar, have []corev1.EnvVar, includes bool) []e
 				found = true
 				if includes {
 					if !strings.Contains(v.Value, val.Value) {
-						errs = append(errs, fmt.Errorf("environment variable does not contain the expected value: expected %#v, got %#v", val, v))
+						te.Errorf("environment variable does not contain the expected value: expected %#v, got %#v", val, v)
 					}
 				} else {
 					if !reflect.DeepEqual(v, val) {
-						errs = append(errs, fmt.Errorf("environment variable does not equal the expected value: expected %#v, got %#v", val, v))
+						te.Errorf("environment variable does not equal the expected value: expected %#v, got %#v", val, v)
 					}
 				}
 			}
 		}
 		if !found {
-			errs = append(errs, fmt.Errorf("unable to find environment variable: wanted %s", val.Name))
+			te.Errorf("unable to find environment variable: wanted %s", val.Name)
 		}
 	}
-
-	return errs
 }


### PR DESCRIPTION
This PR introduces `framework.TestEnv`, a context for test functions.

It carries clients and testing.T, eventually we may want it to implement the context.Context interface. It is supposed to be the first argument of almost every function in the package test/framework. Any function with this context can fail the test (using te.Errorf or te.Fatalf), log additional information (te.Logf), and use k8s/okd clients.

The main idea of this PR is to make our tests more declarative. We usually don't have a fancy error handlers in our e2e tests, they usually look like this:

```
if err != nil {
  return err
}
...
if err != nil {
  t.Fatal(err)
}
```

It's an anti-pattern for the regular code, errors should be handled more carefully and the code should add more context details before returning the error.

But it's OK for tests. Therefore we can use Fatalf inside the helper: something went wrong, there is no reason to continue the test. All these `return err` lines just add visual noise and distract from the test.