### PR TITLE
Bug 1798618: Make driver on Mutators optional.

### DIFF
--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -159,11 +159,9 @@ func (c *Controller) sync() error {
 	}
 
 	var applyError error
-	removed := false
 	switch cr.Spec.ManagementState {
 	case operatorapi.Removed:
 		applyError = c.RemoveResources(cr)
-		removed = true
 	case operatorapi.Managed:
 		applyError = c.createOrUpdateResources(cr)
 	case operatorapi.Unmanaged:
@@ -181,7 +179,7 @@ func (c *Controller) sync() error {
 		deploy = deploy.DeepCopy() // make sure we won't corrupt the cached vesrion
 	}
 
-	c.syncStatus(cr, deploy, applyError, removed)
+	c.syncStatus(cr, deploy, applyError)
 
 	metadataChanged := strategy.Metadata(&prevCR.ObjectMeta, &cr.ObjectMeta)
 	specChanged := !reflect.DeepEqual(prevCR.Spec, cr.Spec)

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -192,7 +192,7 @@ func (c *ImagePrunerController) syncPrunerStatus(cr *imageregistryv1.ImagePruner
 	}
 }
 
-func (c *Controller) syncStatus(cr *imageregistryv1.Config, deploy *appsapi.Deployment, applyError error, removed bool) {
+func (c *Controller) syncStatus(cr *imageregistryv1.Config, deploy *appsapi.Deployment, applyError error) {
 	operatorAvailable := operatorapiv1.OperatorCondition{
 		Status:  operatorapiv1.ConditionFalse,
 		Message: "",
@@ -206,7 +206,7 @@ func (c *Controller) syncStatus(cr *imageregistryv1.Config, deploy *appsapi.Depl
 		if e, ok := applyError.(permanentError); ok {
 			operatorAvailable.Message = applyError.Error()
 			operatorAvailable.Reason = e.Reason
-		} else if removed {
+		} else if cr.Spec.ManagementState == operatorapiv1.Removed {
 			operatorAvailable.Status = operatorapiv1.ConditionTrue
 			operatorAvailable.Message = "The registry is removed"
 			operatorAvailable.Reason = "Removed"
@@ -241,7 +241,7 @@ func (c *Controller) syncStatus(cr *imageregistryv1.Config, deploy *appsapi.Depl
 		operatorProgressing.Status = operatorapiv1.ConditionFalse
 		operatorProgressing.Message = "The registry configuration is set to unmanaged mode"
 		operatorProgressing.Reason = "Unmanaged"
-	} else if removed {
+	} else if cr.Spec.ManagementState == operatorapiv1.Removed {
 		if deploy != nil {
 			operatorProgressing.Message = "The deployment is being removed"
 			operatorProgressing.Reason = "DeletingDeployment"
@@ -294,7 +294,7 @@ func (c *Controller) syncStatus(cr *imageregistryv1.Config, deploy *appsapi.Depl
 		Message: "",
 		Reason:  "",
 	}
-	if removed {
+	if cr.Spec.ManagementState == operatorapiv1.Removed {
 		operatorRemoved.Status = operatorapiv1.ConditionTrue
 		operatorRemoved.Message = "The registry is removed"
 		operatorRemoved.Reason = "Removed"

--- a/pkg/resource/caconfig.go
+++ b/pkg/resource/caconfig.go
@@ -11,7 +11,6 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog"
 
-	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	configlisters "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
 )
@@ -31,7 +30,7 @@ type generatorCAConfig struct {
 	namespace             string
 }
 
-func newGeneratorCAConfig(lister corelisters.ConfigMapNamespaceLister, imageConfigLister configlisters.ImageLister, openshiftConfigLister corelisters.ConfigMapNamespaceLister, serviceLister corelisters.ServiceNamespaceLister, client coreset.CoreV1Interface, params *parameters.Globals, cr *imageregistryv1.Config) *generatorCAConfig {
+func newGeneratorCAConfig(lister corelisters.ConfigMapNamespaceLister, imageConfigLister configlisters.ImageLister, openshiftConfigLister corelisters.ConfigMapNamespaceLister, serviceLister corelisters.ServiceNamespaceLister, client coreset.CoreV1Interface, params *parameters.Globals) *generatorCAConfig {
 	return &generatorCAConfig{
 		lister:                lister,
 		imageConfigLister:     imageConfigLister,

--- a/pkg/resource/clusterrole.go
+++ b/pkg/resource/clusterrole.go
@@ -6,8 +6,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	rbacset "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	rbaclisters "k8s.io/client-go/listers/rbac/v1"
-
-	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 )
 
 var _ Mutator = &generatorClusterRole{}
@@ -17,7 +15,7 @@ type generatorClusterRole struct {
 	client rbacset.RbacV1Interface
 }
 
-func newGeneratorClusterRole(lister rbaclisters.ClusterRoleLister, client rbacset.RbacV1Interface, cr *imageregistryv1.Config) *generatorClusterRole {
+func newGeneratorClusterRole(lister rbaclisters.ClusterRoleLister, client rbacset.RbacV1Interface) *generatorClusterRole {
 	return &generatorClusterRole{
 		lister: lister,
 		client: client,

--- a/pkg/resource/clusterrolebinding.go
+++ b/pkg/resource/clusterrolebinding.go
@@ -7,7 +7,6 @@ import (
 	rbacset "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	rbaclisters "k8s.io/client-go/listers/rbac/v1"
 
-	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
 )
 
@@ -20,7 +19,7 @@ type generatorClusterRoleBinding struct {
 	saNamespace string
 }
 
-func newGeneratorClusterRoleBinding(lister rbaclisters.ClusterRoleBindingLister, client rbacset.RbacV1Interface, params *parameters.Globals, cr *imageregistryv1.Config) *generatorClusterRoleBinding {
+func newGeneratorClusterRoleBinding(lister rbaclisters.ClusterRoleBindingLister, client rbacset.RbacV1Interface, params *parameters.Globals) *generatorClusterRoleBinding {
 	return &generatorClusterRoleBinding{
 		lister:      lister,
 		client:      client,

--- a/pkg/resource/deployment.go
+++ b/pkg/resource/deployment.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/openshift/cluster-image-registry-operator/defaults"
@@ -73,6 +74,10 @@ func (gd *generatorDeployment) GetName() string {
 }
 
 func (gd *generatorDeployment) expected() (runtime.Object, error) {
+	if gd.driver == nil {
+		return nil, fmt.Errorf("no storage driver present")
+	}
+
 	podTemplateSpec, deps, err := makePodTemplateSpec(gd.coreClient, gd.proxyLister, gd.driver, gd.params, gd.cr)
 	if err != nil {
 		return nil, err

--- a/pkg/resource/generator.go
+++ b/pkg/resource/generator.go
@@ -93,21 +93,23 @@ func (g *Generator) listRoutes(cr *imageregistryv1.Config) []Mutator {
 
 func (g *Generator) List(cr *imageregistryv1.Config) ([]Mutator, error) {
 	driver, err := storage.NewDriver(&cr.Spec.Storage, g.kubeconfig, g.listers)
-	if err != nil {
+	if err != nil && err != storage.ErrStorageNotConfigured {
 		return nil, err
+	} else if err == storage.ErrStorageNotConfigured {
+		klog.V(6).Info("storage not configured, some mutators might not work.")
 	}
 
 	var mutators []Mutator
-	mutators = append(mutators, newGeneratorClusterRole(g.listers.ClusterRoles, g.clients.RBAC, cr))
-	mutators = append(mutators, newGeneratorClusterRoleBinding(g.listers.ClusterRoleBindings, g.clients.RBAC, g.params, cr))
-	mutators = append(mutators, newGeneratorServiceAccount(g.listers.ServiceAccounts, g.clients.Core, g.params, cr))
+	mutators = append(mutators, newGeneratorClusterRole(g.listers.ClusterRoles, g.clients.RBAC))
+	mutators = append(mutators, newGeneratorClusterRoleBinding(g.listers.ClusterRoleBindings, g.clients.RBAC, g.params))
+	mutators = append(mutators, newGeneratorServiceAccount(g.listers.ServiceAccounts, g.clients.Core, g.params))
 	mutators = append(mutators, newGeneratorServiceCA(g.listers.ConfigMaps, g.clients.Core, g.params))
-	mutators = append(mutators, newGeneratorCAConfig(g.listers.ConfigMaps, g.listers.ImageConfigs, g.listers.OpenShiftConfig, g.listers.Services, g.clients.Core, g.params, cr))
+	mutators = append(mutators, newGeneratorCAConfig(g.listers.ConfigMaps, g.listers.ImageConfigs, g.listers.OpenShiftConfig, g.listers.Services, g.clients.Core, g.params))
 	mutators = append(mutators, newGeneratorPullSecret(g.clients.Core, g.params))
-	mutators = append(mutators, newGeneratorSecret(g.listers.Secrets, g.clients.Core, driver, g.params, cr))
+	mutators = append(mutators, newGeneratorSecret(g.listers.Secrets, g.clients.Core, driver, g.params))
 	mutators = append(mutators, newGeneratorImageConfig(g.listers.ImageConfigs, g.listers.Routes, g.listers.Services, g.clients.Config, g.params))
 	mutators = append(mutators, newGeneratorNodeCADaemonSet(g.listers.DaemonSets, g.listers.Services, g.clients.Apps, g.params))
-	mutators = append(mutators, newGeneratorService(g.listers.Services, g.clients.Core, g.params, cr))
+	mutators = append(mutators, newGeneratorService(g.listers.Services, g.clients.Core, g.params))
 	mutators = append(mutators, newGeneratorDeployment(g.listers.Deployments, g.listers.ConfigMaps, g.listers.Secrets, g.listers.ProxyConfigs, g.clients.Core, g.clients.Apps, driver, g.params, cr))
 	mutators = append(mutators, g.listRoutes(cr)...)
 

--- a/pkg/resource/secret.go
+++ b/pkg/resource/secret.go
@@ -1,11 +1,12 @@
 package resource
 
 import (
+	"fmt"
+
 	"github.com/openshift/cluster-image-registry-operator/defaults"
 	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage"
 
-	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -23,7 +24,7 @@ type generatorSecret struct {
 	namespace string
 }
 
-func newGeneratorSecret(lister corelisters.SecretNamespaceLister, client coreset.CoreV1Interface, driver storage.Driver, params *parameters.Globals, cr *imageregistryv1.Config) *generatorSecret {
+func newGeneratorSecret(lister corelisters.SecretNamespaceLister, client coreset.CoreV1Interface, driver storage.Driver, params *parameters.Globals) *generatorSecret {
 	return &generatorSecret{
 		lister:    lister,
 		client:    client,
@@ -54,6 +55,10 @@ func (gs *generatorSecret) GetName() string {
 }
 
 func (gs *generatorSecret) expected() (runtime.Object, error) {
+	if gs.driver == nil {
+		return nil, fmt.Errorf("no storage driver present")
+	}
+
 	sec := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      gs.GetName(),

--- a/pkg/resource/service.go
+++ b/pkg/resource/service.go
@@ -7,7 +7,6 @@ import (
 	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
 	"github.com/openshift/cluster-image-registry-operator/pkg/resource/strategy"
 
-	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -28,7 +27,7 @@ type generatorService struct {
 	secretName string
 }
 
-func newGeneratorService(lister corelisters.ServiceNamespaceLister, client coreset.CoreV1Interface, params *parameters.Globals, cr *imageregistryv1.Config) *generatorService {
+func newGeneratorService(lister corelisters.ServiceNamespaceLister, client coreset.CoreV1Interface, params *parameters.Globals) *generatorService {
 	return &generatorService{
 		lister:     lister,
 		client:     client,

--- a/pkg/resource/serviceaccount.go
+++ b/pkg/resource/serviceaccount.go
@@ -7,7 +7,6 @@ import (
 	coreset "k8s.io/client-go/kubernetes/typed/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 
-	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
 )
 
@@ -20,7 +19,7 @@ type generatorServiceAccount struct {
 	namespace string
 }
 
-func newGeneratorServiceAccount(lister corelisters.ServiceAccountNamespaceLister, client coreset.CoreV1Interface, params *parameters.Globals, cr *imageregistryv1.Config) *generatorServiceAccount {
+func newGeneratorServiceAccount(lister corelisters.ServiceAccountNamespaceLister, client coreset.CoreV1Interface, params *parameters.Globals) *generatorServiceAccount {
 	return &generatorServiceAccount{
 		lister:    lister,
 		client:    client,


### PR DESCRIPTION
This patch is needed as when the image registry is Removed in an environment where there is no storage backend the operator keeps logging:

"controller.go:353] unable to sync: unable to get generators: storage backend not configured, requeuing"

During removal the driver property in some Mutators is optional. This PR makes the Mutators to work without them, returning error when they are mandatory.