### PR TITLE
Bug 1806019: Enable --prune-registry flag

### DIFF
--- a/pkg/resource/generator.go
+++ b/pkg/resource/generator.go
@@ -112,7 +112,7 @@ func (g *Generator) List(cr *imageregistryv1.Config) ([]Mutator, error) {
 	mutators = append(mutators, newGeneratorPrunerResource(g.listers.ImagePrunerConfigs, g.clients.RegOp.ImageregistryV1(), g.params))
 	mutators = append(mutators, newGeneratorPrunerClusterRoleBinding(g.listers.ClusterRoleBindings, g.clients.RBAC, g.params))
 	mutators = append(mutators, newGeneratorPrunerServiceAccount(g.listers.ServiceAccounts, g.clients.Core, g.params))
-	mutators = append(mutators, newGeneratorPrunerCronJob(g.listers.CronJobs, g.clients.Batch, g.listers.ImagePrunerConfigs, g.params))
+	mutators = append(mutators, newGeneratorPrunerCronJob(g.listers.CronJobs, g.clients.Batch, g.listers.ImagePrunerConfigs, g.listers.RegistryConfigs, g.params))
 
 	return mutators, nil
 }

--- a/test/e2e/pruner_test.go
+++ b/test/e2e/pruner_test.go
@@ -2,17 +2,97 @@ package e2e
 
 import (
 	"testing"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	operatorapi "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-image-registry-operator/defaults"
 	"github.com/openshift/cluster-image-registry-operator/test/framework"
 )
 
-// TestPrunerInstalled is a test to verify that the pruner cronjob
-// is setup and running
+// TestPruneRegistry ensures that the value for the --prune-registry flag
+// is set correctly based on the image registry's custom resources
+// Spec.ManagementState field
+func TestPruneRegistryFlag(t *testing.T) {
+	client := framework.MustNewClientset(t, nil)
+
+	// TODO: Move these checks to a conformance test run on all providers
+	defer framework.MustRemoveImageRegistry(t, client)
+	framework.MustDeployImageRegistry(t, client, nil)
+	framework.MustEnsureImageRegistryIsAvailable(t, client)
+	framework.MustEnsureInternalRegistryHostnameIsSet(t, client)
+	framework.MustEnsureClusterOperatorStatusIsNormal(t, client)
+	framework.MustEnsureOperatorIsNotHotLooping(t, client)
+	framework.MustEnsureServiceCAConfigMap(t, client)
+	framework.MustEnsureNodeCADaemonSetIsAvailable(t, client)
+
+	cr, err := client.Configs().Get(defaults.ImageRegistryResourceName, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		t.Errorf("unable to get the image registry custom resource: %s", err)
+	} else if err != nil {
+		t.Fatal(err)
+	}
+	// Check that the cronjob was created
+	cronjob, err := client.BatchV1beta1Interface.CronJobs(defaults.ImageRegistryOperatorNamespace).Get("image-pruner", metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		t.Errorf("unable to get the image pruner cronjob: %s", err)
+	} else if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that the image registry is in the Managed state
+	if cr.Spec.ManagementState != operatorapi.Managed {
+		t.Errorf("the image registry Spec.ManagementState should be Managed but was %s instead: %s", cr.Spec.ManagementState, err)
+	}
+
+	// Check that the --prune-registry flag is true on the pruning cronjob
+	if err := framework.FlagExistsWithValue(cronjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Args, "--prune-registry", "true"); err != nil {
+		t.Errorf("%v", err)
+	}
+
+	cr.Spec.ManagementState = operatorapi.Removed
+
+	// Set the image registry to be Removed
+	if _, err := client.Configs().Update(cr); err != nil {
+		t.Errorf("unable to update image registry custom resource: %s", err)
+	}
+
+	var errs []error
+
+	// Wait for the cronjob to have an updated --prune-registry flag
+	err = wait.Poll(1*time.Second, framework.AsyncOperationTimeout, func() (stop bool, err error) {
+		errs = nil
+		// Get an updated version of the cronjob
+		cronjob, err = client.BatchV1beta1Interface.CronJobs(defaults.ImageRegistryOperatorNamespace).Get("image-pruner", metav1.GetOptions{})
+		if err != nil {
+			return true, err
+		}
+
+		// Check if the --prune-registry flag is now false on the pruning cronjob
+		if err = framework.FlagExistsWithValue(cronjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Args, "--prune-registry", "false"); err != nil {
+			errs = append(errs, err)
+			return false, nil
+		}
+
+		return true, nil
+
+	})
+	if err != nil {
+		errs = append(errs, err)
+	}
+	if len(errs) != 0 {
+		for _, err := range errs {
+			t.Errorf("%#v", err)
+		}
+	}
+
+}
+
+// TestPruner verifies that the pruner controller installs the cronjob and sets it's
+// conditions appropriately
 func TestPruner(t *testing.T) {
 	client := framework.MustNewClientset(t, nil)
 
@@ -29,7 +109,7 @@ func TestPruner(t *testing.T) {
 	// Check that the pruner custom resource was created
 	cr, err := client.ImagePruners().Get(defaults.ImageRegistryImagePrunerResourceName, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
-		t.Errorf("unable to get the image registry pruner custom resource: %s", err)
+		t.Errorf("unable to get the image pruner custom resource: %s", err)
 	} else if err != nil {
 		t.Fatal(err)
 	}

--- a/test/framework/util.go
+++ b/test/framework/util.go
@@ -8,6 +8,18 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+func FlagExistsWithValue(args []string, flag string, value string) error {
+	for _, arg := range args {
+		if strings.HasPrefix(arg, flag) {
+			if strings.Split(arg, "=")[1] == value {
+				return nil
+			}
+			return fmt.Errorf("flag %q was found, but the value was %q when it should have been %q: %#v", flag, strings.Split(arg, "=")[1], value, args)
+		}
+	}
+	return fmt.Errorf("flag %q was not found in %#v", flag, args)
+}
+
 func CheckEnvVars(want []corev1.EnvVar, have []corev1.EnvVar, includes bool) []error {
 	var errs []error
 


### PR DESCRIPTION
Adds the --prune-registry flag to the oc admin command in the pruner cronjob based on the management state of the image registry custom resource