### PR TITLE
DEVEXP-515 - Mounting install pull secrets on image registry.

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -11,6 +11,10 @@ const (
 	// PVCImageRegistryName is the default name of the claim provisioned for PVC backend
 	PVCImageRegistryName = "image-registry-storage"
 
+	// InstallationPullSecret is the secret where we keep pull secrets provided during
+	// cluster installation.
+	InstallationPullSecret = "installation-pull-secrets"
+
 	// ImageRegistryResourceName is the name of the image registry config instance
 	ImageRegistryResourceName = "cluster"
 

--- a/pkg/resource/generator.go
+++ b/pkg/resource/generator.go
@@ -103,6 +103,7 @@ func (g *Generator) List(cr *imageregistryv1.Config) ([]Mutator, error) {
 	mutators = append(mutators, newGeneratorServiceAccount(g.listers.ServiceAccounts, g.clients.Core, g.params, cr))
 	mutators = append(mutators, newGeneratorServiceCA(g.listers.ConfigMaps, g.clients.Core, g.params))
 	mutators = append(mutators, newGeneratorCAConfig(g.listers.ConfigMaps, g.listers.ImageConfigs, g.listers.OpenShiftConfig, g.listers.Services, g.clients.Core, g.params, cr))
+	mutators = append(mutators, newGeneratorPullSecret(g.clients.Core, g.params))
 	mutators = append(mutators, newGeneratorSecret(g.listers.Secrets, g.clients.Core, driver, g.params, cr))
 	mutators = append(mutators, newGeneratorImageConfig(g.listers.ImageConfigs, g.listers.Routes, g.listers.Services, g.clients.Config, g.params))
 	mutators = append(mutators, newGeneratorNodeCADaemonSet(g.listers.DaemonSets, g.listers.Services, g.clients.Apps, g.params))

--- a/pkg/resource/podtemplatespec.go
+++ b/pkg/resource/podtemplatespec.go
@@ -273,6 +273,31 @@ func makePodTemplateSpec(coreClient coreset.CoreV1Interface, proxyLister configl
 	mounts = append(mounts, corev1.VolumeMount{Name: vol.Name, MountPath: "/usr/share/pki/ca-trust-source"})
 	deps.AddConfigMap(params.TrustedCA.Name)
 
+	vol = corev1.Volume{
+		Name: defaults.InstallationPullSecret,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				Items: []corev1.KeyToPath{
+					{
+						Key:  ".dockerconfigjson",
+						Path: "config.json",
+					},
+				},
+				SecretName: defaults.InstallationPullSecret,
+				Optional:   &optional,
+			},
+		},
+	}
+	volumes = append(volumes, vol)
+	mounts = append(
+		mounts,
+		corev1.VolumeMount{
+			Name:      vol.Name,
+			MountPath: "/var/lib/kubelet/",
+		},
+	)
+	deps.AddSecret(defaults.InstallationPullSecret)
+
 	image := os.Getenv("IMAGE")
 
 	resources := corev1.ResourceRequirements{

--- a/pkg/resource/podtemplatespec_test.go
+++ b/pkg/resource/podtemplatespec_test.go
@@ -88,6 +88,17 @@ func TestMakePodTemplateSpec(t *testing.T) {
 			},
 			optional: true,
 		},
+		"installation-pull-secrets": {
+			refName:   defaults.InstallationPullSecret,
+			mountPath: "/var/lib/kubelet/",
+			optional:  true,
+			items: []corev1.KeyToPath{
+				{
+					Key:  ".dockerconfigjson",
+					Path: "config.json",
+				},
+			},
+		},
 	}
 	// emptyDir adds an additional volume
 	expectedVolumes["registry-storage"] = &volumeMount{
@@ -132,7 +143,8 @@ func TestMakePodTemplateSpec(t *testing.T) {
 		"image-registry-certificates": false,
 	}
 	expectedSecrets := map[string]bool{
-		"image-registry-tls": false,
+		"image-registry-tls":        false,
+		"installation-pull-secrets": false,
 	}
 	for cm := range deps.configMaps {
 		if _, ok := expectedConfigMaps[cm]; !ok {

--- a/pkg/resource/pullsecret.go
+++ b/pkg/resource/pullsecret.go
@@ -1,0 +1,101 @@
+package resource
+
+import (
+	"github.com/openshift/cluster-image-registry-operator/defaults"
+	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	coreset "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+var _ Mutator = &generatorPullSecret{}
+
+type generatorPullSecret struct {
+	client    coreset.CoreV1Interface
+	namespace string
+}
+
+func newGeneratorPullSecret(
+	client coreset.CoreV1Interface,
+	params *parameters.Globals,
+) *generatorPullSecret {
+	return &generatorPullSecret{
+		client:    client,
+		namespace: params.Deployment.Namespace,
+	}
+}
+
+func (gs *generatorPullSecret) Type() runtime.Object {
+	return &corev1.Secret{}
+}
+
+func (gs *generatorPullSecret) GetGroup() string {
+	return corev1.GroupName
+}
+
+func (gs *generatorPullSecret) GetResource() string {
+	return "secrets"
+}
+
+func (gs *generatorPullSecret) GetNamespace() string {
+	return gs.namespace
+}
+
+func (gs *generatorPullSecret) GetName() string {
+	return defaults.InstallationPullSecret
+}
+
+func (gs *generatorPullSecret) expected() (runtime.Object, error) {
+	sec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gs.GetName(),
+			Namespace: gs.GetNamespace(),
+		},
+		Type: corev1.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{},
+	}
+
+	orig, err := gs.client.Secrets("openshift-config").Get(
+		"pull-secret", metav1.GetOptions{},
+	)
+	if errors.IsNotFound(err) {
+		return sec, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	sec.Data = orig.Data
+	return sec, nil
+}
+
+func (gs *generatorPullSecret) Get() (runtime.Object, error) {
+	return gs.client.Secrets(gs.GetNamespace()).Get(
+		gs.GetName(), metav1.GetOptions{},
+	)
+}
+
+func (gs *generatorPullSecret) Create() (runtime.Object, error) {
+	return commonCreate(gs, func(obj runtime.Object) (runtime.Object, error) {
+		return gs.client.Secrets(gs.GetNamespace()).Create(
+			obj.(*corev1.Secret),
+		)
+	})
+}
+
+func (gs *generatorPullSecret) Update(o runtime.Object) (runtime.Object, bool, error) {
+	return commonUpdate(gs, o, func(obj runtime.Object) (runtime.Object, error) {
+		return gs.client.Secrets(gs.GetNamespace()).Update(
+			obj.(*corev1.Secret),
+		)
+	})
+}
+
+func (gs *generatorPullSecret) Delete(opts *metav1.DeleteOptions) error {
+	return gs.client.Secrets(gs.GetNamespace()).Delete(gs.GetName(), opts)
+}
+
+func (g *generatorPullSecret) Owned() bool {
+	return true
+}


### PR DESCRIPTION
This PRs creates a Mutator that migrates installation pull secrets from
openshift-config namespace into registry's namespace. It also mounts
these pull secrets so we can later on leverage them when doing image
pull throughs.