### PR TITLE
Bug 1776665: Remove watch for KubeSystem ConfigMaps

### DIFF
--- a/pkg/client/fake/fixtures.go
+++ b/pkg/client/fake/fixtures.go
@@ -215,7 +215,6 @@ func (f *FixturesBuilder) BuildListers() *client.Listers {
 		ImageConfigs:        configv1listers.NewImageLister(f.imageConfigsIndexer),
 		ClusterOperators:    configv1listers.NewClusterOperatorLister(f.clusterOperatorsIndexer),
 		RegistryConfigs:     regopv1listers.NewConfigLister(f.registryConfigsIndexer),
-		InstallerConfigMaps: corev1listers.NewConfigMapLister(f.configMapsIndexer).ConfigMaps("kube-system"),
 		ProxyConfigs:        configv1listers.NewProxyLister(f.proxyConfigsIndexer),
 		Infrastructures:     configv1listers.NewInfrastructureLister(f.infraIndexer),
 	}

--- a/pkg/client/listers.go
+++ b/pkg/client/listers.go
@@ -29,7 +29,6 @@ type Listers struct {
 	ClusterOperators    configlisters.ClusterOperatorLister
 	RegistryConfigs     regoplisters.ConfigLister
 	ImagePrunerConfigs  regoplisters.ImagePrunerLister
-	InstallerConfigMaps kcorelisters.ConfigMapNamespaceLister
 	ProxyConfigs        configlisters.ProxyLister
 	Infrastructures     configlisters.InfrastructureLister
 }

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -9,7 +9,6 @@ import (
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage"
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage/pvc"
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage/swift"
-	"github.com/openshift/cluster-image-registry-operator/pkg/storage/util"
 
 	configapiv1 "github.com/openshift/api/config/v1"
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
@@ -67,7 +66,7 @@ func (c *Controller) Bootstrap() error {
 		mgmtState = operatorapi.Removed
 	}
 
-	infra, err := util.GetInfrastructure(c.listers)
+	infra, err := c.listers.Infrastructures.Get("cluster")
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -378,7 +378,6 @@ func (c *Controller) Run(stopCh <-chan struct{}) error {
 	configInformerFactory := configinformers.NewSharedInformerFactory(configClient, defaultResyncDuration)
 	kubeInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(c.clients.Kube, defaultResyncDuration, kubeinformers.WithNamespace(c.params.Deployment.Namespace))
 	openshiftConfigKubeInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(c.clients.Kube, defaultResyncDuration, kubeinformers.WithNamespace(openshiftConfigNamespace))
-	kubeSystemKubeInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(c.clients.Kube, defaultResyncDuration, kubeinformers.WithNamespace(kubeSystemNamespace))
 	regopInformerFactory := regopinformers.NewSharedInformerFactory(c.clients.RegOp, defaultResyncDuration)
 	routeInformerFactory := routeinformers.NewSharedInformerFactoryWithOptions(routeClient, defaultResyncDuration, routeinformers.WithNamespace(c.params.Deployment.Namespace))
 
@@ -460,11 +459,6 @@ func (c *Controller) Run(stopCh <-chan struct{}) error {
 			return informer.Informer()
 		},
 		func() cache.SharedIndexInformer {
-			informer := kubeSystemKubeInformerFactory.Core().V1().ConfigMaps()
-			c.listers.InstallerConfigMaps = informer.Lister().ConfigMaps(kubeSystemNamespace)
-			return informer.Informer()
-		},
-		func() cache.SharedIndexInformer {
 			informer := configInformerFactory.Config().V1().Infrastructures()
 			c.listers.Infrastructures = informer.Lister()
 			return informer.Informer()
@@ -496,7 +490,6 @@ func (c *Controller) Run(stopCh <-chan struct{}) error {
 	configInformerFactory.Start(stopCh)
 	kubeInformerFactory.Start(stopCh)
 	openshiftConfigKubeInformerFactory.Start(stopCh)
-	kubeSystemKubeInformerFactory.Start(stopCh)
 	regopInformerFactory.Start(stopCh)
 	routeInformerFactory.Start(stopCh)
 

--- a/pkg/storage/azure/azure.go
+++ b/pkg/storage/azure/azure.go
@@ -388,7 +388,7 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 		util.UpdateCondition(cr, defaults.StorageExists, operatorapiv1.ConditionUnknown, storageExistsReasonConfigError, fmt.Sprintf("Unable to get configuration: %s", err))
 		return err
 	}
-	infra, err := util.GetInfrastructure(d.Listers)
+	infra, err := d.Listers.Infrastructures.Get("cluster")
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/gcs/gcs.go
+++ b/pkg/storage/gcs/gcs.go
@@ -77,7 +77,7 @@ func (d *driver) getGCSClient() (*gstorage.Client, error) {
 func GetConfig(listers *regopclient.Listers) (*GCS, error) {
 	gcsConfig := &GCS{}
 
-	infra, err := util.GetInfrastructure(listers)
+	infra, err := listers.Infrastructures.Get("cluster")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -57,7 +57,7 @@ func NewDriver(ctx context.Context, c *imageregistryv1.ImageRegistryConfigStorag
 func GetConfig(listers *regopclient.Listers) (*S3, error) {
 	cfg := &S3{}
 
-	infra, err := util.GetInfrastructure(listers)
+	infra, err := listers.Infrastructures.Get("cluster")
 	if err != nil {
 		return nil, err
 	}
@@ -302,7 +302,7 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 		return err
 	}
 
-	infra, err := util.GetInfrastructure(d.Listers)
+	infra, err := d.Listers.Infrastructures.Get("cluster")
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -18,7 +18,6 @@ import (
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage/pvc"
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage/s3"
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage/swift"
-	"github.com/openshift/cluster-image-registry-operator/pkg/storage/util"
 )
 
 var (
@@ -132,7 +131,7 @@ func NewDriver(cfg *imageregistryv1.ImageRegistryConfigStorage, kubeconfig *rest
 func GetPlatformStorage(listers *regopclient.Listers) (imageregistryv1.ImageRegistryConfigStorage, error) {
 	var cfg imageregistryv1.ImageRegistryConfigStorage
 
-	infra, err := util.GetInfrastructure(listers)
+	infra, err := listers.Infrastructures.Get("cluster")
 	if err != nil {
 		return imageregistryv1.ImageRegistryConfigStorage{}, err
 	}

--- a/pkg/storage/swift/swift.go
+++ b/pkg/storage/swift/swift.go
@@ -370,7 +370,7 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 		return err
 	}
 
-	infra, err := util.GetInfrastructure(d.Listers)
+	infra, err := d.Listers.Infrastructures.Get("cluster")
 	if err != nil {
 		return fmt.Errorf("failed to get cluster infrastructure info: %v", err)
 	}

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -10,7 +10,6 @@ import (
 	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage"
 	storages3 "github.com/openshift/cluster-image-registry-operator/pkg/storage/s3"
-	"github.com/openshift/cluster-image-registry-operator/pkg/storage/util"
 	"github.com/openshift/cluster-image-registry-operator/test/framework"
 	"github.com/openshift/cluster-image-registry-operator/test/framework/mock/listers"
 
@@ -44,7 +43,7 @@ func TestAWSDefaults(t *testing.T) {
 	newMockLister, err := listers.NewMockLister(kcfg)
 	mockLister, err := newMockLister.GetListers()
 
-	infra, err := util.GetInfrastructure(mockLister)
+	infra, err := mockLister.Infrastructures.Get("cluster")
 	if err != nil {
 		t.Fatalf("unable to get install configuration: %v", err)
 	}
@@ -344,7 +343,7 @@ func TestAWSUnableToCreateBucketOnStartup(t *testing.T) {
 	newMockLister, err := listers.NewMockLister(kubeconfig)
 	mockLister, err := newMockLister.GetListers()
 
-	infra, err := util.GetInfrastructure(mockLister)
+	infra, err := mockLister.Infrastructures.Get("cluster")
 	if err != nil {
 		t.Fatalf("unable to get install configuration: %v", err)
 	}
@@ -399,7 +398,7 @@ func TestAWSUpdateCredentials(t *testing.T) {
 	newMockLister, err := listers.NewMockLister(kcfg)
 	mockLister, err := newMockLister.GetListers()
 
-	infra, err := util.GetInfrastructure(mockLister)
+	infra, err := mockLister.Infrastructures.Get("cluster")
 	if err != nil {
 		t.Fatalf("unable to get install configuration: %v", err)
 	}
@@ -473,7 +472,7 @@ func TestAWSChangeS3Encryption(t *testing.T) {
 	newMockLister, err := listers.NewMockLister(kubeconfig)
 	mockLister, err := newMockLister.GetListers()
 
-	infra, err := util.GetInfrastructure(mockLister)
+	infra, err := mockLister.Infrastructures.Get("cluster")
 	if err != nil {
 		t.Fatalf("unable to get install configuration: %v", err)
 	}
@@ -660,7 +659,7 @@ func TestAWSFinalizerDeleteS3Bucket(t *testing.T) {
 	newMockLister, err := listers.NewMockLister(kcfg)
 	mockLister, err := newMockLister.GetListers()
 
-	infra, err := util.GetInfrastructure(mockLister)
+	infra, err := mockLister.Infrastructures.Get("cluster")
 	if err != nil {
 		t.Fatalf("unable to get install configuration: %v", err)
 	}

--- a/test/e2e/gcs_test.go
+++ b/test/e2e/gcs_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/openshift/cluster-image-registry-operator/defaults"
 	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
-	"github.com/openshift/cluster-image-registry-operator/pkg/storage/util"
 	"github.com/openshift/cluster-image-registry-operator/test/framework"
 	"github.com/openshift/cluster-image-registry-operator/test/framework/mock/listers"
 
@@ -49,7 +48,7 @@ func TestGCSMinimal(t *testing.T) {
 	newMockLister, err := listers.NewMockLister(kcfg)
 	mockLister, err := newMockLister.GetListers()
 
-	infra, err := util.GetInfrastructure(mockLister)
+	infra, err := mockLister.Infrastructures.Get("cluster")
 	if err != nil {
 		t.Fatalf("unable to get install configuration: %v", err)
 	}

--- a/test/framework/mock/listers/listers.go
+++ b/test/framework/mock/listers/listers.go
@@ -34,7 +34,6 @@ func (m *mockLister) GetListers() (*regopclient.Listers, error) {
 	}
 
 	m.listers.Secrets = MockSecretNamespaceLister{namespace: defaults.ImageRegistryOperatorNamespace, client: coreClient}
-	m.listers.InstallerConfigMaps = MockConfigMapNamespaceLister{namespace: installerConfigNamespace, client: coreClient}
 	m.listers.Infrastructures = MockInfrastructureLister{client: *configClient}
 
 	return &m.listers, err


### PR DESCRIPTION
We should no longer rely on the installConfig configmap in the kubesystem.
Removing the watch for the kubesystem configmaps will fix the out of control
event processing every 4 seconds