### PR TITLE
remove gosec check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,17 +24,12 @@ test-e2e:
 	./hack/test-go.sh -count 1 -timeout 2h -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/
 .PHONY: test-e2e
 
-verify: verify-fmt verify-sec
+verify: verify-fmt
 .PHONY: verify
 
 verify-fmt:
 	./hack/verify-gofmt.sh
 .PHONY: verify-gofmt
-
-verify-sec:
-	go get -u github.com/securego/gosec/cmd/gosec
-	gosec -severity medium -confidence medium -exclude G304 -quiet ./...
-.PHONY: verify-sec
 
 update-deps:
 	go get -d -u \


### PR DESCRIPTION
Per an email thread on aos-devel, gosec does not meet our security/compliance needs, and has already been removed from newer branches of the ciro code including master.  This is just a backport so that make build/make test doesn't take so long to run.