### PR TITLE
Bug 1809467: Making storage driver optional on Mutators.

### DIFF
--- a/pkg/resource/deployment.go
+++ b/pkg/resource/deployment.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/openshift/cluster-image-registry-operator/defaults"
@@ -73,6 +74,10 @@ func (gd *generatorDeployment) GetName() string {
 }
 
 func (gd *generatorDeployment) expected() (runtime.Object, error) {
+	if gd.driver == nil {
+		return nil, fmt.Errorf("no storage driver present")
+	}
+
 	podTemplateSpec, deps, err := makePodTemplateSpec(gd.coreClient, gd.proxyLister, gd.driver, gd.params, gd.cr)
 	if err != nil {
 		return nil, err

--- a/pkg/resource/generator.go
+++ b/pkg/resource/generator.go
@@ -93,8 +93,10 @@ func (g *Generator) listRoutes(cr *imageregistryv1.Config) []Mutator {
 
 func (g *Generator) List(cr *imageregistryv1.Config) ([]Mutator, error) {
 	driver, err := storage.NewDriver(&cr.Spec.Storage, g.kubeconfig, g.listers)
-	if err != nil {
+	if err != nil && err != storage.ErrStorageNotConfigured {
 		return nil, err
+	} else if err == storage.ErrStorageNotConfigured {
+		klog.V(6).Info("storage not configured, some mutators might not work.")
 	}
 
 	var mutators []Mutator

--- a/pkg/resource/secret.go
+++ b/pkg/resource/secret.go
@@ -1,6 +1,8 @@
 package resource
 
 import (
+	"fmt"
+
 	"github.com/openshift/cluster-image-registry-operator/defaults"
 	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage"
@@ -54,6 +56,10 @@ func (gs *generatorSecret) GetName() string {
 }
 
 func (gs *generatorSecret) expected() (runtime.Object, error) {
+	if gs.driver == nil {
+		return nil, fmt.Errorf("no storage driver present")
+	}
+
 	sec := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      gs.GetName(),


### PR DESCRIPTION
Making storage drivers optional on Mutator allows us to the latter when
deleting resources.

This is a stripped down version of:

9869211040b8a038a85f85802d5cf858371b58cb

The original commit contains refactoring that is not needed on a
backport, by doing so we avoid a merge conflict against 4.4 release.