### PR TITLE
Re-grouping and re-ordering go imports

### DIFF
--- a/cmd/cluster-image-registry-operator/main.go
+++ b/cmd/cluster-image-registry-operator/main.go
@@ -8,16 +8,17 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/klog"
+
+	"github.com/openshift/library-go/pkg/operator/watchdog"
 
 	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
 	"github.com/openshift/cluster-image-registry-operator/pkg/metrics"
 	"github.com/openshift/cluster-image-registry-operator/pkg/operator"
 	"github.com/openshift/cluster-image-registry-operator/pkg/signals"
 	"github.com/openshift/cluster-image-registry-operator/version"
-	"github.com/openshift/library-go/pkg/operator/watchdog"
-
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 const metricsPort = 60000

--- a/pkg/client/fake/fixtures.go
+++ b/pkg/client/fake/fixtures.go
@@ -1,14 +1,6 @@
 package fake
 
 import (
-	"github.com/openshift/cluster-image-registry-operator/pkg/client"
-
-	configv1 "github.com/openshift/api/config/v1"
-	regopv1 "github.com/openshift/api/imageregistry/v1"
-	routev1 "github.com/openshift/api/route/v1"
-	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
-	regopv1listers "github.com/openshift/client-go/imageregistry/listers/imageregistry/v1"
-	routev1listers "github.com/openshift/client-go/route/listers/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -18,6 +10,15 @@ import (
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	rbacv1listers "k8s.io/client-go/listers/rbac/v1"
 	"k8s.io/client-go/tools/cache"
+
+	configv1 "github.com/openshift/api/config/v1"
+	regopv1 "github.com/openshift/api/imageregistry/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
+	regopv1listers "github.com/openshift/client-go/imageregistry/listers/imageregistry/v1"
+	routev1listers "github.com/openshift/client-go/route/listers/route/v1"
+
+	"github.com/openshift/cluster-image-registry-operator/pkg/client"
 )
 
 // FixturesBuilder helps create an in-memory version of client.Listers.

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
 	"k8s.io/klog"
 )
 

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -4,22 +4,23 @@ import (
 	"crypto/rand"
 	"fmt"
 
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
-	"github.com/openshift/cluster-image-registry-operator/pkg/storage"
-	"github.com/openshift/cluster-image-registry-operator/pkg/storage/pvc"
-	"github.com/openshift/cluster-image-registry-operator/pkg/storage/swift"
-
-	configapiv1 "github.com/openshift/api/config/v1"
-	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
-	operatorapi "github.com/openshift/api/operator/v1"
-	regopset "github.com/openshift/client-go/imageregistry/clientset/versioned/typed/imageregistry/v1"
 	appsapi "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
+
+	configapiv1 "github.com/openshift/api/config/v1"
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+	operatorapi "github.com/openshift/api/operator/v1"
+	regopset "github.com/openshift/client-go/imageregistry/clientset/versioned/typed/imageregistry/v1"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
+	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
+	"github.com/openshift/cluster-image-registry-operator/pkg/storage"
+	"github.com/openshift/cluster-image-registry-operator/pkg/storage/pvc"
+	"github.com/openshift/cluster-image-registry-operator/pkg/storage/swift"
 )
 
 // randomSecretSize is the number of random bytes to generate

--- a/pkg/operator/complete.go
+++ b/pkg/operator/complete.go
@@ -3,10 +3,10 @@ package operator
 import (
 	"fmt"
 
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+
 	"github.com/openshift/cluster-image-registry-operator/defaults"
 	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
-
-	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 )
 
 func appendFinalizer(cr *imageregistryv1.Config) {

--- a/pkg/operator/finalizer.go
+++ b/pkg/operator/finalizer.go
@@ -13,6 +13,7 @@ import (
 
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	regopset "github.com/openshift/client-go/imageregistry/clientset/versioned/typed/imageregistry/v1"
+
 	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
 )
 

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -2,16 +2,17 @@ package operator
 
 import (
 	"fmt"
-	"github.com/openshift/cluster-image-registry-operator/pkg/metrics"
 
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-
-	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
-	operatorapiv1 "github.com/openshift/api/operator/v1"
 	appsapi "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	batchapi "k8s.io/api/batch/v1beta1"
 	metaapi "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+	operatorapiv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
+	"github.com/openshift/cluster-image-registry-operator/pkg/metrics"
 )
 
 func updateCondition(cr *imageregistryv1.Config, condtype string, condstate operatorapiv1.OperatorCondition) {

--- a/pkg/resource/caconfig.go
+++ b/pkg/resource/caconfig.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/klog"
 
 	configlisters "github.com/openshift/client-go/config/listers/config/v1"
+
 	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
 )
 

--- a/pkg/resource/clusteroperator_test.go
+++ b/pkg/resource/clusteroperator_test.go
@@ -5,15 +5,16 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-
-	cfgapi "github.com/openshift/api/config/v1"
-	imregv1 "github.com/openshift/api/imageregistry/v1"
-	operatorapi "github.com/openshift/api/operator/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	kerror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
+
+	cfgapi "github.com/openshift/api/config/v1"
+	imregv1 "github.com/openshift/api/imageregistry/v1"
+	operatorapi "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
 )
 
 type deployLister struct {

--- a/pkg/resource/deployment.go
+++ b/pkg/resource/deployment.go
@@ -4,16 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
-	"github.com/openshift/cluster-image-registry-operator/pkg/resource/strategy"
-	"github.com/openshift/cluster-image-registry-operator/pkg/storage"
-
-	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
-	operatorv1 "github.com/openshift/api/operator/v1"
-	configlisters "github.com/openshift/client-go/config/listers/config/v1"
-	"github.com/openshift/library-go/pkg/operator/events"
-	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	appsapi "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -21,6 +11,17 @@ import (
 	coreset "k8s.io/client-go/kubernetes/typed/core/v1"
 	appslisters "k8s.io/client-go/listers/apps/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
+
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	configlisters "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
+	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
+	"github.com/openshift/cluster-image-registry-operator/pkg/resource/strategy"
+	"github.com/openshift/cluster-image-registry-operator/pkg/storage"
 )
 
 var _ Mutator = &generatorDeployment{}

--- a/pkg/resource/generator.go
+++ b/pkg/resource/generator.go
@@ -5,14 +5,6 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-	"github.com/openshift/cluster-image-registry-operator/pkg/client"
-	"github.com/openshift/cluster-image-registry-operator/pkg/metrics"
-	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
-	"github.com/openshift/cluster-image-registry-operator/pkg/resource/object"
-	"github.com/openshift/cluster-image-registry-operator/pkg/storage"
-
-	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metaapi "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -20,6 +12,15 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog"
+
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
+	"github.com/openshift/cluster-image-registry-operator/pkg/client"
+	"github.com/openshift/cluster-image-registry-operator/pkg/metrics"
+	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
+	"github.com/openshift/cluster-image-registry-operator/pkg/resource/object"
+	"github.com/openshift/cluster-image-registry-operator/pkg/storage"
 )
 
 func ApplyMutator(gen Mutator) error {

--- a/pkg/resource/generatorimagepruner.go
+++ b/pkg/resource/generatorimagepruner.go
@@ -3,14 +3,15 @@ package resource
 import (
 	"fmt"
 
-	"github.com/openshift/cluster-image-registry-operator/pkg/client"
-	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
-
-	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metaapi "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog"
+
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+
+	"github.com/openshift/cluster-image-registry-operator/pkg/client"
+	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
 )
 
 func NewImagePrunerGenerator(kubeconfig *rest.Config, clients *client.Clients, listers *client.ImagePrunerControllerListers, params *parameters.Globals) *ImagePrunerGenerator {

--- a/pkg/resource/imageconfig.go
+++ b/pkg/resource/imageconfig.go
@@ -6,18 +6,19 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
-
-	configapi "github.com/openshift/api/config/v1"
-	configset "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
-	configlisters "github.com/openshift/client-go/config/listers/config/v1"
-	routelisters "github.com/openshift/client-go/route/listers/route/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	kcorelisters "k8s.io/client-go/listers/core/v1"
+
+	configapi "github.com/openshift/api/config/v1"
+	configset "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	configlisters "github.com/openshift/client-go/config/listers/config/v1"
+	routelisters "github.com/openshift/client-go/route/listers/route/v1"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
+	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
 )
 
 var _ Mutator = &generatorImageConfig{}

--- a/pkg/resource/podtemplatespec.go
+++ b/pkg/resource/podtemplatespec.go
@@ -6,19 +6,20 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
-	"github.com/openshift/cluster-image-registry-operator/pkg/storage"
-
-	configapiv1 "github.com/openshift/api/config/v1"
-	v1 "github.com/openshift/api/imageregistry/v1"
-	configlisters "github.com/openshift/client-go/config/listers/config/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	coreset "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	configapiv1 "github.com/openshift/api/config/v1"
+	v1 "github.com/openshift/api/imageregistry/v1"
+	configlisters "github.com/openshift/client-go/config/listers/config/v1"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
+	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
+	"github.com/openshift/cluster-image-registry-operator/pkg/storage"
 )
 
 func generateLogLevel(cr *v1.Config) string {

--- a/pkg/resource/podtemplatespec_test.go
+++ b/pkg/resource/podtemplatespec_test.go
@@ -3,14 +3,15 @@ package resource
 import (
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "github.com/openshift/api/imageregistry/v1"
+
 	"github.com/openshift/cluster-image-registry-operator/defaults"
 	cirofake "github.com/openshift/cluster-image-registry-operator/pkg/client/fake"
 	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage/emptydir"
-
-	v1 "github.com/openshift/api/imageregistry/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type volumeMount struct {

--- a/pkg/resource/prunercronjob.go
+++ b/pkg/resource/prunercronjob.go
@@ -15,8 +15,8 @@ import (
 
 	imageregistryapiv1 "github.com/openshift/api/imageregistry/v1"
 	operatorapi "github.com/openshift/api/operator/v1"
-
 	imageregistryv1listers "github.com/openshift/client-go/imageregistry/listers/imageregistry/v1"
+
 	"github.com/openshift/cluster-image-registry-operator/defaults"
 	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
 )

--- a/pkg/resource/pullsecret.go
+++ b/pkg/resource/pullsecret.go
@@ -1,13 +1,14 @@
 package resource
 
 import (
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	coreset "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
+	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
 )
 
 var _ Mutator = &generatorPullSecret{}

--- a/pkg/resource/route.go
+++ b/pkg/resource/route.go
@@ -5,11 +5,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	corelisters "k8s.io/client-go/listers/core/v1"
 
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	routeapi "github.com/openshift/api/route/v1"
 	routeset "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	routelisters "github.com/openshift/client-go/route/listers/route/v1"
 
-	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
 )
 

--- a/pkg/resource/secret.go
+++ b/pkg/resource/secret.go
@@ -3,15 +3,15 @@ package resource
 import (
 	"fmt"
 
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
-	"github.com/openshift/cluster-image-registry-operator/pkg/storage"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	coreset "k8s.io/client-go/kubernetes/typed/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
+	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
+	"github.com/openshift/cluster-image-registry-operator/pkg/storage"
 )
 
 var _ Mutator = &generatorSecret{}

--- a/pkg/resource/service.go
+++ b/pkg/resource/service.go
@@ -3,16 +3,16 @@ package resource
 import (
 	"fmt"
 
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
-	"github.com/openshift/cluster-image-registry-operator/pkg/resource/strategy"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	coreset "k8s.io/client-go/kubernetes/typed/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
+	"github.com/openshift/cluster-image-registry-operator/pkg/parameters"
+	"github.com/openshift/cluster-image-registry-operator/pkg/resource/strategy"
 )
 
 var _ Mutator = &generatorService{}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -9,6 +9,7 @@ import (
 
 	configapiv1 "github.com/openshift/api/config/v1"
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+
 	"github.com/openshift/cluster-image-registry-operator/defaults"
 	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
 	"github.com/openshift/cluster-image-registry-operator/pkg/envvar"

--- a/pkg/storage/swift/swift_test.go
+++ b/pkg/storage/swift/swift_test.go
@@ -18,6 +18,7 @@ import (
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	operatorapi "github.com/openshift/api/operator/v1"
 	configlisters "github.com/openshift/client-go/config/listers/config/v1"
+
 	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
 )
 

--- a/pkg/storage/util/util.go
+++ b/pkg/storage/util/util.go
@@ -6,13 +6,14 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
+	corev1 "k8s.io/api/core/v1"
+	metaapi "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	operatorapi "github.com/openshift/api/operator/v1"
-	corev1 "k8s.io/api/core/v1"
-	metaapi "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
+	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
 )
 
 var (

--- a/pkg/storage/util/util_test.go
+++ b/pkg/storage/util/util_test.go
@@ -6,12 +6,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
-
-	configv1 "github.com/openshift/api/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
+	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
 )
 
 type MockInfrastructureLister struct {

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -6,24 +6,26 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	configapiv1 "github.com/openshift/api/config/v1"
+	operatorapi "github.com/openshift/api/operator/v1"
+
 	"github.com/openshift/cluster-image-registry-operator/defaults"
 	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage"
 	storages3 "github.com/openshift/cluster-image-registry-operator/pkg/storage/s3"
 	"github.com/openshift/cluster-image-registry-operator/test/framework"
 	"github.com/openshift/cluster-image-registry-operator/test/framework/mock/listers"
-
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/s3"
-	configapiv1 "github.com/openshift/api/config/v1"
-	operatorapi "github.com/openshift/api/operator/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 var (

--- a/test/e2e/baremetal_test.go
+++ b/test/e2e/baremetal_test.go
@@ -6,6 +6,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	configapiv1 "github.com/openshift/api/config/v1"
+
 	"github.com/openshift/cluster-image-registry-operator/test/framework"
 )
 

--- a/test/e2e/configuration_test.go
+++ b/test/e2e/configuration_test.go
@@ -13,18 +13,19 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-	"github.com/openshift/cluster-image-registry-operator/test/framework"
-
-	configapiv1 "github.com/openshift/api/config/v1"
-	imageregistryapiv1 "github.com/openshift/api/imageregistry/v1"
-	operatorapiv1 "github.com/openshift/api/operator/v1"
 	appsapi "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	configapiv1 "github.com/openshift/api/config/v1"
+	imageregistryapiv1 "github.com/openshift/api/imageregistry/v1"
+	operatorapiv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
+	"github.com/openshift/cluster-image-registry-operator/test/framework"
 )
 
 func TestPodResourceConfiguration(t *testing.T) {

--- a/test/e2e/emptydir_test.go
+++ b/test/e2e/emptydir_test.go
@@ -4,9 +4,10 @@ import (
 	"regexp"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	operatorapi "github.com/openshift/api/operator/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift/cluster-image-registry-operator/defaults"
 	"github.com/openshift/cluster-image-registry-operator/test/framework"

--- a/test/e2e/failing_test.go
+++ b/test/e2e/failing_test.go
@@ -4,12 +4,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-	"github.com/openshift/cluster-image-registry-operator/test/framework"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	operatorapi "github.com/openshift/api/operator/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
+	"github.com/openshift/cluster-image-registry-operator/test/framework"
 )
 
 func TestDegraded(t *testing.T) {

--- a/test/e2e/gcs_test.go
+++ b/test/e2e/gcs_test.go
@@ -4,17 +4,18 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
-	"github.com/openshift/cluster-image-registry-operator/test/framework"
-	"github.com/openshift/cluster-image-registry-operator/test/framework/mock/listers"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	configapiv1 "github.com/openshift/api/config/v1"
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	operatorapi "github.com/openshift/api/operator/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
+	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
+	"github.com/openshift/cluster-image-registry-operator/test/framework"
+	"github.com/openshift/cluster-image-registry-operator/test/framework/mock/listers"
 )
 
 var (

--- a/test/e2e/graceful_shutdown_test.go
+++ b/test/e2e/graceful_shutdown_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-	"github.com/openshift/cluster-image-registry-operator/test/framework"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
+	"github.com/openshift/cluster-image-registry-operator/test/framework"
 )
 
 func TestNodeCAGracefulShutdown(t *testing.T) {

--- a/test/e2e/imageconfig_test.go
+++ b/test/e2e/imageconfig_test.go
@@ -4,14 +4,15 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-	"github.com/openshift/cluster-image-registry-operator/test/framework"
-
-	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
-	operatorapi "github.com/openshift/api/operator/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+	operatorapi "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
+	"github.com/openshift/cluster-image-registry-operator/test/framework"
 )
 
 func TestAdditionalTrustedCA(t *testing.T) {

--- a/test/e2e/managementstate_test.go
+++ b/test/e2e/managementstate_test.go
@@ -4,15 +4,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-	"github.com/openshift/cluster-image-registry-operator/test/framework"
-
-	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
-	operatorapi "github.com/openshift/api/operator/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
+
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+	operatorapi "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
+	"github.com/openshift/cluster-image-registry-operator/test/framework"
 )
 
 func TestManagementStateUnmanaged(t *testing.T) {

--- a/test/e2e/pruner_test.go
+++ b/test/e2e/pruner_test.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	operatorapi "github.com/openshift/api/operator/v1"
+
 	"github.com/openshift/cluster-image-registry-operator/defaults"
 	"github.com/openshift/cluster-image-registry-operator/test/framework"
 )

--- a/test/e2e/pvc_test.go
+++ b/test/e2e/pvc_test.go
@@ -5,11 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-	"github.com/openshift/cluster-image-registry-operator/test/framework"
-
-	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
-	operatorapi "github.com/openshift/api/operator/v1"
 	appsapi "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -17,6 +12,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+	operatorapi "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
+	"github.com/openshift/cluster-image-registry-operator/test/framework"
 )
 
 func testDefer(t *testing.T, client *framework.Clientset) {

--- a/test/e2e/readonly_test.go
+++ b/test/e2e/readonly_test.go
@@ -3,12 +3,13 @@ package e2e
 import (
 	"testing"
 
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-	"github.com/openshift/cluster-image-registry-operator/test/framework"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	operatorapi "github.com/openshift/api/operator/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
+	"github.com/openshift/cluster-image-registry-operator/test/framework"
 )
 
 func TestReadOnly(t *testing.T) {

--- a/test/e2e/recreate_deployment_test.go
+++ b/test/e2e/recreate_deployment_test.go
@@ -4,14 +4,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-	"github.com/openshift/cluster-image-registry-operator/test/framework"
-
-	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
-	operatorapi "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+	operatorapi "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
+	"github.com/openshift/cluster-image-registry-operator/test/framework"
 )
 
 func TestRecreateDeployment(t *testing.T) {

--- a/test/framework/clientset.go
+++ b/test/framework/clientset.go
@@ -14,6 +14,7 @@ import (
 	clientconfigv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	clientimageregistryv1 "github.com/openshift/client-go/imageregistry/clientset/versioned/typed/imageregistry/v1"
 	clientroutev1 "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
+
 	"github.com/openshift/cluster-image-registry-operator/pkg/client"
 )
 

--- a/test/framework/condition.go
+++ b/test/framework/condition.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-
-	operatorapi "github.com/openshift/api/operator/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	operatorapi "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
 )
 
 func ConditionExistsWithStatusAndReason(client *Clientset, conditionType string, conditionStatus operatorapi.ConditionStatus, conditionReason string) []error {

--- a/test/framework/configmap.go
+++ b/test/framework/configmap.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
 )
 
 func MustEnsureServiceCAConfigMap(t *testing.T, client *Clientset) {

--- a/test/framework/daemonset.go
+++ b/test/framework/daemonset.go
@@ -4,12 +4,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
 )
 
 func MustEnsureNodeCADaemonSetIsAvailable(t *testing.T, client *Clientset) {

--- a/test/framework/deployment.go
+++ b/test/framework/deployment.go
@@ -3,12 +3,12 @@ package framework
 import (
 	"time"
 
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-
 	kappsapiv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
 )
 
 func WaitForRegistryDeployment(client *Clientset) (*kappsapiv1.Deployment, error) {

--- a/test/framework/hostname.go
+++ b/test/framework/hostname.go
@@ -5,12 +5,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-
-	configapiv1 "github.com/openshift/api/config/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	configapiv1 "github.com/openshift/api/config/v1"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
 )
 
 func MustEnsureDefaultExternalRegistryHostnameIsSet(t *testing.T, client *Clientset) {

--- a/test/framework/imageregistry.go
+++ b/test/framework/imageregistry.go
@@ -6,17 +6,18 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-
-	configapiv1 "github.com/openshift/api/config/v1"
-	osapi "github.com/openshift/api/config/v1"
-	imageregistryapiv1 "github.com/openshift/api/imageregistry/v1"
-	operatorapiv1 "github.com/openshift/api/operator/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
+
+	configapiv1 "github.com/openshift/api/config/v1"
+	osapi "github.com/openshift/api/config/v1"
+	imageregistryapiv1 "github.com/openshift/api/imageregistry/v1"
+	operatorapiv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
 )
 
 const (

--- a/test/framework/mock/listers/listers.go
+++ b/test/framework/mock/listers/listers.go
@@ -1,12 +1,13 @@
 package listers
 
 import (
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
-
-	configset "github.com/openshift/client-go/config/clientset/versioned"
 	coreset "k8s.io/client-go/kubernetes/typed/core/v1"
 	restclient "k8s.io/client-go/rest"
+
+	configset "github.com/openshift/client-go/config/clientset/versioned"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
+	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
 )
 
 const (

--- a/test/framework/mock/listers/secrets.go
+++ b/test/framework/mock/listers/secrets.go
@@ -2,11 +2,9 @@ package listers
 
 import (
 	coreapi "k8s.io/api/core/v1"
-
-	coreset "k8s.io/client-go/kubernetes/typed/core/v1"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	coreset "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 type MockSecretNamespaceLister struct {

--- a/test/framework/proxy.go
+++ b/test/framework/proxy.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/openshift/cluster-image-registry-operator/defaults"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	openshiftapiv1 "github.com/openshift/api/config/v1"
 	imageregistryapiv1 "github.com/openshift/api/imageregistry/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
 )
 
 // SetResourceProxyConfig patches the image registry resource to contain the provided proxy configuration

--- a/test/framework/pruner.go
+++ b/test/framework/pruner.go
@@ -1,9 +1,9 @@
 package framework
 
 import (
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
 )
 
 func DumpImagePrunerResource(logger Logger, client *Clientset) {

--- a/test/framework/route.go
+++ b/test/framework/route.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openshift/cluster-image-registry-operator/defaults"
-
-	routeapiv1 "github.com/openshift/api/route/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	routeapiv1 "github.com/openshift/api/route/v1"
+
+	"github.com/openshift/cluster-image-registry-operator/defaults"
 )
 
 func MustEnsureDefaultExternalRouteExists(t *testing.T, client *Clientset) {


### PR DESCRIPTION
Re-grouping and re-ordering go imports according to our team preferences:
 - standard
 - other
 - kubernetes
 - openshift
 - module