### PR TITLE
Bug 1808426: Release 4 3 revert install config

### DIFF
--- a/pkg/client/fake/fixtures.go
+++ b/pkg/client/fake/fixtures.go
@@ -216,6 +216,7 @@ func (f *FixturesBuilder) BuildListers() *client.Listers {
 		ImageConfigs:        configv1listers.NewImageLister(f.imageConfigsIndexer),
 		ClusterOperators:    configv1listers.NewClusterOperatorLister(f.clusterOperatorsIndexer),
 		RegistryConfigs:     regopv1listers.NewConfigLister(f.registryConfigsIndexer),
+		InstallerConfigMaps: corev1listers.NewConfigMapLister(f.configMapsIndexer).ConfigMaps("kube-system"),
 		ProxyConfigs:        configv1listers.NewProxyLister(f.proxyConfigsIndexer),
 		Infrastructures:     configv1listers.NewInfrastructureLister(f.infraIndexer),
 	}

--- a/pkg/client/listers.go
+++ b/pkg/client/listers.go
@@ -25,6 +25,7 @@ type Listers struct {
 	ImageConfigs        configlisters.ImageLister
 	ClusterOperators    configlisters.ClusterOperatorLister
 	RegistryConfigs     regoplisters.ConfigLister
+	InstallerConfigMaps kcorelisters.ConfigMapNamespaceLister
 	ProxyConfigs        configlisters.ProxyLister
 	Infrastructures     configlisters.InfrastructureLister
 }

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -272,6 +272,10 @@ func (c *Controller) handler() cache.ResourceEventHandlerFuncs {
 					return
 				}
 			}
+			obj := o.(metaapi.Object)
+			if obj.GetNamespace() == "kube-system" && obj.GetName() != "cluster-config-v1" {
+				return
+			}
 			klog.V(1).Infof("add event to workqueue due to %s (add)", utilObjectInfo(o))
 			c.workqueue.Add(workqueueKey)
 		},
@@ -296,6 +300,10 @@ func (c *Controller) handler() cache.ResourceEventHandlerFuncs {
 					return
 				}
 			}
+			obj := o.(metaapi.Object)
+			if obj.GetNamespace() == "kube-system" && obj.GetName() != "cluster-config-v1" {
+				return
+			}
 			klog.V(1).Infof("add event to workqueue due to %s (update)", utilObjectInfo(n))
 			c.workqueue.Add(workqueueKey)
 		},
@@ -318,6 +326,10 @@ func (c *Controller) handler() cache.ResourceEventHandlerFuncs {
 				if clusterOperator.GetName() != defaults.ImageRegistryClusterOperatorResourceName {
 					return
 				}
+			}
+			obj := o.(metaapi.Object)
+			if obj.GetNamespace() == "kube-system" && obj.GetName() != "cluster-config-v1" {
+				return
 			}
 			klog.V(1).Infof("add event to workqueue due to %s (delete)", utilObjectInfo(object))
 			c.workqueue.Add(workqueueKey)

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -379,6 +379,7 @@ func (c *Controller) Run(stopCh <-chan struct{}) error {
 	configInformerFactory := configinformers.NewSharedInformerFactory(configClient, defaultResyncDuration)
 	kubeInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(c.clients.Kube, defaultResyncDuration, kubeinformers.WithNamespace(c.params.Deployment.Namespace))
 	openshiftConfigKubeInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(c.clients.Kube, defaultResyncDuration, kubeinformers.WithNamespace(openshiftConfigNamespace))
+	kubeSystemKubeInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(c.clients.Kube, defaultResyncDuration, kubeinformers.WithNamespace(kubeSystemNamespace))
 	regopInformerFactory := regopinformers.NewSharedInformerFactory(c.clients.RegOp, defaultResyncDuration)
 	routeInformerFactory := routeinformers.NewSharedInformerFactoryWithOptions(routeClient, defaultResyncDuration, routeinformers.WithNamespace(c.params.Deployment.Namespace))
 
@@ -455,6 +456,11 @@ func (c *Controller) Run(stopCh <-chan struct{}) error {
 			return informer.Informer()
 		},
 		func() cache.SharedIndexInformer {
+			informer := kubeSystemKubeInformerFactory.Core().V1().ConfigMaps()
+			c.listers.InstallerConfigMaps = informer.Lister().ConfigMaps(kubeSystemNamespace)
+			return informer.Informer()
+		},
+		func() cache.SharedIndexInformer {
 			informer := configInformerFactory.Config().V1().Infrastructures()
 			c.listers.Infrastructures = informer.Lister()
 			return informer.Informer()
@@ -468,6 +474,7 @@ func (c *Controller) Run(stopCh <-chan struct{}) error {
 	configInformerFactory.Start(stopCh)
 	kubeInformerFactory.Start(stopCh)
 	openshiftConfigKubeInformerFactory.Start(stopCh)
+	kubeSystemKubeInformerFactory.Start(stopCh)
 	regopInformerFactory.Start(stopCh)
 	routeInformerFactory.Start(stopCh)
 

--- a/pkg/storage/azure/azure.go
+++ b/pkg/storage/azure/azure.go
@@ -402,7 +402,7 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 		util.UpdateCondition(cr, defaults.StorageExists, operatorapiv1.ConditionUnknown, storageExistsReasonConfigError, fmt.Sprintf("Unable to get configuration: %s", err))
 		return err
 	}
-	infra, err := d.Listers.Infrastructures.Get("cluster")
+	infra, err := util.GetInfrastructure(d.Listers)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/gcs/gcs.go
+++ b/pkg/storage/gcs/gcs.go
@@ -75,7 +75,7 @@ func (d *driver) getGCSClient() (*gstorage.Client, error) {
 func GetConfig(listers *regopclient.Listers) (*GCS, error) {
 	gcsConfig := &GCS{}
 
-	infra, err := listers.Infrastructures.Get("cluster")
+	infra, err := util.GetInfrastructure(listers)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -58,7 +58,7 @@ func NewDriver(ctx context.Context, c *imageregistryv1.ImageRegistryConfigStorag
 func GetConfig(kubeconfig *rest.Config, listers *regopclient.Listers) (*S3, error) {
 	cfg := &S3{}
 
-	infra, err := listers.Infrastructures.Get("cluster")
+	infra, err := util.GetInfrastructure(listers)
 	if err != nil {
 		return nil, err
 	}
@@ -321,7 +321,7 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 		return err
 	}
 
-	infra, err := d.Listers.Infrastructures.Get("cluster")
+	infra, err := util.GetInfrastructure(d.Listers)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage/pvc"
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage/s3"
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage/swift"
+	"github.com/openshift/cluster-image-registry-operator/pkg/storage/util"
 )
 
 var (
@@ -129,7 +130,7 @@ func NewDriver(cfg *imageregistryv1.ImageRegistryConfigStorage, kubeconfig *rest
 func GetPlatformStorage(listers *regopclient.Listers) (imageregistryv1.ImageRegistryConfigStorage, error) {
 	var cfg imageregistryv1.ImageRegistryConfigStorage
 
-	infra, err := listers.Infrastructures.Get("cluster")
+	infra, err := util.GetInfrastructure(listers)
 	if err != nil {
 		return imageregistryv1.ImageRegistryConfigStorage{}, err
 	}

--- a/pkg/storage/swift/swift.go
+++ b/pkg/storage/swift/swift.go
@@ -386,7 +386,7 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 		return err
 	}
 
-	infra, err := d.Listers.Infrastructures.Get("cluster")
+	infra, err := util.GetInfrastructure(d.Listers)
 	if err != nil {
 		return fmt.Errorf("failed to get cluster infrastructure info: %v", err)
 	}

--- a/pkg/storage/util/util.go
+++ b/pkg/storage/util/util.go
@@ -8,11 +8,14 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metaapi "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
 
+	configv1 "github.com/openshift/api/config/v1"
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	operatorapi "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-image-registry-operator/defaults"
 	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
+	installer "github.com/openshift/installer/pkg/types"
 )
 
 var (
@@ -58,6 +61,49 @@ func UpdateCondition(cr *imageregistryv1.Config, conditionType string, status op
 	cr.Status.Conditions = conditions
 }
 
+// GetInfrastructure gets information about the cloud platform that the cluster is
+// installed on including the Type, Region, and other platform specific information.
+// Currently the install config is used as a backup to be compatible with upgrades
+// from 4.1 -> 4.2 when platformStatus did not exist, but should be able to be removed
+// in the future.
+func GetInfrastructure(listers *regopclient.Listers) (*configv1.Infrastructure, error) {
+	infra, err := listers.Infrastructures.Get("cluster")
+	if err != nil {
+		return nil, err
+	}
+
+	if infra.Status.PlatformStatus == nil {
+		infra.Status.PlatformStatus = &configv1.PlatformStatus{
+			Type: infra.Status.Platform,
+		}
+
+		// TODO: Eventually we should be able to remove our dependency on the install config
+		// but it is needed for now since platformStatus doesn't get set on upgrade
+		// from 4.1 -> 4.2
+		ic, err := listers.InstallerConfigMaps.Get("cluster-config-v1")
+		if err != nil {
+			return nil, err
+		}
+		installConfig := &installer.InstallConfig{}
+		if err := yaml.NewYAMLOrJSONDecoder(strings.NewReader(string(ic.Data["install-config"])), 100).Decode(installConfig); err != nil {
+			return nil, fmt.Errorf("unable to decode cluster install configuration: %v", err)
+		}
+
+		if installConfig.Platform.AWS != nil {
+			infra.Status.PlatformStatus.AWS = &configv1.AWSPlatformStatus{Region: installConfig.Platform.AWS.Region}
+		}
+
+		if installConfig.Platform.GCP != nil {
+			infra.Status.PlatformStatus.GCP = &configv1.GCPPlatformStatus{
+				Region:    installConfig.Platform.GCP.Region,
+				ProjectID: installConfig.Platform.GCP.ProjectID,
+			}
+		}
+	}
+
+	return infra, nil
+}
+
 // GetValueFromSecret gets value for key in a secret
 // or returns an error if it does not exist
 func GetValueFromSecret(sec *corev1.Secret, key string) (string, error) {
@@ -71,7 +117,7 @@ func GetValueFromSecret(sec *corev1.Secret, key string) (string, error) {
 // medium that the registry will use
 func GenerateStorageName(listers *regopclient.Listers, additionalInfo ...string) (string, error) {
 	// Get the infrastructure name
-	infra, err := listers.Infrastructures.Get("cluster")
+	infra, err := GetInfrastructure(listers)
 	if err != nil {
 		return "", err
 	}

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -24,6 +24,7 @@ import (
 	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage"
 	storages3 "github.com/openshift/cluster-image-registry-operator/pkg/storage/s3"
+	"github.com/openshift/cluster-image-registry-operator/pkg/storage/util"
 	"github.com/openshift/cluster-image-registry-operator/test/framework"
 	"github.com/openshift/cluster-image-registry-operator/test/framework/mock/listers"
 )
@@ -45,7 +46,7 @@ func TestAWSDefaults(t *testing.T) {
 	newMockLister, err := listers.NewMockLister(kcfg)
 	mockLister, err := newMockLister.GetListers()
 
-	infra, err := mockLister.Infrastructures.Get("cluster")
+	infra, err := util.GetInfrastructure(mockLister)
 	if err != nil {
 		t.Fatalf("unable to get install configuration: %v", err)
 	}
@@ -345,7 +346,7 @@ func TestAWSUnableToCreateBucketOnStartup(t *testing.T) {
 	newMockLister, err := listers.NewMockLister(kubeconfig)
 	mockLister, err := newMockLister.GetListers()
 
-	infra, err := mockLister.Infrastructures.Get("cluster")
+	infra, err := util.GetInfrastructure(mockLister)
 	if err != nil {
 		t.Fatalf("unable to get install configuration: %v", err)
 	}
@@ -400,7 +401,7 @@ func TestAWSUpdateCredentials(t *testing.T) {
 	newMockLister, err := listers.NewMockLister(kcfg)
 	mockLister, err := newMockLister.GetListers()
 
-	infra, err := mockLister.Infrastructures.Get("cluster")
+	infra, err := util.GetInfrastructure(mockLister)
 	if err != nil {
 		t.Fatalf("unable to get install configuration: %v", err)
 	}
@@ -474,7 +475,7 @@ func TestAWSChangeS3Encryption(t *testing.T) {
 	newMockLister, err := listers.NewMockLister(kubeconfig)
 	mockLister, err := newMockLister.GetListers()
 
-	infra, err := mockLister.Infrastructures.Get("cluster")
+	infra, err := util.GetInfrastructure(mockLister)
 	if err != nil {
 		t.Fatalf("unable to get install configuration: %v", err)
 	}
@@ -661,7 +662,7 @@ func TestAWSFinalizerDeleteS3Bucket(t *testing.T) {
 	newMockLister, err := listers.NewMockLister(kcfg)
 	mockLister, err := newMockLister.GetListers()
 
-	infra, err := mockLister.Infrastructures.Get("cluster")
+	infra, err := util.GetInfrastructure(mockLister)
 	if err != nil {
 		t.Fatalf("unable to get install configuration: %v", err)
 	}

--- a/test/e2e/gcs_test.go
+++ b/test/e2e/gcs_test.go
@@ -13,6 +13,7 @@ import (
 	operatorapi "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-image-registry-operator/defaults"
 	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
+	"github.com/openshift/cluster-image-registry-operator/pkg/storage/util"
 	"github.com/openshift/cluster-image-registry-operator/test/framework"
 	"github.com/openshift/cluster-image-registry-operator/test/framework/mock/listers"
 )
@@ -48,7 +49,7 @@ func TestGCSMinimal(t *testing.T) {
 	newMockLister, err := listers.NewMockLister(kcfg)
 	mockLister, err := newMockLister.GetListers()
 
-	infra, err := mockLister.Infrastructures.Get("cluster")
+	infra, err := util.GetInfrastructure(mockLister)
 	if err != nil {
 		t.Fatalf("unable to get install configuration: %v", err)
 	}

--- a/test/framework/mock/listers/listers.go
+++ b/test/framework/mock/listers/listers.go
@@ -35,6 +35,7 @@ func (m *mockLister) GetListers() (*regopclient.Listers, error) {
 	}
 
 	m.listers.Secrets = MockSecretNamespaceLister{namespace: defaults.ImageRegistryOperatorNamespace, client: coreClient}
+	m.listers.InstallerConfigMaps = MockConfigMapNamespaceLister{namespace: installerConfigNamespace, client: coreClient}
 	m.listers.Infrastructures = MockInfrastructureLister{client: *configClient}
 
 	return &m.listers, err


### PR DESCRIPTION
Reverts #470 and applies the same fix that we did for release-4.2 to ignore most events from the kube-system namespace