### PR TITLE
Bug 1776665: Ignore most kube system events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/openshift/api v0.0.0-20200311183032-85e16cc5dd7c
 	github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240
 	github.com/openshift/crd-schema-gen v1.0.0
-	github.com/openshift/installer v0.9.0-master.0.20190726121806-6e8f9c335410 // indirect
+	github.com/openshift/installer v0.9.0-master.0.20190726121806-6e8f9c335410
 	github.com/openshift/library-go v0.0.0-20200127110935-527e40ed17d9
 	github.com/prometheus/client_golang v1.1.0
 	github.com/prometheus/client_model v0.0.0-20191202183732-d1d2010b5bee

--- a/pkg/client/fake/fixtures.go
+++ b/pkg/client/fake/fixtures.go
@@ -216,6 +216,7 @@ func (f *FixturesBuilder) BuildListers() *client.Listers {
 		ImageConfigs:        configv1listers.NewImageLister(f.imageConfigsIndexer),
 		ClusterOperators:    configv1listers.NewClusterOperatorLister(f.clusterOperatorsIndexer),
 		RegistryConfigs:     regopv1listers.NewConfigLister(f.registryConfigsIndexer),
+		InstallerConfigMaps: corev1listers.NewConfigMapLister(f.configMapsIndexer).ConfigMaps("kube-system"),
 		ProxyConfigs:        configv1listers.NewProxyLister(f.proxyConfigsIndexer),
 		Infrastructures:     configv1listers.NewInfrastructureLister(f.infraIndexer),
 	}

--- a/pkg/client/listers.go
+++ b/pkg/client/listers.go
@@ -29,6 +29,7 @@ type Listers struct {
 	ClusterOperators    configlisters.ClusterOperatorLister
 	RegistryConfigs     regoplisters.ConfigLister
 	ImagePrunerConfigs  regoplisters.ImagePrunerLister
+	InstallerConfigMaps kcorelisters.ConfigMapNamespaceLister
 	ProxyConfigs        configlisters.ProxyLister
 	Infrastructures     configlisters.InfrastructureLister
 }

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage"
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage/pvc"
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage/swift"
+	"github.com/openshift/cluster-image-registry-operator/pkg/storage/util"
 )
 
 // randomSecretSize is the number of random bytes to generate
@@ -66,7 +67,7 @@ func (c *Controller) Bootstrap() error {
 		mgmtState = operatorapi.Removed
 	}
 
-	infra, err := c.listers.Infrastructures.Get("cluster")
+	infra, err := util.GetInfrastructure(c.listers)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -345,6 +345,7 @@ func (c *Controller) Run(stopCh <-chan struct{}) error {
 	configInformerFactory := configinformers.NewSharedInformerFactory(configClient, defaultResyncDuration)
 	kubeInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(c.clients.Kube, defaultResyncDuration, kubeinformers.WithNamespace(defaults.ImageRegistryOperatorNamespace))
 	openshiftConfigKubeInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(c.clients.Kube, defaultResyncDuration, kubeinformers.WithNamespace(openshiftConfigNamespace))
+	kubeSystemKubeInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(c.clients.Kube, defaultResyncDuration, kubeinformers.WithNamespace(kubeSystemNamespace))
 	regopInformerFactory := regopinformers.NewSharedInformerFactory(c.clients.RegOp, defaultResyncDuration)
 	routeInformerFactory := routeinformers.NewSharedInformerFactoryWithOptions(routeClient, defaultResyncDuration, routeinformers.WithNamespace(defaults.ImageRegistryOperatorNamespace))
 
@@ -426,6 +427,11 @@ func (c *Controller) Run(stopCh <-chan struct{}) error {
 			return informer.Informer()
 		},
 		func() cache.SharedIndexInformer {
+			informer := kubeSystemKubeInformerFactory.Core().V1().ConfigMaps()
+			c.listers.InstallerConfigMaps = informer.Lister().ConfigMaps(kubeSystemNamespace)
+			return informer.Informer()
+		},
+		func() cache.SharedIndexInformer {
 			informer := configInformerFactory.Config().V1().Infrastructures()
 			c.listers.Infrastructures = informer.Lister()
 			return informer.Informer()
@@ -463,6 +469,7 @@ func (c *Controller) Run(stopCh <-chan struct{}) error {
 	configInformerFactory.Start(stopCh)
 	kubeInformerFactory.Start(stopCh)
 	openshiftConfigKubeInformerFactory.Start(stopCh)
+	kubeSystemKubeInformerFactory.Start(stopCh)
 	regopInformerFactory.Start(stopCh)
 	routeInformerFactory.Start(stopCh)
 

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -233,6 +233,10 @@ func (c *Controller) handler() cache.ResourceEventHandlerFuncs {
 					return
 				}
 			}
+			obj := o.(metaapi.Object)
+			if obj.GetNamespace() == "kube-system" && obj.GetName() != "cluster-config-v1" {
+				return
+			}
 			klog.V(1).Infof("add event to workqueue due to %s (add)", utilObjectInfo(o))
 			c.workqueue.Add(workqueueKey)
 		},
@@ -257,6 +261,10 @@ func (c *Controller) handler() cache.ResourceEventHandlerFuncs {
 					return
 				}
 			}
+			obj := o.(metaapi.Object)
+			if obj.GetNamespace() == "kube-system" && obj.GetName() != "cluster-config-v1" {
+				return
+			}
 			klog.V(1).Infof("add event to workqueue due to %s (update)", utilObjectInfo(n))
 			c.workqueue.Add(workqueueKey)
 		},
@@ -279,6 +287,10 @@ func (c *Controller) handler() cache.ResourceEventHandlerFuncs {
 				if clusterOperator.GetName() != defaults.ImageRegistryClusterOperatorResourceName {
 					return
 				}
+			}
+			obj := o.(metaapi.Object)
+			if obj.GetNamespace() == "kube-system" && obj.GetName() != "cluster-config-v1" {
+				return
 			}
 			klog.V(1).Infof("add event to workqueue due to %s (delete)", utilObjectInfo(object))
 			c.workqueue.Add(workqueueKey)

--- a/pkg/storage/azure/azure.go
+++ b/pkg/storage/azure/azure.go
@@ -387,7 +387,7 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 		util.UpdateCondition(cr, defaults.StorageExists, operatorapiv1.ConditionUnknown, storageExistsReasonConfigError, fmt.Sprintf("Unable to get configuration: %s", err))
 		return err
 	}
-	infra, err := d.Listers.Infrastructures.Get("cluster")
+	infra, err := util.GetInfrastructure(d.Listers)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/gcs/gcs.go
+++ b/pkg/storage/gcs/gcs.go
@@ -77,7 +77,7 @@ func (d *driver) getGCSClient() (*gstorage.Client, error) {
 func GetConfig(listers *regopclient.Listers) (*GCS, error) {
 	gcsConfig := &GCS{}
 
-	infra, err := listers.Infrastructures.Get("cluster")
+	infra, err := util.GetInfrastructure(listers)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -57,7 +57,7 @@ func NewDriver(ctx context.Context, c *imageregistryv1.ImageRegistryConfigStorag
 func GetConfig(listers *regopclient.Listers) (*S3, error) {
 	cfg := &S3{}
 
-	infra, err := listers.Infrastructures.Get("cluster")
+	infra, err := util.GetInfrastructure(listers)
 	if err != nil {
 		return nil, err
 	}
@@ -302,7 +302,7 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 		return err
 	}
 
-	infra, err := d.Listers.Infrastructures.Get("cluster")
+	infra, err := util.GetInfrastructure(d.Listers)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage/pvc"
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage/s3"
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage/swift"
+	"github.com/openshift/cluster-image-registry-operator/pkg/storage/util"
 )
 
 var (
@@ -122,7 +123,7 @@ func GetPlatformStorage(listers *regopclient.Listers) (imageregistryv1.ImageRegi
 	var cfg imageregistryv1.ImageRegistryConfigStorage
 	replicas := int32(1)
 
-	infra, err := listers.Infrastructures.Get("cluster")
+	infra, err := util.GetInfrastructure(listers)
 	if err != nil {
 		return imageregistryv1.ImageRegistryConfigStorage{}, replicas, err
 	}

--- a/pkg/storage/swift/swift.go
+++ b/pkg/storage/swift/swift.go
@@ -110,7 +110,7 @@ func GetConfig(listers *regopclient.Listers) (*Swift, error) {
 			}
 
 			var cloudName string
-			cloudInfra, err := listers.Infrastructures.Get("cluster")
+			cloudInfra, err := util.GetInfrastructure(listers)
 			if err != nil {
 				if !errors.IsNotFound(err) {
 					return nil, fmt.Errorf("failed to get cluster infrastructure info: %v", err)
@@ -388,7 +388,7 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 		return err
 	}
 
-	infra, err := d.Listers.Infrastructures.Get("cluster")
+	infra, err := util.GetInfrastructure(d.Listers)
 	if err != nil {
 		return fmt.Errorf("failed to get cluster infrastructure info: %v", err)
 	}

--- a/pkg/storage/util/util.go
+++ b/pkg/storage/util/util.go
@@ -8,9 +8,12 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metaapi "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
 
+	configv1 "github.com/openshift/api/config/v1"
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	operatorapi "github.com/openshift/api/operator/v1"
+	installer "github.com/openshift/installer/pkg/types"
 
 	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
 	"github.com/openshift/cluster-image-registry-operator/pkg/defaults"
@@ -59,6 +62,49 @@ func UpdateCondition(cr *imageregistryv1.Config, conditionType string, status op
 	cr.Status.Conditions = conditions
 }
 
+// GetInfrastructure gets information about the cloud platform that the cluster is
+// installed on including the Type, Region, and other platform specific information.
+// Currently the install config is used as a backup to be compatible with upgrades
+// from 4.1 -> 4.2 when platformStatus did not exist, but should be able to be removed
+// in the future.
+func GetInfrastructure(listers *regopclient.Listers) (*configv1.Infrastructure, error) {
+	infra, err := listers.Infrastructures.Get("cluster")
+	if err != nil {
+		return nil, err
+	}
+
+	if infra.Status.PlatformStatus == nil {
+		infra.Status.PlatformStatus = &configv1.PlatformStatus{
+			Type: infra.Status.Platform,
+		}
+
+		// TODO: Eventually we should be able to remove our dependency on the install config
+		// but it is needed for now since platformStatus doesn't get set on upgrade
+		// from 4.1 -> 4.2
+		ic, err := listers.InstallerConfigMaps.Get("cluster-config-v1")
+		if err != nil {
+			return nil, err
+		}
+		installConfig := &installer.InstallConfig{}
+		if err := yaml.NewYAMLOrJSONDecoder(strings.NewReader(string(ic.Data["install-config"])), 100).Decode(installConfig); err != nil {
+			return nil, fmt.Errorf("unable to decode cluster install configuration: %v", err)
+		}
+
+		if installConfig.Platform.AWS != nil {
+			infra.Status.PlatformStatus.AWS = &configv1.AWSPlatformStatus{Region: installConfig.Platform.AWS.Region}
+		}
+
+		if installConfig.Platform.GCP != nil {
+			infra.Status.PlatformStatus.GCP = &configv1.GCPPlatformStatus{
+				Region:    installConfig.Platform.GCP.Region,
+				ProjectID: installConfig.Platform.GCP.ProjectID,
+			}
+		}
+	}
+
+	return infra, nil
+}
+
 // GetValueFromSecret gets value for key in a secret
 // or returns an error if it does not exist
 func GetValueFromSecret(sec *corev1.Secret, key string) (string, error) {
@@ -72,7 +118,7 @@ func GetValueFromSecret(sec *corev1.Secret, key string) (string, error) {
 // medium that the registry will use
 func GenerateStorageName(listers *regopclient.Listers, additionalInfo ...string) (string, error) {
 	// Get the infrastructure name
-	infra, err := listers.Infrastructures.Get("cluster")
+	infra, err := GetInfrastructure(listers)
 	if err != nil {
 		return "", err
 	}

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openshift/cluster-image-registry-operator/pkg/defaults"
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage"
 	storages3 "github.com/openshift/cluster-image-registry-operator/pkg/storage/s3"
+	"github.com/openshift/cluster-image-registry-operator/pkg/storage/util"
 	"github.com/openshift/cluster-image-registry-operator/test/framework"
 	"github.com/openshift/cluster-image-registry-operator/test/framework/mock/listers"
 )
@@ -45,7 +46,7 @@ func TestAWSDefaults(t *testing.T) {
 	newMockLister, err := listers.NewMockLister(kcfg)
 	mockLister, err := newMockLister.GetListers()
 
-	infra, err := mockLister.Infrastructures.Get("cluster")
+	infra, err := util.GetInfrastructure(mockLister)
 	if err != nil {
 		t.Fatalf("unable to get install configuration: %v", err)
 	}
@@ -345,7 +346,7 @@ func TestAWSUnableToCreateBucketOnStartup(t *testing.T) {
 	newMockLister, err := listers.NewMockLister(kubeconfig)
 	mockLister, err := newMockLister.GetListers()
 
-	infra, err := mockLister.Infrastructures.Get("cluster")
+	infra, err := util.GetInfrastructure(mockLister)
 	if err != nil {
 		t.Fatalf("unable to get install configuration: %v", err)
 	}
@@ -400,7 +401,7 @@ func TestAWSUpdateCredentials(t *testing.T) {
 	newMockLister, err := listers.NewMockLister(kcfg)
 	mockLister, err := newMockLister.GetListers()
 
-	infra, err := mockLister.Infrastructures.Get("cluster")
+	infra, err := util.GetInfrastructure(mockLister)
 	if err != nil {
 		t.Fatalf("unable to get install configuration: %v", err)
 	}
@@ -474,7 +475,7 @@ func TestAWSChangeS3Encryption(t *testing.T) {
 	newMockLister, err := listers.NewMockLister(kubeconfig)
 	mockLister, err := newMockLister.GetListers()
 
-	infra, err := mockLister.Infrastructures.Get("cluster")
+	infra, err := util.GetInfrastructure(mockLister)
 	if err != nil {
 		t.Fatalf("unable to get install configuration: %v", err)
 	}
@@ -661,7 +662,7 @@ func TestAWSFinalizerDeleteS3Bucket(t *testing.T) {
 	newMockLister, err := listers.NewMockLister(kcfg)
 	mockLister, err := newMockLister.GetListers()
 
-	infra, err := mockLister.Infrastructures.Get("cluster")
+	infra, err := util.GetInfrastructure(mockLister)
 	if err != nil {
 		t.Fatalf("unable to get install configuration: %v", err)
 	}

--- a/test/e2e/gcs_test.go
+++ b/test/e2e/gcs_test.go
@@ -14,6 +14,7 @@ import (
 
 	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
 	"github.com/openshift/cluster-image-registry-operator/pkg/defaults"
+	"github.com/openshift/cluster-image-registry-operator/pkg/storage/util"
 	"github.com/openshift/cluster-image-registry-operator/test/framework"
 	"github.com/openshift/cluster-image-registry-operator/test/framework/mock/listers"
 )
@@ -49,7 +50,7 @@ func TestGCSMinimal(t *testing.T) {
 	newMockLister, err := listers.NewMockLister(kcfg)
 	mockLister, err := newMockLister.GetListers()
 
-	infra, err := mockLister.Infrastructures.Get("cluster")
+	infra, err := util.GetInfrastructure(mockLister)
 	if err != nil {
 		t.Fatalf("unable to get install configuration: %v", err)
 	}

--- a/test/framework/mock/listers/listers.go
+++ b/test/framework/mock/listers/listers.go
@@ -35,6 +35,7 @@ func (m *mockLister) GetListers() (*regopclient.Listers, error) {
 	}
 
 	m.listers.Secrets = MockSecretNamespaceLister{namespace: defaults.ImageRegistryOperatorNamespace, client: coreClient}
+	m.listers.InstallerConfigMaps = MockConfigMapNamespaceLister{namespace: installerConfigNamespace, client: coreClient}
 	m.listers.Infrastructures = MockInfrastructureLister{client: *configClient}
 
 	return &m.listers, err

--- a/vendor/github.com/openshift/installer/LICENSE
+++ b/vendor/github.com/openshift/installer/LICENSE
@@ -1,0 +1,202 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/vendor/github.com/openshift/installer/NOTICE
+++ b/vendor/github.com/openshift/installer/NOTICE
@@ -1,0 +1,5 @@
+CoreOS Project
+Copyright 2017 CoreOS, Inc
+
+This product includes software developed at CoreOS, Inc.
+(http://www.coreos.com/).

--- a/vendor/github.com/openshift/installer/pkg/ipnet/ipnet.go
+++ b/vendor/github.com/openshift/installer/pkg/ipnet/ipnet.go
@@ -1,0 +1,96 @@
+// Package ipnet wraps net.IPNet to get CIDR serialization.
+package ipnet
+
+import (
+	"encoding/json"
+	"net"
+	"reflect"
+
+	"github.com/pkg/errors"
+)
+
+var nullString = "null"
+var nullBytes = []byte(nullString)
+var emptyIPNet = net.IPNet{}
+
+// IPNet wraps net.IPNet to get CIDR serialization.
+type IPNet struct {
+	net.IPNet
+}
+
+// String returns a CIDR serialization of the subnet, or an empty
+// string if the subnet is nil.
+func (ipnet *IPNet) String() string {
+	if ipnet == nil {
+		return ""
+	}
+	return ipnet.IPNet.String()
+}
+
+// MarshalJSON interface for an IPNet
+func (ipnet IPNet) MarshalJSON() (data []byte, err error) {
+	if reflect.DeepEqual(ipnet.IPNet, emptyIPNet) {
+		return nullBytes, nil
+	}
+
+	return json.Marshal(ipnet.String())
+}
+
+// UnmarshalJSON interface for an IPNet
+func (ipnet *IPNet) UnmarshalJSON(b []byte) (err error) {
+	if string(b) == nullString {
+		ipnet.IP = net.IP{}
+		ipnet.Mask = net.IPMask{}
+		return nil
+	}
+
+	var cidr string
+	err = json.Unmarshal(b, &cidr)
+	if err != nil {
+		return errors.Wrap(err, "failed to Unmarshal string")
+	}
+
+	parsedIPNet, err := ParseCIDR(cidr)
+	if err != nil {
+		return errors.Wrap(err, "failed to Parse cidr string to net.IPNet")
+	}
+
+	*ipnet = *parsedIPNet
+
+	return nil
+}
+
+// ParseCIDR parses a CIDR from its string representation.
+func ParseCIDR(s string) (*IPNet, error) {
+	ip, cidr, err := net.ParseCIDR(s)
+	if err != nil {
+		return nil, err
+	}
+
+	// This check is needed in order to work around a strange quirk in the Go
+	// standard library. All of the addresses returned by net.ParseCIDR() are
+	// 16-byte addresses. This does _not_ imply that they are IPv6 addresses,
+	// which is what some libraries (e.g. github.com/apparentlymart/go-cidr)
+	// assume. By forcing the address to be the expected length, we can work
+	// around these bugs.
+	if ip.To4() != nil {
+		ip = ip.To4()
+	}
+
+	return &IPNet{
+		IPNet: net.IPNet{
+			IP:   ip,
+			Mask: cidr.Mask,
+		},
+	}, nil
+}
+
+// MustParseCIDR parses a CIDR from its string representation. If the parse fails,
+// the function will panic.
+func MustParseCIDR(s string) *IPNet {
+	cidr, err := ParseCIDR(s)
+	if err != nil {
+		panic(err)
+	}
+	return cidr
+}

--- a/vendor/github.com/openshift/installer/pkg/types/aws/doc.go
+++ b/vendor/github.com/openshift/installer/pkg/types/aws/doc.go
@@ -1,0 +1,6 @@
+// Package aws contains AWS-specific structures for installer
+// configuration and management.
+package aws
+
+// Name is name for the AWS platform.
+const Name string = "aws"

--- a/vendor/github.com/openshift/installer/pkg/types/aws/machinepool.go
+++ b/vendor/github.com/openshift/installer/pkg/types/aws/machinepool.go
@@ -1,0 +1,50 @@
+package aws
+
+// MachinePool stores the configuration for a machine pool installed
+// on AWS.
+type MachinePool struct {
+	// Zones is list of availability zones that can be used.
+	Zones []string `json:"zones,omitempty"`
+
+	// InstanceType defines the ec2 instance type.
+	// eg. m4-large
+	InstanceType string `json:"type"`
+
+	// EC2RootVolume defines the storage for ec2 instance.
+	EC2RootVolume `json:"rootVolume"`
+}
+
+// Set sets the values from `required` to `a`.
+func (a *MachinePool) Set(required *MachinePool) {
+	if required == nil || a == nil {
+		return
+	}
+
+	if len(required.Zones) > 0 {
+		a.Zones = required.Zones
+	}
+
+	if required.InstanceType != "" {
+		a.InstanceType = required.InstanceType
+	}
+
+	if required.EC2RootVolume.IOPS != 0 {
+		a.EC2RootVolume.IOPS = required.EC2RootVolume.IOPS
+	}
+	if required.EC2RootVolume.Size != 0 {
+		a.EC2RootVolume.Size = required.EC2RootVolume.Size
+	}
+	if required.EC2RootVolume.Type != "" {
+		a.EC2RootVolume.Type = required.EC2RootVolume.Type
+	}
+}
+
+// EC2RootVolume defines the storage for an ec2 instance.
+type EC2RootVolume struct {
+	// IOPS defines the iops for the storage.
+	IOPS int `json:"iops"`
+	// Size defines the size of the storage.
+	Size int `json:"size"`
+	// Type defines the type of the storage.
+	Type string `json:"type"`
+}

--- a/vendor/github.com/openshift/installer/pkg/types/aws/metadata.go
+++ b/vendor/github.com/openshift/installer/pkg/types/aws/metadata.go
@@ -1,0 +1,12 @@
+package aws
+
+// Metadata contains AWS metadata (e.g. for uninstalling the cluster).
+type Metadata struct {
+	Region string `json:"region"`
+
+	// Identifier holds a slice of filter maps.  The maps hold the
+	// key/value pairs for the tags we will be matching against.  A
+	// resource matches the map if all of the key/value pairs are in its
+	// tags.  A resource matches Identifier if it matches any of the maps.
+	Identifier []map[string]string `json:"identifier"`
+}

--- a/vendor/github.com/openshift/installer/pkg/types/aws/platform.go
+++ b/vendor/github.com/openshift/installer/pkg/types/aws/platform.go
@@ -1,0 +1,22 @@
+package aws
+
+// Platform stores all the global configuration that all machinesets
+// use.
+type Platform struct {
+	// AMIID is the AMI that should be used to boot machines for the cluster.
+	// If set, the AMI should belong to the same region as the cluster.
+	AMIID string `json:"amiID,omitempty"`
+
+	// Region specifies the AWS region where the cluster will be created.
+	Region string `json:"region"`
+
+	// UserTags specifies additional tags for AWS resources created for the cluster.
+	// +optional
+	UserTags map[string]string `json:"userTags,omitempty"`
+
+	// DefaultMachinePlatform is the default configuration used when
+	// installing on AWS for machine pools which do not define their own
+	// platform configuration.
+	// +optional
+	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
+}

--- a/vendor/github.com/openshift/installer/pkg/types/azure/doc.go
+++ b/vendor/github.com/openshift/installer/pkg/types/azure/doc.go
@@ -1,0 +1,6 @@
+// Package azure contains Azure-specific structures for installer
+// configuration and management.
+package azure
+
+// Name is name for the Azure platform.
+const Name string = "azure"

--- a/vendor/github.com/openshift/installer/pkg/types/azure/machinepool.go
+++ b/vendor/github.com/openshift/installer/pkg/types/azure/machinepool.go
@@ -1,0 +1,41 @@
+package azure
+
+// MachinePool stores the configuration for a machine pool installed
+// on Azure.
+type MachinePool struct {
+	// Zones is list of availability zones that can be used.
+	// eg. ["1", "2", "3"]
+	Zones []string `json:"zones,omitempty"`
+
+	// InstanceType defines the azure instance type.
+	// eg. Standard_DS_V2
+	InstanceType string `json:"type"`
+
+	// OSDisk defines the storage for instance.
+	OSDisk `json:"osDisk"`
+}
+
+// OSDisk defines the disk for machines on Azure.
+type OSDisk struct {
+	// DiskSizeGB defines the size of disk in GB.
+	DiskSizeGB int32 `json:"diskSizeGB"`
+}
+
+// Set sets the values from `required` to `a`.
+func (a *MachinePool) Set(required *MachinePool) {
+	if required == nil || a == nil {
+		return
+	}
+
+	if len(required.Zones) > 0 {
+		a.Zones = required.Zones
+	}
+
+	if required.InstanceType != "" {
+		a.InstanceType = required.InstanceType
+	}
+
+	if required.OSDisk.DiskSizeGB != 0 {
+		a.OSDisk.DiskSizeGB = required.OSDisk.DiskSizeGB
+	}
+}

--- a/vendor/github.com/openshift/installer/pkg/types/azure/metadata.go
+++ b/vendor/github.com/openshift/installer/pkg/types/azure/metadata.go
@@ -1,0 +1,6 @@
+package azure
+
+// Metadata contains Azure metadata (e.g. for uninstalling the cluster).
+type Metadata struct {
+	Region string `json:"region"`
+}

--- a/vendor/github.com/openshift/installer/pkg/types/azure/platform.go
+++ b/vendor/github.com/openshift/installer/pkg/types/azure/platform.go
@@ -1,0 +1,25 @@
+package azure
+
+import "strings"
+
+// Platform stores all the global configuration that all machinesets
+// use.
+type Platform struct {
+	// Region specifies the Azure region where the cluster will be created.
+	Region string `json:"region"`
+
+	// BaseDomainResourceGroupName specifies the resource group where the azure DNS zone for the base domain is found
+	BaseDomainResourceGroupName string `json:"baseDomainResourceGroupName,omitempty"`
+	// DefaultMachinePlatform is the default configuration used when
+	// installing on Azure for machine pools which do not define their own
+	// platform configuration.
+	// +optional
+	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
+}
+
+//SetBaseDomain parses the baseDomainID and sets the related fields on azure.Platform
+func (p *Platform) SetBaseDomain(baseDomainID string) error {
+	parts := strings.Split(baseDomainID, "/")
+	p.BaseDomainResourceGroupName = parts[4]
+	return nil
+}

--- a/vendor/github.com/openshift/installer/pkg/types/baremetal/OWNERS
+++ b/vendor/github.com/openshift/installer/pkg/types/baremetal/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+reviewers:
+  - baremetal-reviewers

--- a/vendor/github.com/openshift/installer/pkg/types/baremetal/doc.go
+++ b/vendor/github.com/openshift/installer/pkg/types/baremetal/doc.go
@@ -1,0 +1,6 @@
+// Package baremetal contains baremetal-specific structures for
+// installer configuration and management.
+package baremetal
+
+// Name is the name for the baremetal platform.
+const Name string = "baremetal"

--- a/vendor/github.com/openshift/installer/pkg/types/baremetal/machinepool.go
+++ b/vendor/github.com/openshift/installer/pkg/types/baremetal/machinepool.go
@@ -1,0 +1,13 @@
+package baremetal
+
+// MachinePool stores the configuration for a machine pool installed
+// on bare metal.
+type MachinePool struct {
+}
+
+// Set sets the values from `required` to `a`.
+func (l *MachinePool) Set(required *MachinePool) {
+	if required == nil || l == nil {
+		return
+	}
+}

--- a/vendor/github.com/openshift/installer/pkg/types/baremetal/metadata.go
+++ b/vendor/github.com/openshift/installer/pkg/types/baremetal/metadata.go
@@ -1,0 +1,7 @@
+package baremetal
+
+// Metadata contains baremetal metadata (e.g. for uninstalling the cluster).
+type Metadata struct {
+	LibvirtURI string `json:"libvirtURI"`
+	IronicURI  string `json:"ironicURI"`
+}

--- a/vendor/github.com/openshift/installer/pkg/types/baremetal/platform.go
+++ b/vendor/github.com/openshift/installer/pkg/types/baremetal/platform.go
@@ -1,0 +1,69 @@
+package baremetal
+
+// BMC stores the information about a baremetal host's management controller.
+type BMC struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Address  string `json:"address"`
+}
+
+// Host stores all the configuration data for a baremetal host.
+type Host struct {
+	Name            string `json:"name,omitempty"`
+	BMC             BMC    `json:"bmc"`
+	Role            string `json:"role"`
+	BootMACAddress  string `json:"bootMACAddress"`
+	HardwareProfile string `json:"hardwareProfile"`
+}
+
+// Image stores details about the locations of various images needed for deployment.
+// FIXME: This should be determined by the installer once Ironic and image downloading occurs in bootstrap VM.
+type Image struct {
+	Source        string `json:"source"`
+	Checksum      string `json:"checksum"`
+	DeployKernel  string `json:"deployKernel"`
+	DeployRamdisk string `json:"deployRamdisk"`
+}
+
+// Platform stores all the global configuration that all machinesets use.
+type Platform struct {
+	// LibvirtURI is the identifier for the libvirtd connection.  It must be
+	// reachable from the host where the installer is run.
+	// +optional
+	// Default is qemu:///system
+	LibvirtURI string `json:"libvirtURI,omitempty"`
+
+	// IronicURI is the identifier for the Ironic connection.  It must be
+	// reachable from the host where the installer is run.
+	// +optional
+	IronicURI string `json:"ironicURI,omitempty"`
+
+	// External bridge is used for external communication.
+	// +optional
+	ExternalBridge string `json:"externalBridge,omitempty"`
+
+	// Provisioning bridge is used for provisioning nodes.
+	// +optional
+	ProvisioningBridge string `json:"provisioningBridge,omitempty"`
+
+	// Hosts is the information needed to create the objects in Ironic.
+	Hosts []*Host `json:"hosts"`
+
+	// Images contains the information needed to provision a host
+	Image Image `json:"image"`
+
+	// DefaultMachinePlatform is the default configuration used when
+	// installing on bare metal for machine pools which do not define their own
+	// platform configuration.
+	// +optional
+	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
+
+	// APIVIP is the VIP to use for internal API communication
+	APIVIP string `json:"apiVIP"`
+
+	// IngressVIP is the VIP to use for ingress traffic
+	IngressVIP string `json:"ingressVIP"`
+
+	// DNSVIP is the VIP to use for internal DNS communication
+	DNSVIP string `json:"dnsVIP"`
+}

--- a/vendor/github.com/openshift/installer/pkg/types/clustermetadata.go
+++ b/vendor/github.com/openshift/installer/pkg/types/clustermetadata.go
@@ -1,0 +1,60 @@
+package types
+
+import (
+	"github.com/openshift/installer/pkg/types/aws"
+	"github.com/openshift/installer/pkg/types/azure"
+	"github.com/openshift/installer/pkg/types/baremetal"
+	"github.com/openshift/installer/pkg/types/gcp"
+	"github.com/openshift/installer/pkg/types/libvirt"
+	"github.com/openshift/installer/pkg/types/openstack"
+)
+
+// ClusterMetadata contains information
+// regarding the cluster that was created by installer.
+type ClusterMetadata struct {
+	// clusterName is the name for the cluster.
+	ClusterName string `json:"clusterName"`
+	// clusterID is a globally unique ID that is used to identify an Openshift cluster.
+	ClusterID string `json:"clusterID"`
+	// infraID is an ID that is used to identify cloud resources created by the installer.
+	InfraID                 string `json:"infraID"`
+	ClusterPlatformMetadata `json:",inline"`
+}
+
+// ClusterPlatformMetadata contains metadata for platfrom.
+type ClusterPlatformMetadata struct {
+	AWS       *aws.Metadata       `json:"aws,omitempty"`
+	OpenStack *openstack.Metadata `json:"openstack,omitempty"`
+	Libvirt   *libvirt.Metadata   `json:"libvirt,omitempty"`
+	Azure     *azure.Metadata     `json:"azure,omitempty"`
+	GCP       *gcp.Metadata       `json:"gcp,omitempty"`
+	BareMetal *baremetal.Metadata `json:"baremetal,omitempty"`
+}
+
+// Platform returns a string representation of the platform
+// (e.g. "aws" if AWS is non-nil).  It returns an empty string if no
+// platform is configured.
+func (cpm *ClusterPlatformMetadata) Platform() string {
+	if cpm == nil {
+		return ""
+	}
+	if cpm.AWS != nil {
+		return aws.Name
+	}
+	if cpm.Libvirt != nil {
+		return libvirt.Name
+	}
+	if cpm.OpenStack != nil {
+		return openstack.Name
+	}
+	if cpm.Azure != nil {
+		return azure.Name
+	}
+	if cpm.GCP != nil {
+		return gcp.Name
+	}
+	if cpm.BareMetal != nil {
+		return "baremetal"
+	}
+	return ""
+}

--- a/vendor/github.com/openshift/installer/pkg/types/doc.go
+++ b/vendor/github.com/openshift/installer/pkg/types/doc.go
@@ -1,0 +1,3 @@
+// Package types defines structures for installer configuration and
+// management.
+package types

--- a/vendor/github.com/openshift/installer/pkg/types/gcp/clouduid.go
+++ b/vendor/github.com/openshift/installer/pkg/types/gcp/clouduid.go
@@ -1,0 +1,13 @@
+package gcp
+
+import (
+	"crypto/md5"
+	"fmt"
+)
+
+// CloudControllerUID generates a UID used by the GCP cloud controller provider
+// to generate certain load balancing resources
+func CloudControllerUID(infraID string) string {
+	hash := md5.Sum([]byte(infraID))
+	return fmt.Sprintf("%x", hash)[:16]
+}

--- a/vendor/github.com/openshift/installer/pkg/types/gcp/doc.go
+++ b/vendor/github.com/openshift/installer/pkg/types/gcp/doc.go
@@ -1,0 +1,6 @@
+// Package gcp contains GCP-specific structures for installer
+// configuration and management.
+package gcp
+
+// Name is name for the gcp platform.
+const Name string = "gcp"

--- a/vendor/github.com/openshift/installer/pkg/types/gcp/machinepools.go
+++ b/vendor/github.com/openshift/installer/pkg/types/gcp/machinepools.go
@@ -1,0 +1,26 @@
+package gcp
+
+// MachinePool stores the configuration for a machine pool installed on GCP.
+type MachinePool struct {
+	// Zones is list of availability zones that can be used.
+	Zones []string `json:"zones,omitempty"`
+
+	// InstanceType defines the GCP instance type.
+	// eg. n1-standard-4
+	InstanceType string `json:"type"`
+}
+
+// Set sets the values from `required` to `a`.
+func (a *MachinePool) Set(required *MachinePool) {
+	if required == nil || a == nil {
+		return
+	}
+
+	if len(required.Zones) > 0 {
+		a.Zones = required.Zones
+	}
+
+	if required.InstanceType != "" {
+		a.InstanceType = required.InstanceType
+	}
+}

--- a/vendor/github.com/openshift/installer/pkg/types/gcp/metadata.go
+++ b/vendor/github.com/openshift/installer/pkg/types/gcp/metadata.go
@@ -1,0 +1,7 @@
+package gcp
+
+// Metadata contains GCP metadata (e.g. for uninstalling the cluster).
+type Metadata struct {
+	Region    string `json:"region"`
+	ProjectID string `json:"projectID"`
+}

--- a/vendor/github.com/openshift/installer/pkg/types/gcp/platform.go
+++ b/vendor/github.com/openshift/installer/pkg/types/gcp/platform.go
@@ -1,0 +1,17 @@
+package gcp
+
+// Platform stores all the global configuration that all machinesets
+// use.
+type Platform struct {
+	// ProjectID is the the project that will be used for the cluster.
+	ProjectID string `json:"projectID"`
+
+	// Region specifies the GCP region where the cluster will be created.
+	Region string `json:"region"`
+
+	// DefaultMachinePlatform is the default configuration used when
+	// installing on GCP for machine pools which do not define their own
+	// platform configuration.
+	// +optional
+	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
+}

--- a/vendor/github.com/openshift/installer/pkg/types/installconfig.go
+++ b/vendor/github.com/openshift/installer/pkg/types/installconfig.go
@@ -1,0 +1,239 @@
+package types
+
+import (
+	"fmt"
+
+	"github.com/openshift/installer/pkg/ipnet"
+	"github.com/openshift/installer/pkg/types/aws"
+	"github.com/openshift/installer/pkg/types/azure"
+	"github.com/openshift/installer/pkg/types/baremetal"
+	"github.com/openshift/installer/pkg/types/gcp"
+	"github.com/openshift/installer/pkg/types/libvirt"
+	"github.com/openshift/installer/pkg/types/none"
+	"github.com/openshift/installer/pkg/types/openstack"
+	"github.com/openshift/installer/pkg/types/vsphere"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// InstallConfigVersion is the version supported by this package.
+	// If you bump this, you must also update the list of convertable values in
+	// pkg/types/conversion/installconfig.go
+	InstallConfigVersion = "v1"
+)
+
+var (
+	// PlatformNames is a slice with all the visibly-supported
+	// platform names in alphabetical order. This is the list of
+	// platforms presented to the user in the interactive wizard.
+	PlatformNames = []string{
+		aws.Name,
+		azure.Name,
+		gcp.Name,
+	}
+	// HiddenPlatformNames is a slice with all the
+	// hidden-but-supported platform names. This list isn't presented
+	// to the user in the interactive wizard.
+	HiddenPlatformNames = []string{
+		baremetal.Name,
+		none.Name,
+		openstack.Name,
+		vsphere.Name,
+	}
+)
+
+// InstallConfig is the configuration for an OpenShift install.
+type InstallConfig struct {
+	// +optional
+	metav1.TypeMeta `json:",inline"`
+
+	metav1.ObjectMeta `json:"metadata"`
+
+	// AdditionalTrustBundle is a certificate bundle that will be added to the nodes
+	// trusted certificate store.
+	// +optional
+	AdditionalTrustBundle string `json:"additionalTrustBundle,omitempty"`
+
+	// SSHKey is the public ssh key to provide access to instances.
+	// +optional
+	SSHKey string `json:"sshKey,omitempty"`
+
+	// BaseDomain is the base domain to which the cluster should belong.
+	BaseDomain string `json:"baseDomain"`
+
+	// Networking defines the pod network provider in the cluster.
+	*Networking `json:"networking,omitempty"`
+
+	// ControlPlane is the configuration for the machines that comprise the
+	// control plane.
+	// +optional
+	ControlPlane *MachinePool `json:"controlPlane,omitempty"`
+
+	// Compute is the list of compute MachinePools that need to be installed.
+	// +optional
+	Compute []MachinePool `json:"compute,omitempty"`
+
+	// Platform is the configuration for the specific platform upon which to
+	// perform the installation.
+	Platform `json:"platform"`
+
+	// PullSecret is the secret to use when pulling images.
+	PullSecret string `json:"pullSecret"`
+
+	// Proxy defines the proxy settings for the cluster.
+	// If unset, the cluster will not be configured to use a proxy.
+	// +optional
+	Proxy *Proxy `json:"proxy,omitempty"`
+
+	// ImageContentSources lists sources/repositories for the release-image content.
+	ImageContentSources []ImageContentSource `json:"imageContentSources,omitempty"`
+}
+
+// ClusterDomain returns the DNS domain that all records for a cluster must belong to.
+func (c *InstallConfig) ClusterDomain() string {
+	return fmt.Sprintf("%s.%s", c.ObjectMeta.Name, c.BaseDomain)
+}
+
+// Platform is the configuration for the specific platform upon which to perform
+// the installation. Only one of the platform configuration should be set.
+type Platform struct {
+	// AWS is the configuration used when installing on AWS.
+	// +optional
+	AWS *aws.Platform `json:"aws,omitempty"`
+
+	// Azure is the configuration used when installing on Azure.
+	// +optional
+	Azure *azure.Platform `json:"azure,omitempty"`
+
+	// BareMetal is the configuration used when installing on bare metal.
+	// +optional
+	BareMetal *baremetal.Platform `json:"baremetal,omitempty"`
+
+	// GCP is the configuration used when installing on Google Cloud Platform.
+	// +optional
+	GCP *gcp.Platform `json:"gcp,omitempty"`
+
+	// Libvirt is the configuration used when installing on libvirt.
+	// +optional
+	Libvirt *libvirt.Platform `json:"libvirt,omitempty"`
+
+	// None is the empty configuration used when installing on an unsupported
+	// platform.
+	None *none.Platform `json:"none,omitempty"`
+
+	// OpenStack is the configuration used when installing on OpenStack.
+	// +optional
+	OpenStack *openstack.Platform `json:"openstack,omitempty"`
+
+	// VSphere is the configuration used when installing on vSphere.
+	// +optional
+	VSphere *vsphere.Platform `json:"vsphere,omitempty"`
+}
+
+// Name returns a string representation of the platform (e.g. "aws" if
+// AWS is non-nil).  It returns an empty string if no platform is
+// configured.
+func (p *Platform) Name() string {
+	switch {
+	case p == nil:
+		return ""
+	case p.AWS != nil:
+		return aws.Name
+	case p.Azure != nil:
+		return azure.Name
+	case p.BareMetal != nil:
+		return baremetal.Name
+	case p.GCP != nil:
+		return gcp.Name
+	case p.Libvirt != nil:
+		return libvirt.Name
+	case p.None != nil:
+		return none.Name
+	case p.OpenStack != nil:
+		return openstack.Name
+	case p.VSphere != nil:
+		return vsphere.Name
+	default:
+		return ""
+	}
+}
+
+// Networking defines the pod network provider in the cluster.
+type Networking struct {
+	// MachineCIDR is the IP address space from which to assign machine IPs.
+	// +optional
+	// Default is 10.0.0.0/16 for all platforms other than Libvirt.
+	// For Libvirt, the default is 192.168.126.0/24.
+	MachineCIDR *ipnet.IPNet `json:"machineCIDR,omitempty"`
+
+	// NetworkType is the type of network to install.
+	// +optional
+	// Default is OpenShiftSDN.
+	NetworkType string `json:"networkType,omitempty"`
+
+	// ClusterNetwork is the IP address pool to use for pod IPs.
+	// +optional
+	// Default is 10.128.0.0/14 and a host prefix of /23
+	ClusterNetwork []ClusterNetworkEntry `json:"clusterNetwork,omitempty"`
+
+	// ServiceNetwork is the IP address pool to use for service IPs.
+	// +optional
+	// Default is 172.30.0.0/16
+	// NOTE: currently only one entry is supported.
+	ServiceNetwork []ipnet.IPNet `json:"serviceNetwork,omitempty"`
+
+	// Deprected types, scheduled to be removed
+
+	// Deprecated name for NetworkType
+	// +optional
+	DeprecatedType string `json:"type,omitempty"`
+
+	// Depcreated name for ServiceNetwork
+	// +optional
+	DeprecatedServiceCIDR *ipnet.IPNet `json:"serviceCIDR,omitempty"`
+
+	// Deprecated name for ClusterNetwork
+	// +optional
+	DeprecatedClusterNetworks []ClusterNetworkEntry `json:"clusterNetworks,omitempty"`
+}
+
+// ClusterNetworkEntry is a single IP address block for pod IP blocks. IP blocks
+// are allocated with size 2^HostSubnetLength.
+type ClusterNetworkEntry struct {
+	// The IP block address pool
+	CIDR ipnet.IPNet `json:"cidr"`
+
+	// HostPrefix is the prefix size to allocate to each node from the CIDR.
+	// For example, 24 would allocate 2^8=256 adresses to each node.
+	HostPrefix int32 `json:"hostPrefix"`
+
+	// The size of blocks to allocate from the larger pool.
+	// This is the length in bits - so a 9 here will allocate a /23.
+	DeprecatedHostSubnetLength int32 `json:"hostSubnetLength,omitempty"`
+}
+
+// Proxy defines the proxy settings for the cluster.
+// At least one of HTTPProxy or HTTPSProxy is required.
+type Proxy struct {
+	// HTTPProxy is the URL of the proxy for HTTP requests.
+	// +optional
+	HTTPProxy string `json:"httpProxy,omitempty"`
+
+	// HTTPSProxy is the URL of the proxy for HTTPS requests.
+	// +optional
+	HTTPSProxy string `json:"httpsProxy,omitempty"`
+
+	// NoProxy is a comma-separated list of domains and CIDRs for which the proxy should not be used.
+	// +optional
+	NoProxy string `json:"noProxy,omitempty"`
+}
+
+// ImageContentSource defines a list of sources/repositories that can be used to pull content.
+type ImageContentSource struct {
+	// Source is the repository that users refer to, e.g. in image pull specifications.
+	Source string `json:"source"`
+
+	// Mirrors is one or more repositories that may also contain the same images.
+	// +optional
+	Mirrors []string `json:"mirrors,omitempty"`
+}

--- a/vendor/github.com/openshift/installer/pkg/types/installconfig_libvirt.go
+++ b/vendor/github.com/openshift/installer/pkg/types/installconfig_libvirt.go
@@ -1,0 +1,14 @@
+// +build libvirt
+
+package types
+
+import (
+	"sort"
+
+	"github.com/openshift/installer/pkg/types/libvirt"
+)
+
+func init() {
+	PlatformNames = append(PlatformNames, libvirt.Name)
+	sort.Strings(PlatformNames)
+}

--- a/vendor/github.com/openshift/installer/pkg/types/libvirt/OWNERS
+++ b/vendor/github.com/openshift/installer/pkg/types/libvirt/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+reviewers:
+  - libvirt-reviewers

--- a/vendor/github.com/openshift/installer/pkg/types/libvirt/doc.go
+++ b/vendor/github.com/openshift/installer/pkg/types/libvirt/doc.go
@@ -1,0 +1,6 @@
+// Package libvirt contains libvirt-specific structures for
+// installer configuration and management.
+package libvirt
+
+// Name is the name for the libvirt platform.
+const Name string = "libvirt"

--- a/vendor/github.com/openshift/installer/pkg/types/libvirt/machinepool.go
+++ b/vendor/github.com/openshift/installer/pkg/types/libvirt/machinepool.go
@@ -1,0 +1,13 @@
+package libvirt
+
+// MachinePool stores the configuration for a machine pool installed
+// on libvirt.
+type MachinePool struct {
+}
+
+// Set sets the values from `required` to `a`.
+func (l *MachinePool) Set(required *MachinePool) {
+	if required == nil || l == nil {
+		return
+	}
+}

--- a/vendor/github.com/openshift/installer/pkg/types/libvirt/metadata.go
+++ b/vendor/github.com/openshift/installer/pkg/types/libvirt/metadata.go
@@ -1,0 +1,6 @@
+package libvirt
+
+// Metadata contains libvirt metadata (e.g. for uninstalling the cluster).
+type Metadata struct {
+	URI string `json:"uri"`
+}

--- a/vendor/github.com/openshift/installer/pkg/types/libvirt/network.go
+++ b/vendor/github.com/openshift/installer/pkg/types/libvirt/network.go
@@ -1,0 +1,8 @@
+package libvirt
+
+// Network is the configuration of the libvirt network.
+type Network struct {
+	// +optional
+	// Default is tt0.
+	IfName string `json:"if,omitempty"`
+}

--- a/vendor/github.com/openshift/installer/pkg/types/libvirt/platform.go
+++ b/vendor/github.com/openshift/installer/pkg/types/libvirt/platform.go
@@ -1,0 +1,23 @@
+package libvirt
+
+// Platform stores all the global configuration that all
+// machinesets use.
+type Platform struct {
+	// URI is the identifier for the libvirtd connection.  It must be
+	// reachable from both the host (where the installer is run) and the
+	// cluster (where the cluster-API controller pod will be running).
+	// +optional
+	// Default is qemu+tcp://192.168.122.1/system
+	URI string `json:"URI,omitempty"`
+
+	// DefaultMachinePlatform is the default configuration used when
+	// installing on libvirt for machine pools which do not define their
+	// own platform configuration.
+	// +optional
+	// Default will set the image field to the latest RHCOS image.
+	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
+
+	// Network
+	// +optional
+	Network *Network `json:"network,omitempty"`
+}

--- a/vendor/github.com/openshift/installer/pkg/types/machinepools.go
+++ b/vendor/github.com/openshift/installer/pkg/types/machinepools.go
@@ -1,0 +1,92 @@
+package types
+
+import (
+	"github.com/openshift/installer/pkg/types/aws"
+	"github.com/openshift/installer/pkg/types/azure"
+	"github.com/openshift/installer/pkg/types/baremetal"
+	"github.com/openshift/installer/pkg/types/gcp"
+	"github.com/openshift/installer/pkg/types/libvirt"
+	"github.com/openshift/installer/pkg/types/openstack"
+	"github.com/openshift/installer/pkg/types/vsphere"
+)
+
+// HyperthreadingMode is the mode of hyperthreading for a machine.
+type HyperthreadingMode string
+
+const (
+	// HyperthreadingEnabled indicates that hyperthreading is enabled.
+	HyperthreadingEnabled HyperthreadingMode = "Enabled"
+	// HyperthreadingDisabled indicates that hyperthreading is disabled.
+	HyperthreadingDisabled HyperthreadingMode = "Disabled"
+)
+
+// MachinePool is a pool of machines to be installed.
+type MachinePool struct {
+	// Name is the name of the machine pool.
+	// For the control plane machine pool, the name will always be "master".
+	// For the compute machine pools, the only valid name is "worker".
+	Name string `json:"name"`
+
+	// Replicas is the count of machines for this machine pool.
+	Replicas *int64 `json:"replicas,omitempty"`
+
+	// Platform is configuration for machine pool specific to the platform.
+	Platform MachinePoolPlatform `json:"platform"`
+
+	// Hyperthreading determines the mode of hyperthreading that machines in this
+	// pool will utilize.
+	// +optional
+	// Default is for hyperthreading to be enabled.
+	Hyperthreading HyperthreadingMode `json:"hyperthreading,omitempty"`
+}
+
+// MachinePoolPlatform is the platform-specific configuration for a machine
+// pool. Only one of the platforms should be set.
+type MachinePoolPlatform struct {
+	// AWS is the configuration used when installing on AWS.
+	AWS *aws.MachinePool `json:"aws,omitempty"`
+
+	// Azure is the configuration used when installing on Azure.
+	Azure *azure.MachinePool `json:"azure,omitempty"`
+
+	// BareMetal is the configuration used when installing on bare metal.
+	BareMetal *baremetal.MachinePool `json:"baremetal,omitempty"`
+
+	// GCP is the configuration used when installing on GCP
+	GCP *gcp.MachinePool `json:"gcp,omitempty"`
+
+	// Libvirt is the configuration used when installing on libvirt.
+	Libvirt *libvirt.MachinePool `json:"libvirt,omitempty"`
+
+	// OpenStack is the configuration used when installing on OpenStack.
+	OpenStack *openstack.MachinePool `json:"openstack,omitempty"`
+
+	// VSphere is the configuration used when installing on vSphere.
+	VSphere *vsphere.MachinePool `json:"vsphere,omitempty"`
+}
+
+// Name returns a string representation of the platform (e.g. "aws" if
+// AWS is non-nil).  It returns an empty string if no platform is
+// configured.
+func (p *MachinePoolPlatform) Name() string {
+	switch {
+	case p == nil:
+		return ""
+	case p.AWS != nil:
+		return aws.Name
+	case p.Azure != nil:
+		return azure.Name
+	case p.BareMetal != nil:
+		return baremetal.Name
+	case p.GCP != nil:
+		return gcp.Name
+	case p.Libvirt != nil:
+		return libvirt.Name
+	case p.OpenStack != nil:
+		return openstack.Name
+	case p.VSphere != nil:
+		return vsphere.Name
+	default:
+		return ""
+	}
+}

--- a/vendor/github.com/openshift/installer/pkg/types/none/doc.go
+++ b/vendor/github.com/openshift/installer/pkg/types/none/doc.go
@@ -1,0 +1,6 @@
+// Package none contains generic structures for installer
+// configuration and management.
+package none
+
+// Name is name for the None platform.
+const Name string = "none"

--- a/vendor/github.com/openshift/installer/pkg/types/none/platform.go
+++ b/vendor/github.com/openshift/installer/pkg/types/none/platform.go
@@ -1,0 +1,5 @@
+package none
+
+// Platform stores any global configuration used for generic
+// platforms.
+type Platform struct{}

--- a/vendor/github.com/openshift/installer/pkg/types/openstack/OWNERS
+++ b/vendor/github.com/openshift/installer/pkg/types/openstack/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - openstack-approvers

--- a/vendor/github.com/openshift/installer/pkg/types/openstack/doc.go
+++ b/vendor/github.com/openshift/installer/pkg/types/openstack/doc.go
@@ -1,0 +1,6 @@
+// Package openstack contains OpenStack-specific structures for
+// installer configuration and management.
+package openstack
+
+// Name is the name for the Openstack platform.
+const Name string = "openstack"

--- a/vendor/github.com/openshift/installer/pkg/types/openstack/machinepool.go
+++ b/vendor/github.com/openshift/installer/pkg/types/openstack/machinepool.go
@@ -1,0 +1,20 @@
+package openstack
+
+// MachinePool stores the configuration for a machine pool installed
+// on OpenStack.
+type MachinePool struct {
+	// FlavorName defines the OpenStack Nova flavor.
+	// eg. m1.large
+	FlavorName string `json:"type"`
+}
+
+// Set sets the values from `required` to `a`.
+func (o *MachinePool) Set(required *MachinePool) {
+	if required == nil || o == nil {
+		return
+	}
+
+	if required.FlavorName != "" {
+		o.FlavorName = required.FlavorName
+	}
+}

--- a/vendor/github.com/openshift/installer/pkg/types/openstack/metadata.go
+++ b/vendor/github.com/openshift/installer/pkg/types/openstack/metadata.go
@@ -1,0 +1,9 @@
+package openstack
+
+// Metadata contains OpenStack metadata (e.g. for uninstalling the cluster).
+type Metadata struct {
+	Region string `json:"region"`
+	Cloud  string `json:"cloud"`
+	// Most OpenStack resources are tagged with these tags as identifier.
+	Identifier map[string]string `json:"identifier"`
+}

--- a/vendor/github.com/openshift/installer/pkg/types/openstack/platform.go
+++ b/vendor/github.com/openshift/installer/pkg/types/openstack/platform.go
@@ -1,0 +1,38 @@
+package openstack
+
+// Platform stores all the global configuration that all
+// machinesets use.
+type Platform struct {
+	// Region specifies the OpenStack region where the cluster will be created.
+	Region string `json:"region"`
+
+	// DefaultMachinePlatform is the default configuration used when
+	// installing on OpenStack for machine pools which do not define their own
+	// platform configuration.
+	// +optional
+	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
+
+	// Cloud
+	// Name of OpenStack cloud to use from clouds.yaml
+	Cloud string `json:"cloud"`
+
+	// ExternalNetwork
+	// The OpenStack external network name to be used for installation.
+	ExternalNetwork string `json:"externalNetwork"`
+
+	// FlavorName
+	// The OpenStack compute flavor to use for servers.
+	FlavorName string `json:"computeFlavor"`
+
+	// LbFloatingIP
+	// Existing Floating IP to associate with the OpenStack load balancer.
+	LbFloatingIP string `json:"lbFloatingIP"`
+
+	// TrunkSupport
+	// Whether OpenStack ports can be trunked
+	TrunkSupport string `json:"trunkSupport"`
+
+	// OctaviaSupport
+	// Whether OpenStack has Octavia support
+	OctaviaSupport string `json:"octaviaSupport"`
+}

--- a/vendor/github.com/openshift/installer/pkg/types/vsphere/OWNERS
+++ b/vendor/github.com/openshift/installer/pkg/types/vsphere/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - vsphere-approvers

--- a/vendor/github.com/openshift/installer/pkg/types/vsphere/doc.go
+++ b/vendor/github.com/openshift/installer/pkg/types/vsphere/doc.go
@@ -1,0 +1,6 @@
+// Package vsphere contains vSphere-specific structures for installer
+// configuration and management.
+package vsphere
+
+// Name is name for the vsphere platform.
+const Name string = "vsphere"

--- a/vendor/github.com/openshift/installer/pkg/types/vsphere/machinepool.go
+++ b/vendor/github.com/openshift/installer/pkg/types/vsphere/machinepool.go
@@ -1,0 +1,13 @@
+package vsphere
+
+// MachinePool stores the configuration for a machine pool installed
+// on vSphere.
+type MachinePool struct {
+}
+
+// Set sets the values from `required` to `p`.
+func (p *MachinePool) Set(required *MachinePool) {
+	if required == nil || p == nil {
+		return
+	}
+}

--- a/vendor/github.com/openshift/installer/pkg/types/vsphere/platform.go
+++ b/vendor/github.com/openshift/installer/pkg/types/vsphere/platform.go
@@ -1,0 +1,15 @@
+package vsphere
+
+// Platform stores any global configuration used for vsphere platforms.
+type Platform struct {
+	// VCenter is the domain name or IP address of the vCenter.
+	VCenter string `json:"vCenter"`
+	// Username is the name of the user to use to connect to the vCenter.
+	Username string `json:"username"`
+	// Password is the password for the user to use to connect to the vCenter.
+	Password string `json:"password"`
+	// Datacenter is the name of the datacenter to use in the vCenter.
+	Datacenter string `json:"datacenter"`
+	// DefaultDatastore is the default datastore to use for provisioning volumes.
+	DefaultDatastore string `json:"defaultDatastore"`
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -266,6 +266,17 @@ github.com/openshift/client-go/route/listers/route/v1
 # github.com/openshift/crd-schema-gen v1.0.0
 github.com/openshift/crd-schema-gen/cmd/crd-schema-gen
 github.com/openshift/crd-schema-gen/cmd/crd-schema-gen/generator
+# github.com/openshift/installer v0.9.0-master.0.20190726121806-6e8f9c335410
+github.com/openshift/installer/pkg/ipnet
+github.com/openshift/installer/pkg/types
+github.com/openshift/installer/pkg/types/aws
+github.com/openshift/installer/pkg/types/azure
+github.com/openshift/installer/pkg/types/baremetal
+github.com/openshift/installer/pkg/types/gcp
+github.com/openshift/installer/pkg/types/libvirt
+github.com/openshift/installer/pkg/types/none
+github.com/openshift/installer/pkg/types/openstack
+github.com/openshift/installer/pkg/types/vsphere
 # github.com/openshift/library-go v0.0.0-20200127110935-527e40ed17d9
 github.com/openshift/library-go/alpha-build-machinery/make/targets/openshift
 github.com/openshift/library-go/pkg/config/client


### PR DESCRIPTION
Corrects issues that could arise from 4.1 clusters being upgraded through 4.5

 - Reverts #470 
 - Ignores events from the kube-system namespace except for the cluster-config-v1 configmap
