### PR TITLE
Wait until operator is rolled out after its deployment is changed

### DIFF
--- a/test/framework/cvo.go
+++ b/test/framework/cvo.go
@@ -78,10 +78,6 @@ func DisableCVOForOperator(te TestEnv) {
 		}
 	}
 
-	if err := StopDeployment(te, te.Client(), "kube-apiserver-operator", "openshift-kube-apiserver-operator"); err != nil {
-		te.Fatalf("unable to stop kube apiserver operator: %v", err)
-	}
-	if err := StopDeployment(te, te.Client(), "openshift-apiserver-operator", "openshift-apiserver-operator"); err != nil {
-		te.Fatalf("unable to stop openshift apiserver operator: %v", err)
-	}
+	StopDeployment(te, "openshift-kube-apiserver-operator", "kube-apiserver-operator")
+	StopDeployment(te, "openshift-apiserver-operator", "openshift-apiserver-operator")
 }

--- a/test/framework/imageregistry.go
+++ b/test/framework/imageregistry.go
@@ -168,9 +168,7 @@ func RemoveImageRegistry(te TestEnv) {
 	te.Logf("uninstalling the image registry...")
 	ensureImageRegistryToBeRemoved(te)
 	te.Logf("stopping the operator...")
-	if err := StopDeployment(te, te.Client(), OperatorDeploymentName, OperatorDeploymentNamespace); err != nil {
-		te.Fatalf("unable to stop the operator: %s", err)
-	}
+	StopDeployment(te, OperatorDeploymentNamespace, OperatorDeploymentName)
 	te.Logf("deleting the image registry resource...")
 	deleteImageRegistryResource(te)
 }
@@ -192,9 +190,7 @@ func DeployImageRegistry(te TestEnv, spec *imageregistryapiv1.ImageRegistrySpec)
 	}
 
 	te.Logf("starting the operator...")
-	if err := startOperator(te.Client()); err != nil {
-		te.Fatalf("unable to start the operator: %s", err)
-	}
+	startOperator(te)
 }
 
 func DumpImageRegistryResource(te TestEnv) {


### PR DESCRIPTION
This should fix flakes when proxy environments leak into another test.

For example in https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_cluster-image-registry-operator/507/pull-ci-openshift-cluster-image-registry-operator-master-e2e-aws-operator/2524, TestImageRegistryGracefulShutdown:

```
          - lastTransitionTime: "2020-04-01T13:58:46Z"
            message: |-
              RequestError: send request failed
              caused by: Head https://ci-op-h5fdww49-12abb-grk4s-image-registry-us-west-2-vyoknhwswx.s3.dualstack.us-west-2.amazonaws.com/: proxyconnect tcp: dial tcp: lookup https.example.org on 172.30.0.10:53: no such host
            reason: Unknown Error Occurred
            status: Unknown
            type: StorageExists
```