### PR TITLE
Bug 1809245: Try to attach to all pods during test

### DIFF
--- a/test/framework/daemonset.go
+++ b/test/framework/daemonset.go
@@ -23,10 +23,7 @@ func WaitForNodeCADaemonSet(client *Clientset) (*appsv1.DaemonSet, error) {
 	err := wait.Poll(1*time.Second, AsyncOperationTimeout, func() (stop bool, err error) {
 		ds, err = client.DaemonSets(defaults.ImageRegistryOperatorNamespace).Get("node-ca", metav1.GetOptions{})
 		if err == nil {
-			if ds.Status.NumberAvailable > 0 {
-				return true, nil
-			}
-			return false, nil
+			return ds.Status.NumberAvailable > 0, nil
 		}
 		if errors.IsNotFound(err) {
 			return false, nil

--- a/test/framework/logs.go
+++ b/test/framework/logs.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"regexp"
-	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -99,19 +98,18 @@ func DumpPodLogs(logger Logger, podLogs PodSetLogs) {
 	}
 }
 
-// MustFollowPodLog attaches to the pod log stream, reads it until the pod is
-// dead or an error happens while reading.
+// FollowPodLog attaches to the pod log stream, reads it until the pod is dead
+// or an error happens while reading.
 //
-// If an error happens when fetching pod's Stream() this function calls t.Fatal
-// while if a failure happens during pods log read the error is sent back to
-// the caller through an error channel.
-func MustFollowPodLog(t *testing.T, pod corev1.Pod) (<-chan string, <-chan error) {
-	client := MustNewClientset(t, nil)
+// If an error happens when fetching pod's Stream() this function returns
+// immediately. If a failure happens during pods log read the error is sent back
+// to the caller through an error channel.
+func FollowPodLog(client *Clientset, pod corev1.Pod) (<-chan string, <-chan error, error) {
 	ls, err := client.Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
 		Follow: true,
 	}).Stream()
 	if err != nil {
-		t.Fatal(err)
+		return nil, nil, err
 	}
 
 	logch := make(chan string, 100)
@@ -135,5 +133,5 @@ func MustFollowPodLog(t *testing.T, pod corev1.Pod) (<-chan string, <-chan error
 			}
 		}
 	}()
-	return logch, errch
+	return logch, errch, nil
 }


### PR DESCRIPTION
Graceful shutdown tests now attempt to attach to any available pod before failing.

This should mitigate the problem we are seeing during node-ca GracefulShutdown tests..