### PR TITLE
Add component to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,3 +8,4 @@ approvers:
 - bparees
 - dmage
 - adambkaplan
+component: "Image Registry"


### PR DESCRIPTION
Image registry operator is associated with the "Image Registry" component in bugzilla.