### PR TITLE
Bug 1809005: Always set node selector kubernetes.io/os to linux

### DIFF
--- a/pkg/resource/podtemplatespec.go
+++ b/pkg/resource/podtemplatespec.go
@@ -336,13 +336,21 @@ func makePodTemplateSpec(coreClient coreset.CoreV1Interface, proxyLister configl
 		}
 	}
 
+	nodeSelectors := map[string]string{}
+	for k, v := range cr.Spec.NodeSelector {
+		nodeSelectors[k] = v
+	}
+	if _, ok := nodeSelectors["kubernetes.io/os"]; !ok {
+		nodeSelectors["kubernetes.io/os"] = "linux"
+	}
+
 	spec := corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: defaults.DeploymentLabels,
 		},
 		Spec: corev1.PodSpec{
 			Tolerations:       cr.Spec.Tolerations,
-			NodeSelector:      cr.Spec.NodeSelector,
+			NodeSelector:      nodeSelectors,
 			PriorityClassName: "system-cluster-critical",
 			Containers: []corev1.Container{
 				{


### PR DESCRIPTION
This assures we only run the operator and the operand on linux nodes.