### PR TITLE
bindata: Run node-ca as hostNetwork to avoid NetworkNotReady

### DIFF
--- a/bindata/nodecadaemon.yaml
+++ b/bindata/nodecadaemon.yaml
@@ -17,6 +17,7 @@ spec:
       priorityClassName: system-cluster-critical
       tolerations:
       - operator: Exists
+      hostNetwork: true # run as host network to tolerate unready networks
       serviceAccountName: node-ca
       containers:
       - name: node-ca

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -64,6 +64,7 @@ spec:
       priorityClassName: system-cluster-critical
       tolerations:
       - operator: Exists
+      hostNetwork: true # run as host network to tolerate unready networks
       serviceAccountName: node-ca
       containers:
       - name: node-ca


### PR DESCRIPTION
The node-ca daemon is expected to run on all nodes soon after start
and has no need of pod network access. This causes a large number
of NetworkNotReady events to be sent and is unnecessary - the pod
should start as soon as the node is up.