### PR TITLE
Bug 1825055: Bumping default image registry resources

### DIFF
--- a/pkg/resource/podtemplatespec.go
+++ b/pkg/resource/podtemplatespec.go
@@ -305,8 +305,8 @@ func makePodTemplateSpec(coreClient coreset.CoreV1Interface, proxyLister configl
 
 	resources := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("100m"),
-			corev1.ResourceMemory: resource.MustParse("256Mi"),
+			corev1.ResourceCPU:    resource.MustParse("1"),
+			corev1.ResourceMemory: resource.MustParse("1Gi"),
 		},
 	}
 	if cr.Spec.Resources != nil {


### PR DESCRIPTION
After some discussions with @dmage we decided that a bump on these values would be a good thing as it would restrict a little the number of other pods that may be running on the same node image registry pods are.

Any input on this is very welcomed as we run two image registry replicas by default, that would makes us to consume 2 vCPU and ~2Gb of memory from the day 1.

This relates to BZ 1825055 because I have noticed the erroneous behavior described on it when under CPU pressure.
