### PR TITLE
Bug 1829910: fail the test when required objects are not found

### DIFF
--- a/test/e2e/pruner_test.go
+++ b/test/e2e/pruner_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -31,18 +30,14 @@ func TestPruneRegistryFlag(t *testing.T) {
 	cr, err := te.Client().Configs().Get(
 		context.Background(), defaults.ImageRegistryResourceName, metav1.GetOptions{},
 	)
-	if errors.IsNotFound(err) {
-		t.Errorf("unable to get the image registry custom resource: %s", err)
-	} else if err != nil {
+	if err != nil {
 		t.Fatal(err)
 	}
 	// Check that the cronjob was created
 	cronjob, err := te.Client().BatchV1beta1Interface.CronJobs(defaults.ImageRegistryOperatorNamespace).Get(
 		context.Background(), "image-pruner", metav1.GetOptions{},
 	)
-	if errors.IsNotFound(err) {
-		t.Errorf("unable to get the image pruner cronjob: %s", err)
-	} else if err != nil {
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -62,7 +57,7 @@ func TestPruneRegistryFlag(t *testing.T) {
 	if _, err := te.Client().Configs().Update(
 		context.Background(), cr, metav1.UpdateOptions{},
 	); err != nil {
-		t.Errorf("unable to update image registry custom resource: %s", err)
+		t.Fatalf("unable to update image registry custom resource: %s", err)
 	}
 
 	var errs []error
@@ -95,7 +90,6 @@ func TestPruneRegistryFlag(t *testing.T) {
 			t.Errorf("%#v", err)
 		}
 	}
-
 }
 
 // TestPruner verifies that the pruner controller installs the cronjob and sets it's
@@ -120,9 +114,7 @@ func TestPruner(t *testing.T) {
 	cr, err := te.Client().ImagePruners().Get(
 		context.Background(), defaults.ImageRegistryImagePrunerResourceName, metav1.GetOptions{},
 	)
-	if errors.IsNotFound(err) {
-		t.Errorf("unable to get the image pruner custom resource: %s", err)
-	} else if err != nil {
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -130,9 +122,7 @@ func TestPruner(t *testing.T) {
 	_, err = te.Client().BatchV1beta1Interface.CronJobs(defaults.ImageRegistryOperatorNamespace).Get(
 		context.Background(), "image-pruner", metav1.GetOptions{},
 	)
-	if errors.IsNotFound(err) {
-		t.Errorf("unable to get the image pruner cronjob: %s", err)
-	} else if err != nil {
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -153,9 +143,7 @@ func TestPruner(t *testing.T) {
 	_, err = te.Client().ImagePruners().Update(
 		context.Background(), cr, metav1.UpdateOptions{},
 	)
-	if errors.IsNotFound(err) {
-		t.Errorf("unable to get the image registry pruner custom resource: %s", err)
-	} else if err != nil {
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -165,9 +153,7 @@ func TestPruner(t *testing.T) {
 	cronjob, err := te.Client().BatchV1beta1Interface.CronJobs(defaults.ImageRegistryOperatorNamespace).Get(
 		context.Background(), "image-pruner", metav1.GetOptions{},
 	)
-	if errors.IsNotFound(err) {
-		t.Errorf("unable to get the image pruner cronjob: %s", err)
-	} else if err != nil {
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -183,9 +169,7 @@ func TestPruner(t *testing.T) {
 	cr, err = te.Client().ImagePruners().Get(
 		context.Background(), defaults.ImageRegistryImagePrunerResourceName, metav1.GetOptions{},
 	)
-	if errors.IsNotFound(err) {
-		t.Errorf("unable to get the image registry pruner custom resource: %s", err)
-	} else if err != nil {
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -195,9 +179,7 @@ func TestPruner(t *testing.T) {
 	_, err = te.Client().ImagePruners().Update(
 		context.Background(), cr, metav1.UpdateOptions{},
 	)
-	if errors.IsNotFound(err) {
-		t.Errorf("unable to get the image registry pruner custom resource: %s", err)
-	} else if err != nil {
+	if err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
```
panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0

goroutine 1557 [running]:
testing.tRunner.func1(0xc000291500)
	/usr/local/go/src/testing/testing.go:874 +0x3a3
panic(0x19541e0, 0xc00073c920)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/openshift/cluster-image-registry-operator/test/e2e.TestPruneRegistryFlag(0xc000291500)
	/go/src/github.com/openshift/cluster-image-registry-operator/test/e2e/pruner_test.go:55 +0xafc
testing.tRunner(0xc000291500, 0x1b43d50)
	/usr/local/go/src/testing/testing.go:909 +0xc9
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:960 +0x350
FAIL	github.com/openshift/cluster-image-registry-operator/test/e2e	1384.405s
```