### PR TITLE
Bug 1817119: Remove retries from azure client

### DIFF
--- a/test/e2e/configuration_test.go
+++ b/test/e2e/configuration_test.go
@@ -221,6 +221,7 @@ func TestOperatorProxyConfiguration(t *testing.T) {
 	}
 
 	// Set the proxy env vars
+	t.Logf("setting fake proxy environment variables on the operator deployment...")
 	if _, err := te.Client().Deployments(framework.OperatorDeploymentNamespace).Patch(
 		context.Background(),
 		framework.OperatorDeploymentName,
@@ -231,6 +232,7 @@ func TestOperatorProxyConfiguration(t *testing.T) {
 		t.Fatalf("failed to patch operator env vars: %v", err)
 	}
 	defer func() {
+		t.Logf("resetting proxy environment variables of the operator deployment...")
 		if _, err := te.Client().Deployments(framework.OperatorDeploymentNamespace).Patch(
 			context.Background(),
 			framework.OperatorDeploymentName,
@@ -267,8 +269,9 @@ func TestOperatorProxyConfiguration(t *testing.T) {
 
 	// Wait for the image registry resource to have an updated StorageExists condition
 	// showing that the operator can no longer reach the storage providers api
-	framework.ConditionExistsWithStatusAndReason(te, defaults.StorageExists, operatorapiv1.ConditionUnknown, "Unknown Error Occurred")
+	framework.ConditionExistsWithStatusAndReason(te, defaults.StorageExists, operatorapiv1.ConditionUnknown, "")
 
+	t.Logf("resetting proxy environment variables of the operator deployment...")
 	if _, err := te.Client().Deployments(framework.OperatorDeploymentNamespace).Patch(
 		context.Background(),
 		framework.OperatorDeploymentName,

--- a/test/framework/imageregistry.go
+++ b/test/framework/imageregistry.go
@@ -305,6 +305,11 @@ func WaitUntilImageRegistryConfigIsProcessed(te TestEnv) *imageregistryapiv1.Con
 			return false, err
 		}
 
+		if cr.Status.ObservedGeneration < cr.Generation {
+			te.Logf("waiting for the registry: generation=%d, observedGeneration=%d", cr.Generation, cr.Status.ObservedGeneration)
+			return false, nil
+		}
+
 		conds := GetImageRegistryConditions(cr)
 		te.Logf("waiting for the registry: %s", conds)
 		return conds.Progressing.IsFalse() && conds.Available.IsTrue() || conds.Degraded.IsTrue(), nil


### PR DESCRIPTION
The operator's workqueue already have a retry logic, additional retries on the client side makes the operator actions less clear.