### PR TITLE
Bug 1828608: Removing ImageRegistryRemoved alert

### DIFF
--- a/manifests/09-prometheus-rules.yaml
+++ b/manifests/09-prometheus-rules.yaml
@@ -17,17 +17,6 @@ spec:
         message: |
           Image Registry Storage configuration has changed in the last 30
           minutes. This change may have caused data loss.
-    - alert: ImageRegistryRemoved
-      expr: cluster_operator_conditions{name="image-registry",condition="Available",reason="Removed"} > 0
-      for: 5m
-      labels:
-        severity: warning
-      annotations:
-        message: |
-          Image Registry has been removed. ImageStreamTags, BuildConfigs and
-          DeploymentConfigs which reference ImageStreamTags may not work as
-          expected. Please configure storage and update the config to Managed
-          state by editing configs.imageregistry.operator.openshift.io.
   - name: ImagePruner
     rules:
     - alert: ImagePruningDisabled


### PR DESCRIPTION
Dear reviewer

In the past we have decided do bootstrap the registry as removed in some platforms, around the same time we also added an alert to notify the administrator if the registry was removed. Now we are having problems with some CI setup on VSphere(see related BZ) because the registry is bootstrapping as removed therefore this alarm is being triggered.

This PR removes this alert completely. Another option would be to postpone it to be triggered only a few hours later, please keep that in mind when reviewing this.

I have opted for removing this as the Registry being in a removed state is a "normal" situation, in the sense that any administrator may remove it by simply editing the config.