### PR TITLE
Bug 1838960: Change region parameters only when region is not configured

### DIFF
--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -117,13 +117,12 @@ func (d *driver) updateConfigAndGetCredentials() (accessKey, secretKey string, e
 		return "", "", err
 	}
 
-	if len(d.Config.Region) == 0 {
+	if len(d.Config.Region) == 0 && len(d.Config.RegionEndpoint) == 0 {
 		d.Config.Region = cfg.Region
-	}
-
-	if len(d.Config.RegionEndpoint) == 0 && len(cfg.RegionEndpoint) != 0 {
 		d.Config.RegionEndpoint = cfg.RegionEndpoint
-		d.Config.VirtualHostedStyle = true
+		if len(cfg.RegionEndpoint) != 0 {
+			d.Config.VirtualHostedStyle = true
+		}
 	}
 
 	return cfg.AccessKey, cfg.SecretKey, nil


### PR DESCRIPTION
The operator should update the S3 region configuration only when both region and regionEndpoint are unset.