### PR TITLE
Bug 1841080: Increasing default startingDeadlineSeconds

### DIFF
--- a/pkg/resource/prunercronjob.go
+++ b/pkg/resource/prunercronjob.go
@@ -24,7 +24,7 @@ import (
 var (
 	defaultSuspend                          = false
 	defaultSchedule                         = "0 0 * * *"
-	defaultStartingDeadlineSeconds    int64 = 60
+	defaultStartingDeadlineSeconds    int64 = 3600
 	defaultFailedJobsHistoryLimit     int32 = 3
 	defaultSuccessfulJobsHistoryLimit int32 = 3
 	defaultKeepTagRevisions                 = 3


### PR DESCRIPTION
A value of 60 seconds might make the cronjob not to be started in time.
This patch increases the deadline to 10 minutes, as we run the pruner job
only once a day a delay increase here is acceptable.