### PR TITLE
Bug 1846263: Avoiding bootstrap failure on unavailable swift

### DIFF
--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -150,20 +150,15 @@ func GetPlatformStorage(listers *regopclient.Listers) (imageregistryv1.ImageRegi
 		cfg.GCS = &imageregistryv1.ImageRegistryConfigStorageGCS{}
 		replicas = 2
 	case configapiv1.OpenStackPlatformType:
-		isSwiftEnabled, err := swift.IsSwiftEnabled(listers)
-		if err != nil {
-			return imageregistryv1.ImageRegistryConfigStorage{}, replicas, err
-		}
-		if !isSwiftEnabled {
-			cfg.PVC = &imageregistryv1.ImageRegistryConfigStoragePVC{
-				Claim: defaults.PVCImageRegistryName,
-			}
-			replicas = 1
-		} else {
+		if swift.IsSwiftEnabled(listers) {
 			cfg.Swift = &imageregistryv1.ImageRegistryConfigStorageSwift{}
 			replicas = 2
+			break
 		}
-
+		cfg.PVC = &imageregistryv1.ImageRegistryConfigStoragePVC{
+			Claim: defaults.PVCImageRegistryName,
+		}
+		replicas = 1
 	// Unknown platforms or LibVirt: we configure image registry using
 	// EmptyDir storage.
 	case configapiv1.LibvirtPlatformType:

--- a/pkg/storage/swift/swift.go
+++ b/pkg/storage/swift/swift.go
@@ -20,6 +20,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog"
 
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	operatorapi "github.com/openshift/api/operator/v1"
@@ -58,35 +59,19 @@ func replaceEmpty(a string, b string) string {
 }
 
 // IsSwiftEnabled checks if Swift service is available for OpenStack platform
-func IsSwiftEnabled(listers *regopclient.Listers) (bool, error) {
+func IsSwiftEnabled(listers *regopclient.Listers) bool {
 	driver := NewDriver(&imageregistryv1.ImageRegistryConfigStorageSwift{}, listers)
 	conn, err := driver.getSwiftClient()
 	if err != nil {
-		// ErrEndpointNotFound means that Swift is not available
-		if _, ok := err.(*gophercloud.ErrEndpointNotFound); ok {
-			return false, nil
-		}
-		return false, err
+		klog.Errorf("swift storage inaccessible: %v", err)
+		return false
 	}
-
 	// Try to list containers to make sure the user has required permissions to do that
-	listOpts := containers.ListOpts{Full: false}
-	_, err = containers.List(conn, listOpts).AllPages()
-	if err != nil {
-		// If the user has no permissions, we consider that Swift is unavailable
-		// Depending on the configuration swift returns different error codes:
-		// 403 with Keystone and 401 with internal Swauth.
-		// It means we have to catch them both.
-		// More information about Swith auth: https://docs.openstack.org/swift/latest/overview_auth.html
-		if _, ok := err.(gophercloud.ErrDefault403); ok {
-			return false, nil
-		}
-		if _, ok := err.(gophercloud.ErrDefault401); ok {
-			return false, nil
-		}
-		return false, err
+	if _, err = containers.List(conn, containers.ListOpts{}).AllPages(); err != nil {
+		klog.Errorf("error listing swift containers: %v", err)
+		return false
 	}
-	return true, nil
+	return true
 }
 
 // GetConfig reads credentials

--- a/pkg/storage/swift/swift_test.go
+++ b/pkg/storage/swift/swift_test.go
@@ -750,9 +750,7 @@ func TestSwiftIsAvailable(t *testing.T) {
 		Infrastructures: fakeInfrastructureLister(cloudName),
 		OpenShiftConfig: MockConfigMapNamespaceLister{},
 	}
-	res, err := IsSwiftEnabled(listers)
-	th.AssertNoErr(t, err)
-	th.AssertEquals(t, true, res)
+	th.AssertEquals(t, true, IsSwiftEnabled(listers))
 }
 
 func TestSwiftIsNotAvailable(t *testing.T) {
@@ -804,9 +802,7 @@ func TestSwiftIsNotAvailable(t *testing.T) {
 		Infrastructures: fakeInfrastructureLister(cloudName),
 		OpenShiftConfig: MockConfigMapNamespaceLister{},
 	}
-	res, err := IsSwiftEnabled(listers)
-	th.AssertNoErr(t, err)
-	th.AssertEquals(t, false, res)
+	th.AssertEquals(t, false, IsSwiftEnabled(listers))
 }
 
 func TestNoPermissionsKeystone(t *testing.T) {
@@ -856,9 +852,7 @@ func TestNoPermissionsKeystone(t *testing.T) {
 		Infrastructures: fakeInfrastructureLister(cloudName),
 		OpenShiftConfig: MockConfigMapNamespaceLister{},
 	}
-	res, err := IsSwiftEnabled(listers)
-	th.AssertNoErr(t, err)
-	th.AssertEquals(t, false, res)
+	th.AssertEquals(t, false, IsSwiftEnabled(listers))
 }
 
 func TestNoPermissionsSwauth(t *testing.T) {
@@ -908,7 +902,5 @@ func TestNoPermissionsSwauth(t *testing.T) {
 		Infrastructures: fakeInfrastructureLister(cloudName),
 		OpenShiftConfig: MockConfigMapNamespaceLister{},
 	}
-	res, err := IsSwiftEnabled(listers)
-	th.AssertNoErr(t, err)
-	th.AssertEquals(t, false, res)
+	th.AssertEquals(t, false, IsSwiftEnabled(listers))
 }


### PR DESCRIPTION
If operator can't reach remote swift storage bootstrap using a
persistent volume claim. Operator was doing something very similar to
this, but under certain circumstances it was not completing the
bootstrap (e.g. when swift username/password pair was not configured)