### PR TITLE
Enable registry by default for ovirt

### DIFF
--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -133,7 +133,6 @@ func GetPlatformStorage(listers *regopclient.Listers) (imageregistryv1.ImageRegi
 	// These are the platforms we don't configure any backend for, on these
 	// we should bootstrap the image registry as "Removed".
 	case configapiv1.BareMetalPlatformType,
-		configapiv1.OvirtPlatformType,
 		configapiv1.VSpherePlatformType,
 		configapiv1.NonePlatformType:
 		break
@@ -155,6 +154,11 @@ func GetPlatformStorage(listers *regopclient.Listers) (imageregistryv1.ImageRegi
 			replicas = 2
 			break
 		}
+		cfg.PVC = &imageregistryv1.ImageRegistryConfigStoragePVC{
+			Claim: defaults.PVCImageRegistryName,
+		}
+		replicas = 1
+	case configapiv1.OvirtPlatformType:
 		cfg.PVC = &imageregistryv1.ImageRegistryConfigStoragePVC{
 			Claim: defaults.PVCImageRegistryName,
 		}


### PR DESCRIPTION
As part of the upcommig CSI Driver support a registry should be enabled by
default.
The CSI driver support is part of Cluster Storage Operator support in
external providers. See
https://github.com/openshift/enhancements/pull/352

Signed-off-by: Roy Golan <rgolan@redhat.com>
