### PR TITLE
Bug 1857684: Using last finished job status and disabling retries

### DIFF
--- a/pkg/operator/controllerimagepruner.go
+++ b/pkg/operator/controllerimagepruner.go
@@ -226,8 +226,15 @@ func (c *ImagePrunerController) sync() error {
 
 	lastPrunerJobConditions := []batchv1.JobCondition{}
 	if len(prunerJobs) > 0 {
-		sort.Sort(byCreationTimestamp(prunerJobs))
-		lastPrunerJobConditions = prunerJobs[len(prunerJobs)-1].Status.Conditions
+		sort.Sort(sort.Reverse(byCreationTimestamp(prunerJobs)))
+		for _, job := range prunerJobs {
+			// skip not finished jobs.
+			if len(job.Status.Conditions) == 0 {
+				continue
+			}
+			lastPrunerJobConditions = job.Status.Conditions
+			break
+		}
 	}
 
 	c.syncPrunerStatus(pcr, applyError, prunerCronJob, lastPrunerJobConditions)

--- a/pkg/resource/prunercronjob.go
+++ b/pkg/resource/prunercronjob.go
@@ -81,6 +81,7 @@ func (gcj *generatorPrunerCronJob) expected() (runtime.Object, error) {
 		return nil, err
 	}
 
+	backoffLimit := int32(0)
 	cj := &batchapi.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      gcj.GetName(),
@@ -95,9 +96,10 @@ func (gcj *generatorPrunerCronJob) expected() (runtime.Object, error) {
 			StartingDeadlineSeconds:    &defaultStartingDeadlineSeconds,
 			JobTemplate: batchapi.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
+					BackoffLimit: &backoffLimit,
 					Template: kcorev1.PodTemplateSpec{
 						Spec: kcorev1.PodSpec{
-							RestartPolicy:      kcorev1.RestartPolicyOnFailure,
+							RestartPolicy:      kcorev1.RestartPolicyNever,
 							ServiceAccountName: "pruner",
 							Affinity:           gcj.getAffinity(cr),
 							NodeSelector:       gcj.getNodeSelector(cr),


### PR DESCRIPTION
This commit disables retries on pruning jobs, it also uses now the last
finished job status when checking for Condition (the operator becomes
deprecated only if the last finished job failed).