### PR TITLE
Removed shared process namespace

### DIFF
--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -17,7 +17,6 @@ spec:
         name: cluster-image-registry-operator
     spec:
       serviceAccountName: cluster-image-registry-operator
-      shareProcessNamespace: true
       priorityClassName: system-cluster-critical
       nodeSelector:
         node-role.kubernetes.io/master: ""


### PR DESCRIPTION
As we don't have two containers running on this POD anymore there is no
need to have this shared namespace.