### PR TITLE
Bug 1857782: Setting shareProcessNamespace to false

### DIFF
--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -17,6 +17,7 @@ spec:
         name: cluster-image-registry-operator
     spec:
       serviceAccountName: cluster-image-registry-operator
+      shareProcessNamespace: false
       priorityClassName: system-cluster-critical
       nodeSelector:
         node-role.kubernetes.io/master: ""


### PR DESCRIPTION
Cluster version operator treats unset pointers in manifests as "operator
maintainers have no opinion". If we want to actually clear this, we
need explicitly set shareProcessNamespace to false. As this property was
set to true we need now to set it to false.

For reference https://github.com/openshift/cluster-image-registry-operator/pull/587#discussion_r472576936