### PR TITLE
[release-4.4] Bug 1873534: Using last finished job and disabling retries

### DIFF
--- a/pkg/operator/controllerimagepruner.go
+++ b/pkg/operator/controllerimagepruner.go
@@ -183,8 +183,15 @@ func (c *ImagePrunerController) sync() error {
 
 	lastPrunerJobConditions := []batchv1.JobCondition{}
 	if len(prunerJobs) > 0 {
-		sort.Sort(ByCreationTimestamp(prunerJobs))
-		lastPrunerJobConditions = prunerJobs[len(prunerJobs)-1].Status.Conditions
+		sort.Sort(sort.Reverse(ByCreationTimestamp(prunerJobs)))
+		for _, job := range prunerJobs {
+			// skip not finished jobs.
+			if len(job.Status.Conditions) == 0 {
+				continue
+			}
+			lastPrunerJobConditions = job.Status.Conditions
+			break
+		}
 	}
 
 	c.syncPrunerStatus(pcr, prunerCronJob, lastPrunerJobConditions)

--- a/pkg/resource/prunercronjob.go
+++ b/pkg/resource/prunercronjob.go
@@ -90,6 +90,7 @@ func (gcj *generatorPrunerCronJob) expected() (runtime.Object, error) {
 		return nil, err
 	}
 
+	backoffLimit := int32(0)
 	cj := &batchapi.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      gcj.GetName(),
@@ -104,9 +105,10 @@ func (gcj *generatorPrunerCronJob) expected() (runtime.Object, error) {
 			StartingDeadlineSeconds:    &defaultStartingDeadlineSeconds,
 			JobTemplate: batchapi.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
+					BackoffLimit: &backoffLimit,
 					Template: kcorev1.PodTemplateSpec{
 						Spec: kcorev1.PodSpec{
-							RestartPolicy:      kcorev1.RestartPolicyOnFailure,
+							RestartPolicy:      kcorev1.RestartPolicyNever,
 							ServiceAccountName: "pruner",
 							Affinity:           gcj.getAffinity(cr),
 							NodeSelector:       gcj.getNodeSelector(cr),


### PR DESCRIPTION
**DUE TO CONFLICTS THIS GOT MANUALLY CHERRY PICKED FROM https://github.com/openshift/cluster-image-registry-operator/pull/586**

This commit disables retries on pruning jobs, it also uses now the last
finished job status when checking for Condition (the operator becomes
deprecated only if the last finished job failed).