### PR TITLE
Bug 1857246: Retrying in case of conflict during Config update

### DIFF
--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -15,6 +15,7 @@ import (
 	kubeclient "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
 
@@ -247,14 +248,27 @@ func (c *Controller) sync() error {
 		}
 		klog.Infof("object changed: %s (metadata=%t, spec=%t): %s", utilObjectInfo(cr), metadataChanged, specChanged, difference)
 
-		updatedCR, err := c.clients.RegOp.ImageregistryV1().Configs().Update(
-			context.TODO(), cr, metaapi.UpdateOptions{},
-		)
-		if err != nil {
-			if !errors.IsConflict(err) {
-				klog.Errorf("unable to update %s: %s", utilObjectInfo(cr), err)
+		var updatedCR *imageregistryv1.Config
+		if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			updatedCR, err = c.listers.RegistryConfigs.Get(defaults.ImageRegistryResourceName)
+			if err != nil {
+				return err
 			}
+			updatedCR = updatedCR.DeepCopy()
+
+			if metadataChanged {
+				updatedCR.ObjectMeta = cr.ObjectMeta
+			}
+			if specChanged {
+				updatedCR.Spec = cr.Spec
+			}
+
+			updatedCR, err = c.clients.RegOp.ImageregistryV1().Configs().Update(
+				context.TODO(), updatedCR, metaapi.UpdateOptions{},
+			)
 			return err
+		}); err != nil {
+			return fmt.Errorf("unable to update config spec: %s", err)
 		}
 
 		// If we updated the Status field too, we'll make one more call and we

--- a/test/e2e/bootstrap_test.go
+++ b/test/e2e/bootstrap_test.go
@@ -1,0 +1,28 @@
+package e2e
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openshift/cluster-image-registry-operator/test/framework"
+)
+
+func TestBootstrapFailToUpdateSpec(t *testing.T) {
+	te := framework.SetupAvailableImageRegistry(t, nil)
+	defer framework.TeardownImageRegistry(te)
+
+	logs, err := framework.GetOperatorLogs(te.Client())
+	if err != nil {
+		t.Fatalf("error reading operator logs: %s", err)
+	}
+
+	for _, podLogs := range logs {
+		for _, containerLogs := range podLogs {
+			for _, logLine := range containerLogs {
+				if strings.Contains(logLine, "unable to update config spec") {
+					t.Errorf("error on spec update found, this should not happen")
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
We have multiple controllers concurrently writting the status of the
config, this commit introduces retries in case of any of them updated
the config resource before us. This is clearly a workaround, as the
main controller may create storage if we fail to update the
configuration here it may ended up creating storage again on the next
cycle, hence the need to make sure we succeed.