### PR TITLE
Bug 1876961: Fix "slice index out of range"

### DIFF
--- a/pkg/client/operatorclient.go
+++ b/pkg/client/operatorclient.go
@@ -47,6 +47,7 @@ func (c *ConfigOperatorClient) GetOperatorState() (spec *operatorv1.OperatorSpec
 	if err != nil {
 		return nil, nil, "", err
 	}
+	config = config.DeepCopy()
 
 	// TODO(dmage): this should be updated when we add OperatorSpec to the config object
 	return &operatorv1.OperatorSpec{}, &config.Status.OperatorStatus, config.ResourceVersion, nil


### PR DESCRIPTION
The result of GetOperatorState is used by different controllers to
report about their conditions, sometimes they mutate the returned value.

Listers return pointer to the same value if Get is used multiple times
and the object didn't change between calls.

It means that the clients of GetOperatorState could mutate the same
object without any synchronization. In some cases it caused panics.