### PR TITLE
Bug 1824834: httpSecret should be generated when it is not set

### DIFF
--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -2,7 +2,6 @@ package operator
 
 import (
 	"context"
-	"crypto/rand"
 	"fmt"
 
 	appsapi "k8s.io/api/apps/v1"
@@ -22,10 +21,6 @@ import (
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage/util"
 )
 
-// randomSecretSize is the number of random bytes to generate
-// for the http secret
-const randomSecretSize = 64
-
 // Bootstrap registers this operator with OpenShift by creating an appropriate
 // ClusterOperator custom resource. This function also creates the initial
 // configuration for the Image Registry.
@@ -42,11 +37,6 @@ func (c *Controller) Bootstrap() error {
 
 	// If no registry resource exists, let's create one with sane defaults
 	klog.Infof("generating registry custom resource")
-
-	var secretBytes [randomSecretSize]byte
-	if _, err := rand.Read(secretBytes[:]); err != nil {
-		return fmt.Errorf("could not generate random bytes for HTTP secret: %s", err)
-	}
 
 	platformStorage, replicas, err := storage.GetPlatformStorage(c.listers)
 	if err != nil {
@@ -85,7 +75,6 @@ func (c *Controller) Bootstrap() error {
 			ManagementState: mgmtState,
 			Storage:         platformStorage,
 			Replicas:        replicas,
-			HTTPSecret:      fmt.Sprintf("%x", string(secretBytes[:])),
 			RolloutStrategy: string(rolloutStrategy),
 		},
 		Status: imageregistryv1.ImageRegistryStatus{},

--- a/pkg/operator/bootstrap_test.go
+++ b/pkg/operator/bootstrap_test.go
@@ -68,11 +68,6 @@ func TestBootstrapAWS(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if config.Spec.HTTPSecret == "" {
-		t.Errorf("got empty spec.httpSecrets, want random string")
-	}
-	config.Spec.HTTPSecret = ""
-
 	expected := imageregistryv1.ImageRegistrySpec{
 		ManagementState: "Managed",
 		Storage: imageregistryv1.ImageRegistryConfigStorage{

--- a/pkg/operator/complete.go
+++ b/pkg/operator/complete.go
@@ -1,12 +1,17 @@
 package operator
 
 import (
+	"crypto/rand"
 	"fmt"
 
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 
 	"github.com/openshift/cluster-image-registry-operator/pkg/defaults"
 )
+
+// randomSecretSize is the number of random bytes to generate
+// for the http secret
+const randomSecretSize = 64
 
 func appendFinalizer(cr *imageregistryv1.Config) {
 	for i := range cr.ObjectMeta.Finalizers {
@@ -33,6 +38,19 @@ func verifyResource(cr *imageregistryv1.Config) error {
 			return fmt.Errorf("duplication of names has been detected in the additional routes")
 		}
 		names[routeSpec.Name] = struct{}{}
+	}
+
+	return nil
+}
+
+func applyDefaults(cr *imageregistryv1.Config) error {
+	if cr.Spec.HTTPSecret == "" {
+		var secretBytes [randomSecretSize]byte
+		if _, err := rand.Read(secretBytes[:]); err != nil {
+			return fmt.Errorf("could not generate random bytes for HTTP secret: %s", err)
+		}
+
+		cr.Spec.HTTPSecret = fmt.Sprintf("%x", string(secretBytes[:]))
 	}
 
 	return nil

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -189,6 +189,11 @@ func (c *Controller) createOrUpdateResources(cr *imageregistryv1.Config) error {
 		return newPermanentError("VerificationFailed", fmt.Errorf("unable to complete resource: %s", err))
 	}
 
+	err = applyDefaults(cr)
+	if err != nil {
+		return err
+	}
+
 	err = c.generator.Apply(cr)
 	if err == storage.ErrStorageNotConfigured {
 		return newPermanentError("StorageNotConfigured", err)


### PR DESCRIPTION
This PR have two purposes:

1. it reduces the risk of failing to bootstrap the image registry config
2. it ensures that httpSecret is set even if the config object is created by someone else