### PR TITLE
Bug 1886849: panic during creation of Azure storage container

### DIFF
--- a/pkg/storage/azure/azure.go
+++ b/pkg/storage/azure/azure.go
@@ -510,7 +510,7 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 						return err
 					}
 				} else {
-					util.UpdateCondition(cr, defaults.StorageExists, operatorapiv1.ConditionUnknown, string(e.ServiceCode()), fmt.Sprintf("Unable to create storage container: %s", err))
+					util.UpdateCondition(cr, defaults.StorageExists, operatorapiv1.ConditionUnknown, storageExistsReasonAzureError, fmt.Sprintf("Unable to create storage container: %s", err))
 					return err
 				}
 			}


### PR DESCRIPTION
When the operator fails to create an Azure storage container, it panics in attempt to format the error reason.