### PR TITLE
Bug 1850465: Keep node-ca daemonset in-sync with reference version

### DIFF
--- a/pkg/operator/nodecadaemon.go
+++ b/pkg/operator/nodecadaemon.go
@@ -88,7 +88,7 @@ func (c *NodeCADaemonController) processNextWorkItem() bool {
 }
 
 func (c *NodeCADaemonController) sync() error {
-	gen := resource.NewGeneratorNodeCADaemonSet(c.daemonSetLister, c.serviceLister, c.appsClient)
+	gen := resource.NewGeneratorNodeCADaemonSet(c.daemonSetLister, c.serviceLister, c.appsClient, c.operatorClient)
 	err := resource.ApplyMutator(gen)
 	if err != nil {
 		_, _, updateError := v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{

--- a/pkg/resource/nodecadaemon_test.go
+++ b/pkg/resource/nodecadaemon_test.go
@@ -1,11 +1,21 @@
 package resource
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	kfake "k8s.io/client-go/kubernetes/fake"
+
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+	imageregistryfake "github.com/openshift/client-go/imageregistry/clientset/versioned/fake"
+	imageregistryinformers "github.com/openshift/client-go/imageregistry/informers/externalversions"
+
+	"github.com/openshift/cluster-image-registry-operator/pkg/client"
 )
 
 func findToleration(list []corev1.Toleration, cond func(toleration corev1.Toleration) bool) *corev1.Toleration {
@@ -18,9 +28,31 @@ func findToleration(list []corev1.Toleration, cond func(toleration corev1.Tolera
 }
 
 func TestNodeCADaemon(t *testing.T) {
-	clientset := kfake.NewSimpleClientset()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	g := NewGeneratorNodeCADaemonSet(nil, nil, clientset.AppsV1())
+	imageregistryObjects := []runtime.Object{
+		&imageregistryv1.Config{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cluster",
+			},
+		},
+	}
+
+	clientset := kfake.NewSimpleClientset()
+	imageregistryClient := imageregistryfake.NewSimpleClientset(imageregistryObjects...)
+
+	imageregistryInformers := imageregistryinformers.NewSharedInformerFactory(imageregistryClient, time.Minute)
+
+	operatorClient := client.NewConfigOperatorClient(
+		imageregistryClient.ImageregistryV1().Configs(),
+		imageregistryInformers.Imageregistry().V1().Configs(),
+	)
+
+	imageregistryInformers.Start(ctx.Done())
+	imageregistryInformers.WaitForCacheSync(ctx.Done())
+
+	g := NewGeneratorNodeCADaemonSet(nil, nil, clientset.AppsV1(), operatorClient)
 	obj, err := g.Create()
 	if err != nil {
 		t.Fatal(err)

--- a/test/e2e/nodecadaemon_test.go
+++ b/test/e2e/nodecadaemon_test.go
@@ -2,15 +2,19 @@ package e2e
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	imageregistryapiv1 "github.com/openshift/api/imageregistry/v1"
-	operatorapiv1 "github.com/openshift/api/operator/v1"
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 
 	"github.com/openshift/cluster-image-registry-operator/pkg/defaults"
 	"github.com/openshift/cluster-image-registry-operator/test/framework"
@@ -20,8 +24,8 @@ func TestNodeCADaemonAlwaysDeployed(t *testing.T) {
 	te := framework.Setup(t)
 	defer framework.TeardownImageRegistry(te)
 
-	framework.DeployImageRegistry(te, &imageregistryapiv1.ImageRegistrySpec{
-		ManagementState: operatorapiv1.Removed,
+	framework.DeployImageRegistry(te, &imageregistryv1.ImageRegistrySpec{
+		ManagementState: operatorv1.Removed,
 		Replicas:        1,
 	})
 	framework.WaitUntilImageRegistryIsAvailable(te)
@@ -47,5 +51,70 @@ func TestNodeCADaemonAlwaysDeployed(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestNodeCADaemonChangesReverted(t *testing.T) {
+	te := framework.SetupAvailableImageRegistry(t, &imageregistryv1.ImageRegistrySpec{
+		ManagementState: operatorv1.Managed,
+		Storage: imageregistryv1.ImageRegistryConfigStorage{
+			EmptyDir: &imageregistryv1.ImageRegistryConfigStorageEmptyDir{},
+		},
+		Replicas: 1,
+	})
+	defer framework.TeardownImageRegistry(te)
+
+	t.Log("waiting until the node-ca daemonset is created")
+	err := wait.Poll(5*time.Second, framework.AsyncOperationTimeout, func() (stop bool, err error) {
+		_, err = te.Client().DaemonSets(defaults.ImageRegistryOperatorNamespace).Get(
+			context.Background(), "node-ca", metav1.GetOptions{},
+		)
+		if errors.IsNotFound(err) {
+			t.Logf("ds/node-ca has not been created yet: %s", err)
+			return false, nil
+		} else if err != nil {
+			return false, err
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("changing the node-ca daemonset")
+	if _, err := te.Client().DaemonSets(defaults.ImageRegistryOperatorNamespace).Patch(
+		context.Background(),
+		"node-ca",
+		types.JSONPatchType,
+		framework.MarshalJSON([]framework.JSONPatch{
+			{
+				Op:   "remove",
+				Path: "/spec/template/spec/tolerations",
+			},
+		}),
+		metav1.PatchOptions{},
+	); err != nil {
+		t.Fatalf("unable to remove tolerations from node-ca: %s", err)
+	}
+
+	if err := wait.Poll(time.Second, framework.AsyncOperationTimeout, func() (stop bool, err error) {
+		ds, err := te.Client().DaemonSets(defaults.ImageRegistryOperatorNamespace).Get(
+			context.Background(), "node-ca", metav1.GetOptions{},
+		)
+		if err != nil {
+			return false, fmt.Errorf("unable to get node-ca: %s", err)
+		}
+
+		t.Logf("node-ca tolerations: %#v", ds.Spec.Template.Spec.Tolerations)
+
+		return reflect.DeepEqual(
+			ds.Spec.Template.Spec.Tolerations,
+			[]corev1.Toleration{
+				{Operator: corev1.TolerationOpExists},
+			},
+		), nil
+	}); err != nil {
+		t.Fatalf("failed to wait until node-ca is restored: %s", err)
 	}
 }


### PR DESCRIPTION
The PR makes the operator to detect when the daemonset is changed and stomp these changes.