### PR TITLE
Bug 1885856: Creating prometheus record rule for v1 imports

### DIFF
--- a/manifests/09-prometheus-rules.yaml
+++ b/manifests/09-prometheus-rules.yaml
@@ -17,3 +17,5 @@ spec:
         message: |
           Image Registry Storage configuration has changed in the last 30
           minutes. This change may have caused data loss.
+    - expr: sum(apiserver_v1_image_imports_total)
+      record: :apiserver_v1_image_imports:sum


### PR DESCRIPTION
Creating a record rule keeping track of the number of repository imports
using registry v1 protocol.