### PR TITLE
Bug 1887010: Make pruner always aware of registry name

### DIFF
--- a/pkg/client/listers.go
+++ b/pkg/client/listers.go
@@ -37,4 +37,5 @@ type ImagePrunerControllerListers struct {
 	RegistryConfigs     regoplisters.ConfigLister
 	ImagePrunerConfigs  regoplisters.ImagePrunerLister
 	ConfigMaps          kcorelisters.ConfigMapNamespaceLister
+	ImageConfigs        configlisters.ImageLister
 }

--- a/pkg/operator/controllerimagepruner.go
+++ b/pkg/operator/controllerimagepruner.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/klog"
 
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	imageregistryclient "github.com/openshift/client-go/imageregistry/clientset/versioned"
 	imageregistryinformers "github.com/openshift/client-go/imageregistry/informers/externalversions"
 
@@ -50,6 +51,7 @@ func NewImagePrunerController(
 	imageregistryClient imageregistryclient.Interface,
 	kubeInformerFactory kubeinformers.SharedInformerFactory,
 	regopInformerFactory imageregistryinformers.SharedInformerFactory,
+	imageConfigInformer configv1informers.ImageInformer,
 ) *ImagePrunerController {
 	listers := &regopclient.ImagePrunerControllerListers{}
 	clients := &regopclient.Clients{}
@@ -110,6 +112,10 @@ func NewImagePrunerController(
 			informer := kubeInformerFactory.Core().V1().ConfigMaps()
 			c.listers.ConfigMaps = informer.Lister().ConfigMaps(defaults.ImageRegistryOperatorNamespace)
 			return informer.Informer()
+		},
+		func() cache.SharedIndexInformer {
+			c.listers.ImageConfigs = imageConfigInformer.Lister()
+			return imageConfigInformer.Informer()
 		},
 	} {
 		informer := ctor()

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -109,6 +109,7 @@ func RunOperator(ctx context.Context, kubeconfig *restclient.Config) error {
 		imageregistryClient,
 		kubeInformers,
 		imageregistryInformers,
+		configInformers.Config().V1().Images(),
 	)
 
 	loggingController := loglevel.NewClusterOperatorLoggingController(

--- a/pkg/resource/generatorimagepruner.go
+++ b/pkg/resource/generatorimagepruner.go
@@ -29,7 +29,7 @@ func (g *ImagePrunerGenerator) List(cr *imageregistryv1.ImagePruner) ([]Mutator,
 	mutators = append(mutators, newGeneratorPrunerClusterRoleBinding(g.listers.ClusterRoleBindings, g.clients.RBAC))
 	mutators = append(mutators, newGeneratorPrunerServiceAccount(g.listers.ServiceAccounts, g.clients.Core))
 	mutators = append(mutators, newGeneratorServiceCA(g.listers.ConfigMaps, g.clients.Core))
-	mutators = append(mutators, newGeneratorPrunerCronJob(g.listers.CronJobs, g.clients.Batch, g.listers.ImagePrunerConfigs, g.listers.RegistryConfigs))
+	mutators = append(mutators, newGeneratorPrunerCronJob(g.listers.CronJobs, g.clients.Batch, g.listers.ImagePrunerConfigs, g.listers.ImageConfigs))
 
 	return mutators, nil
 }

--- a/test/e2e/pruner_test.go
+++ b/test/e2e/pruner_test.go
@@ -153,6 +153,11 @@ func TestPruner(t *testing.T) {
 		t.Fatalf("flag --ignore-invalid-refs=true is not found")
 	}
 
+	if !containsString(cronjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Args, "--registry-url=https://image-registry.openshift-image-registry.svc:5000") {
+		defer framework.DumpYAML(t, "cronjob", cronjob)
+		t.Fatalf("flag --registry-url is not found")
+	}
+
 	// Check that making changes to the pruner custom resource trickle down to the cronjob
 	// and that the conditions get updated correctly
 	truePtr := true


### PR DESCRIPTION
If the image pruner is not provided with a registry hostname, it tries to guess it from image streams. But they might be missing on fresh clusters without the samples operator. To avoid this problem, the operator should provide the pruner with the registry hostname.