### PR TITLE
Bug 1892799: Operator should use entrypoint script

### DIFF
--- a/cmd/cluster-image-registry-operator/main.go
+++ b/cmd/cluster-image-registry-operator/main.go
@@ -64,6 +64,7 @@ func main() {
 				"image-registry-operator",
 				func(ctx context.Context, cctx *controllercmd.ControllerContext) error {
 					printVersion()
+					klog.Infof("Watching files %v...", filesToWatch)
 					rand.Seed(time.Now().UnixNano())
 					go metrics.RunServer(metricsPort)
 					return operator.RunOperator(ctx, cctx.KubeConfig)

--- a/images/bin/entrypoint.sh
+++ b/images/bin/entrypoint.sh
@@ -9,4 +9,4 @@ if [ -e "$trustedCA" ]; then
     cp -f "$trustedCA" /etc/pki/ca-trust/extracted/pem/
 fi
 
-exec /usr/bin/cluster-image-registry-operator
+exec /usr/bin/cluster-image-registry-operator "$@"

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -35,8 +35,6 @@ spec:
         tolerationSeconds: 120
       containers:
         - name: cluster-image-registry-operator
-          command:
-          - cluster-image-registry-operator
           args:
           - --files=/var/run/configmaps/trusted-ca/tls-ca-bundle.pem
           - --files=/etc/secrets/tls.crt

--- a/test/e2e/emptydir_test.go
+++ b/test/e2e/emptydir_test.go
@@ -43,16 +43,16 @@ func TestBasicEmptyDir(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	badlogs := false
+	if !logs.Contains(regexp.MustCompile(`Overwriting root TLS certificate authority trust store`)) {
+		t.Error("error: the log doesn't contain message from the entrypoint script")
+	}
 	if !logs.Contains(regexp.MustCompile(`Cluster Image Registry Operator Version: .+`)) {
-		badlogs = true
 		t.Error("error: the log doesn't contain the operator's version")
 	}
-	if !logs.Contains(regexp.MustCompile(`object changed`)) {
-		badlogs = true
-		t.Error("error: the log doesn't contain changes")
+	if !logs.Contains(regexp.MustCompile(`Watching files \[/var/run/configmaps/trusted-ca/tls-ca-bundle\.pem /etc/secrets/tls\.crt /etc/secrets/tls\.key\]`)) {
+		t.Error("error: the log doesn't contain correct watch files")
 	}
-	if badlogs {
-		framework.DumpPodLogs(t, logs)
+	if !logs.Contains(regexp.MustCompile(`object changed`)) {
+		t.Error("error: the log doesn't contain changes")
 	}
 }


### PR DESCRIPTION
In 4.6 we've lost entrypoint script. This PR restores it and adds tests to avoid future regressions.