### PR TITLE
Bug 1894677: Reduce default log level for pruner

### DIFF
--- a/pkg/resource/prunercronjob.go
+++ b/pkg/resource/prunercronjob.go
@@ -239,7 +239,17 @@ func (gcj *generatorPrunerCronJob) getKeepYoungerThan(cr *imageregistryapiv1.Ima
 }
 
 func (gcj *generatorPrunerCronJob) getLogLevel(cr *imageregistryapiv1.ImagePruner) int {
-	return loglevel.LogLevelToVerbosity(cr.Spec.LogLevel)
+	level := loglevel.LogLevelToVerbosity(cr.Spec.LogLevel)
+	if level == 2 {
+		// The Normal log level is 2, but it causes `oc` to print stack traces
+		// for all goroutines in case of an error. It makes termination
+		// messages meaningless as they contain only few last lines of the log.
+		// The default value for `oc` is 0 (i.e. commands are usually run
+		// without -v), but let's pick a value closer to 2 that doesn't cause
+		// problems.
+		return 1
+	}
+	return level
 }
 
 func (gcj *generatorPrunerCronJob) Get() (runtime.Object, error) {

--- a/pkg/resource/prunercronjob_test.go
+++ b/pkg/resource/prunercronjob_test.go
@@ -71,7 +71,7 @@ func TestLogLevel(t *testing.T) {
 			imagePruner: &imageregistryv1.ImagePruner{
 				Spec: imageregistryv1.ImagePrunerSpec{},
 			},
-			want: 2,
+			want: 1,
 		},
 		{
 			imagePruner: &imageregistryv1.ImagePruner{


### PR DESCRIPTION
Log level 2 causes `oc adm prune images` to print stack traces for goroutines in case of an error. This makes the last chunk of logs meaningless, but only this chunk is available in the termination message.