### PR TITLE
CORS-1584: support custom CA bundle for AWS API

### DIFF
--- a/pkg/client/fake/fixtures.go
+++ b/pkg/client/fake/fixtures.go
@@ -207,19 +207,20 @@ func (f *FixturesBuilder) Build() *Fixtures {
 // BuildListers creates an in-memory instance of client.Listers
 func (f *FixturesBuilder) BuildListers() *client.Listers {
 	listers := &client.Listers{
-		Deployments:         appsv1listers.NewDeploymentLister(f.deploymentIndexer).Deployments("openshift-image-registry"),
-		Services:            corev1listers.NewServiceLister(f.servicesIndexer).Services("openshift-image-registry"),
-		Secrets:             corev1listers.NewSecretLister(f.secretsIndexer).Secrets("openshift-image-registry"),
-		ConfigMaps:          corev1listers.NewConfigMapLister(f.configMapsIndexer).ConfigMaps("openshift-image-registry"),
-		ServiceAccounts:     corev1listers.NewServiceAccountLister(f.serviceAcctIndexer).ServiceAccounts("openshift-image-registry"),
-		Routes:              routev1listers.NewRouteLister(f.routesIndexer).Routes("openshift-image-registry"),
-		ClusterRoles:        rbacv1listers.NewClusterRoleLister(f.clusterRolesIndexer),
-		ClusterRoleBindings: rbacv1listers.NewClusterRoleBindingLister(f.clusterRoleBindingsIndexer),
-		OpenShiftConfig:     corev1listers.NewConfigMapLister(f.configMapsIndexer).ConfigMaps("openshift-config"),
-		RegistryConfigs:     regopv1listers.NewConfigLister(f.registryConfigsIndexer),
-		InstallerConfigMaps: corev1listers.NewConfigMapLister(f.configMapsIndexer).ConfigMaps("kube-system"),
-		ProxyConfigs:        configv1listers.NewProxyLister(f.proxyConfigsIndexer),
-		Infrastructures:     configv1listers.NewInfrastructureLister(f.infraIndexer),
+		Deployments:            appsv1listers.NewDeploymentLister(f.deploymentIndexer).Deployments("openshift-image-registry"),
+		Services:               corev1listers.NewServiceLister(f.servicesIndexer).Services("openshift-image-registry"),
+		Secrets:                corev1listers.NewSecretLister(f.secretsIndexer).Secrets("openshift-image-registry"),
+		ConfigMaps:             corev1listers.NewConfigMapLister(f.configMapsIndexer).ConfigMaps("openshift-image-registry"),
+		ServiceAccounts:        corev1listers.NewServiceAccountLister(f.serviceAcctIndexer).ServiceAccounts("openshift-image-registry"),
+		Routes:                 routev1listers.NewRouteLister(f.routesIndexer).Routes("openshift-image-registry"),
+		ClusterRoles:           rbacv1listers.NewClusterRoleLister(f.clusterRolesIndexer),
+		ClusterRoleBindings:    rbacv1listers.NewClusterRoleBindingLister(f.clusterRoleBindingsIndexer),
+		OpenShiftConfig:        corev1listers.NewConfigMapLister(f.configMapsIndexer).ConfigMaps("openshift-config"),
+		OpenShiftConfigManaged: corev1listers.NewConfigMapLister(f.configMapsIndexer).ConfigMaps("openshift-config-managed"),
+		RegistryConfigs:        regopv1listers.NewConfigLister(f.registryConfigsIndexer),
+		InstallerConfigMaps:    corev1listers.NewConfigMapLister(f.configMapsIndexer).ConfigMaps("kube-system"),
+		ProxyConfigs:           configv1listers.NewProxyLister(f.proxyConfigsIndexer),
+		Infrastructures:        configv1listers.NewInfrastructureLister(f.infraIndexer),
 	}
 	return listers
 }

--- a/pkg/client/listers.go
+++ b/pkg/client/listers.go
@@ -13,19 +13,20 @@ import (
 )
 
 type Listers struct {
-	Deployments         kappslisters.DeploymentNamespaceLister
-	Services            kcorelisters.ServiceNamespaceLister
-	Secrets             kcorelisters.SecretNamespaceLister
-	ConfigMaps          kcorelisters.ConfigMapNamespaceLister
-	ServiceAccounts     kcorelisters.ServiceAccountNamespaceLister
-	Routes              routelisters.RouteNamespaceLister
-	ClusterRoles        krbaclisters.ClusterRoleLister
-	ClusterRoleBindings krbaclisters.ClusterRoleBindingLister
-	OpenShiftConfig     kcorelisters.ConfigMapNamespaceLister
-	RegistryConfigs     regoplisters.ConfigLister
-	InstallerConfigMaps kcorelisters.ConfigMapNamespaceLister
-	ProxyConfigs        configlisters.ProxyLister
-	Infrastructures     configlisters.InfrastructureLister
+	Deployments            kappslisters.DeploymentNamespaceLister
+	Services               kcorelisters.ServiceNamespaceLister
+	Secrets                kcorelisters.SecretNamespaceLister
+	ConfigMaps             kcorelisters.ConfigMapNamespaceLister
+	ServiceAccounts        kcorelisters.ServiceAccountNamespaceLister
+	Routes                 routelisters.RouteNamespaceLister
+	ClusterRoles           krbaclisters.ClusterRoleLister
+	ClusterRoleBindings    krbaclisters.ClusterRoleBindingLister
+	OpenShiftConfig        kcorelisters.ConfigMapNamespaceLister
+	OpenShiftConfigManaged kcorelisters.ConfigMapNamespaceLister
+	RegistryConfigs        regoplisters.ConfigLister
+	InstallerConfigMaps    kcorelisters.ConfigMapNamespaceLister
+	ProxyConfigs           configlisters.ProxyLister
+	Infrastructures        configlisters.InfrastructureLister
 }
 
 type ImagePrunerControllerListers struct {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -106,6 +106,15 @@ const (
 
 	// OpenShiftConfigNamespace is a namespace with global configuration resources.
 	OpenShiftConfigNamespace = "openshift-config"
+
+	// OpenShiftConfigManagedNamespace is a namespace with managed global configuration resources.
+	OpenShiftConfigManagedNamespace = "openshift-config-managed"
+
+	// KubeCloudConfigName is the name of the ConfigMap containing the kube cloud config.
+	KubeCloudConfigName = "kube-cloud-config"
+
+	// CloudCABundleKey is the name of the CA bundle to use when interacting with the cloud API.
+	CloudCABundleKey = "ca-bundle.pem"
 )
 
 var (

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -70,6 +70,7 @@ func NewController(
 	routeClient routeclient.Interface,
 	kubeInformerFactory kubeinformers.SharedInformerFactory,
 	openshiftConfigKubeInformerFactory kubeinformers.SharedInformerFactory,
+	openshiftConfigManagedKubeInformerFactory kubeinformers.SharedInformerFactory,
 	kubeSystemKubeInformerFactory kubeinformers.SharedInformerFactory,
 	configInformerFactory configinformers.SharedInformerFactory,
 	regopInformerFactory imageregistryinformers.SharedInformerFactory,
@@ -141,6 +142,11 @@ func NewController(
 		func() cache.SharedIndexInformer {
 			informer := openshiftConfigKubeInformerFactory.Core().V1().ConfigMaps()
 			c.listers.OpenShiftConfig = informer.Lister().ConfigMaps(defaults.OpenShiftConfigNamespace)
+			return informer.Informer()
+		},
+		func() cache.SharedIndexInformer {
+			informer := openshiftConfigManagedKubeInformerFactory.Core().V1().ConfigMaps()
+			c.listers.OpenShiftConfigManaged = informer.Lister().ConfigMaps(defaults.OpenShiftConfigManagedNamespace)
 			return informer.Informer()
 		},
 		func() cache.SharedIndexInformer {

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -41,6 +41,7 @@ func RunOperator(ctx context.Context, kubeconfig *restclient.Config) error {
 
 	kubeInformers := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, defaultResyncDuration, kubeinformers.WithNamespace(defaults.ImageRegistryOperatorNamespace))
 	kubeInformersForOpenShiftConfig := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, defaultResyncDuration, kubeinformers.WithNamespace(defaults.OpenShiftConfigNamespace))
+	kubeInformersForOpenShiftConfigManaged := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, defaultResyncDuration, kubeinformers.WithNamespace(defaults.OpenShiftConfigManagedNamespace))
 	kubeInformersForKubeSystem := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, defaultResyncDuration, kubeinformers.WithNamespace(kubeSystemNamespace))
 	configInformers := configinformers.NewSharedInformerFactory(configClient, defaultResyncDuration)
 	imageregistryInformers := imageregistryinformers.NewSharedInformerFactory(imageregistryClient, defaultResyncDuration)
@@ -59,6 +60,7 @@ func RunOperator(ctx context.Context, kubeconfig *restclient.Config) error {
 		routeClient,
 		kubeInformers,
 		kubeInformersForOpenShiftConfig,
+		kubeInformersForOpenShiftConfigManaged,
 		kubeInformersForKubeSystem,
 		configInformers,
 		imageregistryInformers,
@@ -119,6 +121,7 @@ func RunOperator(ctx context.Context, kubeconfig *restclient.Config) error {
 
 	kubeInformers.Start(ctx.Done())
 	kubeInformersForOpenShiftConfig.Start(ctx.Done())
+	kubeInformersForOpenShiftConfigManaged.Start(ctx.Done())
 	kubeInformersForKubeSystem.Start(ctx.Done())
 	configInformers.Start(ctx.Done())
 	imageregistryInformers.Start(ctx.Done())

--- a/test/framework/mock/listers/listers.go
+++ b/test/framework/mock/listers/listers.go
@@ -37,6 +37,7 @@ func (m *mockLister) GetListers() (*regopclient.Listers, error) {
 	m.listers.Secrets = MockSecretNamespaceLister{namespace: defaults.ImageRegistryOperatorNamespace, client: coreClient}
 	m.listers.InstallerConfigMaps = MockConfigMapNamespaceLister{namespace: installerConfigNamespace, client: coreClient}
 	m.listers.Infrastructures = MockInfrastructureLister{client: *configClient}
+	m.listers.OpenShiftConfigManaged = MockConfigMapNamespaceLister{namespace: defaults.OpenShiftConfigManagedNamespace, client: coreClient}
 
 	return &m.listers, err
 }


### PR DESCRIPTION
When a cluster is installed in a AWS C2S region, access to the AWS API requires a custom CA bundle for trust. The custom CA bundle is read from the "ca-bundle.pem" key of the kube-cloud-config ConfigMap in the openshift-config-managed namespace.

https://issues.redhat.com/browse/CORS-1584