### PR TITLE
Bug 1921909: build and use AWS config file for operator and operand

### DIFF
--- a/manifests/01-registry-credentials-request.yaml
+++ b/manifests/01-registry-credentials-request.yaml
@@ -31,10 +31,10 @@ spec:
       - s3:GetLifecycleConfiguration
       - s3:GetBucketLocation
       - s3:ListBucket
-      - s3:HeadBucket
       - s3:GetObject
       - s3:PutObject
       - s3:DeleteObject
       - s3:ListBucketMultipartUploads
       - s3:AbortMultipartUpload
+      - s3:ListMultipartUploadParts
       resource: "*"

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -69,6 +69,9 @@ spec:
               mountPath: /var/run/configmaps/trusted-ca/
             - name: image-registry-operator-tls
               mountPath: /etc/secrets
+            - name: bound-sa-token
+              mountPath: /var/run/secrets/openshift/serviceaccount
+              readOnly: true
       volumes:
         - name: image-registry-operator-tls
           secret:
@@ -80,3 +83,12 @@ spec:
             items:
             - key: ca-bundle.crt
               path: tls-ca-bundle.pem
+        # This service account token can be used to provide identity outside the cluster.
+        # For example, this token can be used with AssumeRoleWithWebIdentity to authenticate
+        # with AWS using an IAM OIDC provider and STS.
+        - name: bound-sa-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                path: token
+                audience: openshift

--- a/pkg/resource/deployment_test.go
+++ b/pkg/resource/deployment_test.go
@@ -1,0 +1,239 @@
+package resource
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	appsapi "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	kubeinformers "k8s.io/client-go/informers"
+	kubeclient "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+	fakeconfig "github.com/openshift/client-go/config/clientset/versioned/fake"
+	configinformers "github.com/openshift/client-go/config/informers/externalversions"
+
+	"github.com/openshift/cluster-image-registry-operator/pkg/defaults"
+	"github.com/openshift/cluster-image-registry-operator/pkg/envvar"
+)
+
+func TestChecksum(t *testing.T) {
+	tests := []struct {
+		name          string
+		origSecret    *corev1.Secret
+		updatedSecret *corev1.Secret
+		validate      func(*testing.T, string, *appsapi.Deployment)
+	}{
+		{
+			name: "no secret changes",
+			origSecret: testSecret(map[string][]byte{
+				"credentials": []byte("orig creds"),
+			}),
+			validate: func(t *testing.T, origHash string, dep *appsapi.Deployment) {
+				currentHash := dep.Annotations[defaults.ChecksumOperatorAnnotation]
+				if origHash != currentHash {
+					t.Errorf("Has unexpectedly changed from %s to %s", origHash, currentHash)
+				}
+			},
+		},
+		{
+			name: "secret changes",
+			origSecret: testSecret(map[string][]byte{
+				"credentials": []byte("orig creds"),
+			}),
+			updatedSecret: testSecret(map[string][]byte{
+				"credentials": []byte("updated creds"),
+			}),
+			validate: func(t *testing.T, origHash string, dep *appsapi.Deployment) {
+				currentHash := dep.Annotations[defaults.ChecksumOperatorAnnotation]
+				if origHash == currentHash {
+					t.Errorf("Hash unexpectedly didn't change from %s", origHash)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			kubeClient := fake.NewSimpleClientset(test.origSecret)
+			kubeInformer := kubeinformers.NewSharedInformerFactory(kubeClient, 0)
+
+			configClient := fakeconfig.NewSimpleClientset()
+			configInformer := configinformers.NewSharedInformerFactory(configClient, 0)
+
+			cmLister := kubeInformer.Core().V1().ConfigMaps().Lister().ConfigMaps(defaults.ImageRegistryOperatorNamespace)
+			secretLister := kubeInformer.Core().V1().Secrets().Lister().Secrets(defaults.ImageRegistryOperatorNamespace)
+
+			proxyLister := configInformer.Config().V1().Proxies().Lister()
+
+			kubeInformer.Start(ctx.Done())
+			configInformer.Start(ctx.Done())
+
+			_, err := kubeClient.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: defaults.ImageRegistryOperatorNamespace,
+					Annotations: map[string]string{
+						defaults.SupplementalGroupsAnnotation: "1/2",
+					},
+				},
+			}, metav1.CreateOptions{})
+			if err != nil {
+				t.Errorf("failed to create namespace for test: %s", err)
+				t.FailNow()
+			}
+
+			_, err = kubeClient.CoreV1().ConfigMaps(defaults.ImageRegistryOperatorNamespace).Create(context.TODO(), &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      defaults.ImageRegistryCertificatesName,
+					Namespace: defaults.ImageRegistryOperatorNamespace,
+				},
+			}, metav1.CreateOptions{})
+			if err != nil {
+				t.Errorf("unable to create ConfigMap %s: %s", defaults.ImageRegistryCertificatesName, err)
+				t.FailNow()
+			}
+
+			driver := &testDriver{}
+
+			gd := &generatorDeployment{
+				driver:          driver,
+				coreClient:      kubeClient.CoreV1(),
+				proxyLister:     proxyLister,
+				cr:              &imageregistryv1.Config{},
+				configMapLister: cmLister,
+				secretLister:    secretLister,
+			}
+
+			cache.WaitForCacheSync(ctx.Done(), kubeInformer.Core().V1().ConfigMaps().Informer().HasSynced)
+			cache.WaitForCacheSync(ctx.Done(), kubeInformer.Core().V1().Secrets().Informer().HasSynced)
+
+			// Generate a base deployment
+			obj, err := gd.expected()
+			if err != nil {
+				t.Errorf("unexpected error: %s", err)
+				t.FailNow()
+			}
+
+			generatedDeployment, ok := obj.(*appsapi.Deployment)
+			if !ok {
+				t.Errorf("failed to convert to Deployment")
+				t.FailNow()
+			}
+
+			origHash := generatedDeployment.Annotations[defaults.ChecksumOperatorAnnotation]
+
+			if test.updatedSecret != nil {
+				_, err = kubeClient.CoreV1().Secrets(defaults.ImageRegistryOperatorNamespace).Update(context.TODO(), test.updatedSecret, metav1.UpdateOptions{})
+				if err != nil {
+					t.Errorf("failed to update secret: %s", err)
+					t.FailNow()
+				}
+
+				cache.WaitForCacheSync(ctx.Done(), kubeInformer.Core().V1().Secrets().Informer().HasSynced)
+				// Fixme: why is this wait necessary?
+				if err := waitForUpdatedSecret(t, kubeClient, test.updatedSecret.Data); err != nil {
+					t.Errorf("failed waiting for secret update to become visible: %s", err)
+					t.FailNow()
+				}
+			}
+
+			// Check for expected changes in the deployment
+			obj, err = gd.expected()
+			if err != nil {
+				t.Errorf("unexpected error: %s", err)
+				t.FailNow()
+			}
+
+			regeneratedDeployment, ok := obj.(*appsapi.Deployment)
+			if !ok {
+				t.Errorf("failed to convert to Deployment")
+				t.FailNow()
+			}
+
+			test.validate(t, origHash, regeneratedDeployment)
+		})
+	}
+}
+
+func testSecret(sData map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: defaults.ImageRegistryOperatorNamespace,
+			Name:      defaults.ImageRegistryPrivateConfiguration,
+		},
+		Data: sData,
+	}
+}
+
+func waitForUpdatedSecret(t *testing.T, kubeClient kubeclient.Interface, expectedData map[string][]byte) error {
+	err := wait.Poll(time.Second, time.Minute, func() (stop bool, err error) {
+		sec, err := kubeClient.CoreV1().Secrets(defaults.ImageRegistryOperatorNamespace).Get(context.TODO(), defaults.ImageRegistryPrivateConfiguration, metav1.GetOptions{})
+		if err != nil {
+			// Keep waiting
+			return false, nil
+		}
+		if reflect.DeepEqual(sec.Data, expectedData) {
+			return true, nil
+		}
+		// Keep trying
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("failed to wait for the Secret to be updated: %s", err)
+	}
+	return err
+}
+
+type testDriver struct{}
+
+func (d *testDriver) ConfigEnv() (envvar.List, error) {
+	return nil, nil
+}
+
+func (d *testDriver) CreateStorage(*imageregistryv1.Config) error {
+	panic("CreateStorage not implemented")
+}
+
+func (d *testDriver) ID() string {
+	panic("ID not implemented")
+}
+
+func (d *testDriver) RemoveStorage(*imageregistryv1.Config) (bool, error) {
+	panic("RemoveStorage not implemented")
+}
+
+func (d *testDriver) StorageChanged(*imageregistryv1.Config) bool {
+	panic("StorageChanged not implemented")
+}
+
+func (d *testDriver) StorageExists(*imageregistryv1.Config) (bool, error) {
+	panic("StorageExists not implemented")
+}
+
+func (d *testDriver) VolumeSecrets() (map[string]string, error) {
+	panic("VolumeSecrets not implemented")
+}
+
+func (d *testDriver) Volumes() ([]corev1.Volume, []corev1.VolumeMount, error) {
+	volumes := []corev1.Volume{
+		{
+			Name: defaults.ImageRegistryPrivateConfiguration,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: defaults.ImageRegistryPrivateConfiguration,
+				},
+			},
+		},
+	}
+	return volumes, []corev1.VolumeMount{}, nil
+}

--- a/pkg/resource/podtemplatespec_test.go
+++ b/pkg/resource/podtemplatespec_test.go
@@ -98,6 +98,9 @@ func TestMakePodTemplateSpec(t *testing.T) {
 				},
 			},
 		},
+		"bound-sa-token": {
+			mountPath: "/var/run/secrets/openshift/serviceaccount",
+		},
 	}
 	// emptyDir adds an additional volume
 	expectedVolumes["registry-storage"] = &volumeMount{

--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -55,15 +55,19 @@ type driver struct {
 
 	// roundTripper is used only during tests.
 	roundTripper http.RoundTripper
+
+	// used during tests to insert custom credentials
+	GetCloudCredentials func(*regopclient.Listers) (string, error)
 }
 
 // NewDriver creates a new s3 storage driver
 // Used during bootstrapping
 func NewDriver(ctx context.Context, c *imageregistryv1.ImageRegistryConfigStorageS3, listers *regopclient.Listers) *driver {
 	return &driver{
-		Context: ctx,
-		Config:  c,
-		Listers: listers,
+		Context:             ctx,
+		Config:              c,
+		Listers:             listers,
+		GetCloudCredentials: getCloudCredentials,
 	}
 }
 
@@ -88,46 +92,55 @@ func (d *driver) GetConfig() (*S3, error) {
 		}
 	}
 
-	// Create the AWS shared credentials file
-	var sharedCredsFile string
-
-	// Look for a user defined secret to get the AWS credentials from first
-	sec, err := d.Listers.Secrets.Get(defaults.ImageRegistryPrivateConfigurationUser)
-	if err != nil && errors.IsNotFound(err) {
-		// Fall back to those provided by the credential minter if nothing is provided by the user
-		sec, err = d.Listers.Secrets.Get(defaults.CloudCredentialsName)
-		if err != nil {
-			return nil, fmt.Errorf("unable to get cluster minted credentials %q: %v", fmt.Sprintf("%s/%s", defaults.ImageRegistryOperatorNamespace, defaults.CloudCredentialsName), err)
-		}
-
-		sharedCredsFile, err = sharedCredentialsFileFromSecret(sec)
-		if err != nil {
-			return nil, fmt.Errorf("failed to save shared secrets file: %v", err)
-		}
-	} else if err != nil {
+	sharedCredsFile, err := d.GetCloudCredentials(d.Listers)
+	if err != nil {
 		return nil, err
-	} else {
-		var accessKey, secretKey string
-		if v, ok := sec.Data["REGISTRY_STORAGE_S3_ACCESSKEY"]; ok {
-			accessKey = string(v)
-		} else {
-			return nil, fmt.Errorf("secret %q does not contain required key \"REGISTRY_STORAGE_S3_ACCESSKEY\"", fmt.Sprintf("%s/%s", defaults.ImageRegistryOperatorNamespace, defaults.ImageRegistryPrivateConfigurationUser))
-		}
-		if v, ok := sec.Data["REGISTRY_STORAGE_S3_SECRETKEY"]; ok {
-			secretKey = string(v)
-		} else {
-			return nil, fmt.Errorf("secret %q does not contain required key \"REGISTRY_STORAGE_S3_SECRETKEY\"", fmt.Sprintf("%s/%s", defaults.ImageRegistryOperatorNamespace, defaults.ImageRegistryPrivateConfigurationUser))
-		}
-
-		sharedCredsFile, err = sharedCredentialsFileFromStaticCreds(accessKey, secretKey)
-		if err != nil {
-			return nil, fmt.Errorf("failed to save shared secrets file: %v", err)
-		}
 	}
 
 	cfg.SharedCredentialsFile = sharedCredsFile
 
 	return cfg, nil
+}
+
+// getCloudCredentials will return a file containing an AWS credentials configuration
+func getCloudCredentials(listers *regopclient.Listers) (string, error) {
+	var sharedCredsFile string
+
+	// Look for a user defined secret to get the AWS credentials from first
+	sec, err := listers.Secrets.Get(defaults.ImageRegistryPrivateConfigurationUser)
+	if err != nil && errors.IsNotFound(err) {
+		// Fall back to those provided by the credential minter if nothing is provided by the user
+		sec, err = listers.Secrets.Get(defaults.CloudCredentialsName)
+		if err != nil {
+			return "", fmt.Errorf("unable to get cluster minted credentials %q: %v", fmt.Sprintf("%s/%s", defaults.ImageRegistryOperatorNamespace, defaults.CloudCredentialsName), err)
+		}
+
+		sharedCredsFile, err = sharedCredentialsFileFromSecret(sec)
+		if err != nil {
+			return "", fmt.Errorf("failed to save shared secrets file: %v", err)
+		}
+	} else if err != nil {
+		return "", err
+	} else {
+		var accessKey, secretKey string
+		if v, ok := sec.Data["REGISTRY_STORAGE_S3_ACCESSKEY"]; ok {
+			accessKey = string(v)
+		} else {
+			return "", fmt.Errorf("secret %q does not contain required key \"REGISTRY_STORAGE_S3_ACCESSKEY\"", fmt.Sprintf("%s/%s", defaults.ImageRegistryOperatorNamespace, defaults.ImageRegistryPrivateConfigurationUser))
+		}
+		if v, ok := sec.Data["REGISTRY_STORAGE_S3_SECRETKEY"]; ok {
+			secretKey = string(v)
+		} else {
+			return "", fmt.Errorf("secret %q does not contain required key \"REGISTRY_STORAGE_S3_SECRETKEY\"", fmt.Sprintf("%s/%s", defaults.ImageRegistryOperatorNamespace, defaults.ImageRegistryPrivateConfigurationUser))
+		}
+
+		sharedCredsFile, err = sharedCredentialsFileFromStaticCreds(accessKey, secretKey)
+		if err != nil {
+			return "", fmt.Errorf("failed to save shared secrets file: %v", err)
+		}
+	}
+
+	return sharedCredsFile, nil
 }
 
 // updateConfigAndGetCredentialsLocation will return the location of an AWS

--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -89,7 +89,7 @@ func (d *driver) UpdateEffectiveConfig() (*imageregistryv1.ImageRegistryConfigSt
 	}
 
 	// Use cluster defaults when custom config doesn't define values
-	if d.Config == nil || len(effectiveConfig.Region) == 0 {
+	if d.Config == nil || (len(effectiveConfig.Region) == 0 && len(effectiveConfig.RegionEndpoint) == 0) {
 		effectiveConfig.Region = clusterRegion
 		effectiveConfig.RegionEndpoint = clusterRegionEndpoint
 		if len(effectiveConfig.RegionEndpoint) != 0 {

--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -787,13 +787,9 @@ func sharedCredentialsDataFromSecret(secret *corev1.Secret) ([]byte, error) {
 
 func sharedCredentialsDataFromStaticCreds(accessKey, accessSecret string) []byte {
 	buf := &bytes.Buffer{}
-	// fmt.Fprint(buf, "[default]\n")
-	// fmt.Fprintf(buf, "aws_access_key_id = %s\n", accessKey)
-	// fmt.Fprintf(buf, "aws_secret_access_key = %s\n", accessSecret)
-	fmt.Fprintf(buf, `[default]
-aws_access_key_id = %s
-aws_secret_access_key = %s`, accessKey, accessSecret)
-	data := buf.Bytes()
+	fmt.Fprint(buf, "[default]\n")
+	fmt.Fprintf(buf, "aws_access_key_id = %s\n", accessKey)
+	fmt.Fprintf(buf, "aws_secret_access_key = %s\n", accessSecret)
 
-	return data
+	return buf.Bytes()
 }

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -696,6 +696,15 @@ func TestAWSFinalizerDeleteS3Bucket(t *testing.T) {
 	if err != nil {
 		t.Errorf("unable to get custom resource %s/%s: %#v", defaults.ImageRegistryOperatorNamespace, defaults.ImageRegistryResourceName, err)
 	}
+
+	// Save the credentials so we can verify that the S3 bucket was deleted later
+	imageRegistryPrivateConfiguration, err := te.Client().Secrets(defaults.ImageRegistryOperatorNamespace).Get(
+		context.Background(), defaults.ImageRegistryPrivateConfiguration, metav1.GetOptions{},
+	)
+	if err != nil {
+		t.Errorf("unable to get secret %s/%s: %#v", defaults.ImageRegistryOperatorNamespace, defaults.ImageRegistryPrivateConfiguration, err)
+	}
+
 	// Check that the S3 bucket gets cleaned up by the finalizer (if we manage it)
 	err = te.Client().Configs().Delete(
 		context.Background(), defaults.ImageRegistryResourceName, metav1.DeleteOptions{},
@@ -705,13 +714,6 @@ func TestAWSFinalizerDeleteS3Bucket(t *testing.T) {
 	}
 
 	// Create an AWS config using the in-cluster credentials so that we can watch the S3 bucket
-	imageRegistryPrivateConfiguration, err := te.Client().Secrets(defaults.ImageRegistryOperatorNamespace).Get(
-		context.Background(), defaults.ImageRegistryPrivateConfiguration, metav1.GetOptions{},
-	)
-	if err != nil {
-		t.Errorf("unable to get secret %s/%s: %#v", defaults.ImageRegistryOperatorNamespace, defaults.ImageRegistryPrivateConfiguration, err)
-	}
-
 	awsConfigTempFile, awsCleanupFunc, err := createAWSConfigFile(imageRegistryPrivateConfiguration, te.Client())
 	if err != nil {
 		t.Fatalf("failed to setup AWS client config file: %s", err)


### PR DESCRIPTION
In order to support alternative AWS authentication mechanisms beyond just access/secret key authentication:

- [x] Update the operator Deployment to mount in the projected ServiceAccount token (to a default-by-convention location of /var/run/secrets/openshift/serviceaccount).
- [x] Update the AWS S3 driver to respect the new CredentialsRequest Secret field ('credentials'), but keep supporting the old-style format.
- [x] Build and use an AWS config file when creating the AWS S3 client (whether new-style or old-style Secret data).
- [x] Store the AWS credentials config in the image-registry's image-registry-private-configuration Secret.
- [x] Mount the image-registry-private-configuration Secret into the image-registry Deployment PodSpec so that the image-registry can start consuming creds from the Secret instead of only using access/secret key data (requires separate code changes to image-registry).
- [x] Update the image-registry environment variables so that the operator sets the location of the fully-formed credentials file.
- [x] Modify the PodTemplate to always mount in the ServiceAccount projected volume (to a default-by-convention location of /var/run/secrets/openshift/serviceaccount).

With these changes (and the corresponding image-registry support), it should now be possible to use web identity token authentication. This requires:
- setting up an AWS OpenID identity provider that trusts the cluster's OIDC provider
- creating an AWS IAM Role with the permissions requested in this repo's CredentialsRequest
- granting both ServiceAccounts 'registry' and 'cluster-image-registry-operator' to be allowed to assume the AWS IAM Role
- setting up the Secret holding the AWS credentials (installer-cloud-credentials) so that the 'credentials' field contains a working AWS configuration:
```
[default]
role_arn = arn:aws:iam:ACCOUNT_NUM:role/ROLE_NAME
web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
```

There is still an open question about if/when we move to temporary credentials by default, how the e2e tests should work. They presently re-use the credentials found in the cluster, but when using web identity authentication, it is the Pod that is granted permissions and there are no credentials that can just be grabbed for the various e2e tests.

This is related to https://issues.redhat.com/browse/CO-1255