### PR TITLE
Annotate manifests for single-node-developer cluster profile

### DIFF
--- a/manifests/0000_90_cluster-image-registry-operator_00_servicemonitor-rbac.yaml
+++ b/manifests/0000_90_cluster-image-registry-operator_00_servicemonitor-rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 - apiGroups:
   - image.openshift.io
@@ -21,6 +22,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 subjects:
 - kind: ServiceAccount
   name: prometheus-k8s
@@ -39,6 +41,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 - apiGroups:
   - ""
@@ -59,6 +62,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/manifests/0000_90_cluster-image-registry-operator_01_operand-servicemonitor.yaml
+++ b/manifests/0000_90_cluster-image-registry-operator_01_operand-servicemonitor.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/manifests/0000_90_cluster-image-registry-operator_02_operator-servicemonitor.yaml
+++ b/manifests/0000_90_cluster-image-registry-operator_02_operator-servicemonitor.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   endpoints:
   - targetPort: 60000

--- a/manifests/01-namespace.yaml
+++ b/manifests/01-namespace.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     openshift.io/cluster-monitoring: "true"
 spec:

--- a/manifests/01-registry-credentials-request-azure.yaml
+++ b/manifests/01-registry-credentials-request-azure.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   secretRef:
     name: installer-cloud-credentials

--- a/manifests/01-registry-credentials-request-gcs.yaml
+++ b/manifests/01-registry-credentials-request-gcs.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   secretRef:
     name: installer-cloud-credentials

--- a/manifests/01-registry-credentials-request-openstack.yaml
+++ b/manifests/01-registry-credentials-request-openstack.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   secretRef:
     name: installer-cloud-credentials

--- a/manifests/01-registry-credentials-request.yaml
+++ b/manifests/01-registry-credentials-request.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   secretRef:
     name: installer-cloud-credentials

--- a/manifests/02-rbac.yaml
+++ b/manifests/02-rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 - apiGroups:
   - imageregistry.operator.openshift.io
@@ -126,6 +127,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 subjects:
 - kind: ServiceAccount
   name: cluster-image-registry-operator

--- a/manifests/03-sa.yaml
+++ b/manifests/03-sa.yaml
@@ -7,3 +7,4 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"

--- a/manifests/04-ca-trusted.yaml
+++ b/manifests/04-ca-trusted.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     config.openshift.io/inject-trusted-cabundle: "true"
   name: trusted-ca

--- a/manifests/05-ca-rbac.yaml
+++ b/manifests/05-ca-rbac.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 - apiGroups:
   - security.openshift.io
@@ -25,6 +26,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 subjects:
 - kind: ServiceAccount
   name: node-ca

--- a/manifests/06-ca-serviceaccount.yaml
+++ b/manifests/06-ca-serviceaccount.yaml
@@ -7,3 +7,4 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"

--- a/manifests/07-operator-service.yaml
+++ b/manifests/07-operator-service.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     service.alpha.openshift.io/serving-cert-secret-name: image-registry-operator-tls
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     name: image-registry-operator
   name: image-registry-operator

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -8,6 +8,7 @@ metadata:
     config.openshift.io/inject-proxy: cluster-image-registry-operator
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   replicas: 1
   selector:

--- a/manifests/08-clusteroperator.yaml
+++ b/manifests/08-clusteroperator.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec: {}
 status:
   versions:

--- a/manifests/09-prometheus-rules.yaml
+++ b/manifests/09-prometheus-rules.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   groups:
   - name: ImageRegistryOperator


### PR DESCRIPTION
This partially implements phase 1 of openshift/enhancements#482
and does not change behavior. Initially, all cluster-image-registry-operator
manifests are included in the single-node-developer cluster profile.
Follow-on PRs may exclude any of these that are not needed in the
profile.