### PR TITLE
add 'single-node-production-edge' annotations to CVO manifests.

### DIFF
--- a/manifests/0000_90_cluster-image-registry-operator_00_servicemonitor-rbac.yaml
+++ b/manifests/0000_90_cluster-image-registry-operator_00_servicemonitor-rbac.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - image.openshift.io
@@ -23,6 +24,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 subjects:
 - kind: ServiceAccount
   name: prometheus-k8s
@@ -42,6 +44,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - ""
@@ -63,6 +66,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/manifests/0000_90_cluster-image-registry-operator_01_operand-servicemonitor.yaml
+++ b/manifests/0000_90_cluster-image-registry-operator_01_operand-servicemonitor.yaml
@@ -8,6 +8,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/manifests/0000_90_cluster-image-registry-operator_02_operator-servicemonitor.yaml
+++ b/manifests/0000_90_cluster-image-registry-operator_02_operator-servicemonitor.yaml
@@ -8,6 +8,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   endpoints:
   - targetPort: 60000

--- a/manifests/01-namespace.yaml
+++ b/manifests/01-namespace.yaml
@@ -8,6 +8,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     openshift.io/cluster-monitoring: "true"
 spec:

--- a/manifests/01-registry-credentials-request-azure.yaml
+++ b/manifests/01-registry-credentials-request-azure.yaml
@@ -9,6 +9,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   secretRef:
     name: installer-cloud-credentials

--- a/manifests/01-registry-credentials-request-gcs.yaml
+++ b/manifests/01-registry-credentials-request-gcs.yaml
@@ -9,6 +9,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   secretRef:
     name: installer-cloud-credentials

--- a/manifests/01-registry-credentials-request-openstack.yaml
+++ b/manifests/01-registry-credentials-request-openstack.yaml
@@ -9,6 +9,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   secretRef:
     name: installer-cloud-credentials

--- a/manifests/01-registry-credentials-request.yaml
+++ b/manifests/01-registry-credentials-request.yaml
@@ -9,6 +9,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   secretRef:
     name: installer-cloud-credentials

--- a/manifests/02-rbac.yaml
+++ b/manifests/02-rbac.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - imageregistry.operator.openshift.io
@@ -128,6 +129,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 subjects:
 - kind: ServiceAccount
   name: cluster-image-registry-operator

--- a/manifests/03-sa.yaml
+++ b/manifests/03-sa.yaml
@@ -8,3 +8,4 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"

--- a/manifests/04-ca-trusted.yaml
+++ b/manifests/04-ca-trusted.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     config.openshift.io/inject-trusted-cabundle: "true"
   name: trusted-ca

--- a/manifests/05-ca-rbac.yaml
+++ b/manifests/05-ca-rbac.yaml
@@ -8,6 +8,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - security.openshift.io
@@ -27,6 +28,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 subjects:
 - kind: ServiceAccount
   name: node-ca

--- a/manifests/06-ca-serviceaccount.yaml
+++ b/manifests/06-ca-serviceaccount.yaml
@@ -8,3 +8,4 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"

--- a/manifests/07-operator-service.yaml
+++ b/manifests/07-operator-service.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     service.alpha.openshift.io/serving-cert-secret-name: image-registry-operator-tls
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     name: image-registry-operator
   name: image-registry-operator

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -9,6 +9,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   replicas: 1
   selector:

--- a/manifests/08-clusteroperator.yaml
+++ b/manifests/08-clusteroperator.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec: {}
 status:
   versions:

--- a/manifests/09-prometheus-rules.yaml
+++ b/manifests/09-prometheus-rules.yaml
@@ -9,6 +9,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   groups:
   - name: ImageRegistryOperator


### PR DESCRIPTION
This adds annotations for the single-node-production-edge cluster profile. There's a growing requirement from several customers to enable creation of single-node (not high-available) Openshift clusters.
In stage one (following openshift/enhancements#504) there should be no implication on components logic.
In the next stage, the component's behavior will match a non high-availability profile if the customer is specifically interested in one.
This PR is separate from the 'single-node-developer' work, which will implement a different behavior and is currently on another stage of implementation.

For more info, please refer to the enhancement link and participate in the discussion.