### PR TITLE
Bug 1902091: Using http.DefaultTransport timeouts

### DIFF
--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -3,10 +3,12 @@ package s3
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -169,6 +171,16 @@ func (d *driver) getS3Service() (*s3.S3, error) {
 					Proxy: func(req *http.Request) (*url.URL, error) {
 						return httpproxy.FromEnvironment().ProxyFunc()(req.URL)
 					},
+					DialContext: (&net.Dialer{
+						Timeout:   30 * time.Second,
+						KeepAlive: 30 * time.Second,
+						DualStack: true,
+					}).DialContext,
+					ForceAttemptHTTP2:     true,
+					MaxIdleConns:          100,
+					IdleConnTimeout:       90 * time.Second,
+					TLSHandshakeTimeout:   10 * time.Second,
+					ExpectContinueTimeout: 1 * time.Second,
 				},
 			},
 		},


### PR DESCRIPTION
Using the very same timeouts present on http.DefaultTransport into our
custom http client Transport.