### PR TITLE
Bug 1915041: add ListMultipartUploadParts permission

### DIFF
--- a/manifests/01-registry-credentials-request.yaml
+++ b/manifests/01-registry-credentials-request.yaml
@@ -37,4 +37,5 @@ spec:
       - s3:DeleteObject
       - s3:ListBucketMultipartUploads
       - s3:AbortMultipartUpload
+      - s3:ListMultipartUploadParts
       resource: "*"


### PR DESCRIPTION
s3:ListMultipartUploadParts is needed to be able to check on status of uploads. The permission is implied when the IAM user/credentials that created the MultiPartUploads is the same as the user/credentials trying to list them (see https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html ).

When users/credentials are rotated, there can be a disconnect between the user/creds performing the ListMultipartUploadParts and the user/creds performing the uploads.

Stop depending on the ListMultipartUploadParts permission being implicitly granted, and just explicitly list this permission as required to allow credentials rotation without a risk of losing the ability to s3:ListMultipartuploadParts.