### PR TITLE
Bug 1907202: Sync status to spec with regards to Swift config

### DIFF
--- a/pkg/storage/swift/swift.go
+++ b/pkg/storage/swift/swift.go
@@ -407,6 +407,9 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 				cr.Spec.Storage.ManagementState = imageregistryv1.StorageManagementStateUnmanaged
 			}
 			util.UpdateCondition(cr, defaults.StorageExists, operatorapi.ConditionTrue, "Container exists", "User supplied container already exists")
+			cr.Status.Storage = imageregistryv1.ImageRegistryConfigStorage{
+				Swift: d.Config.DeepCopy(),
+			}
 			break
 		}
 		// If we generated a container name and it exists

--- a/pkg/storage/swift/swift_test.go
+++ b/pkg/storage/swift/swift_test.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"reflect"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -1047,4 +1049,49 @@ func TestNoPermissionsSwauth(t *testing.T) {
 		OpenShiftConfig: MockConfigMapNamespaceLister{},
 	}
 	th.AssertEquals(t, false, IsSwiftEnabled(listers))
+}
+
+func TestConfigStatusUpdate(t *testing.T) {
+	th.SetupHTTP()
+	handleAuthentication(t, "container")
+
+	httpHandler := &handler{}
+	th.Mux.HandleFunc("/", httpHandler.request)
+	httpHandler.setResponses([]int{http.StatusOK, http.StatusOK})
+
+	drv, installConfig := mockConfig(
+		false, th.Endpoint()+"v3", MockUPISecretNamespaceLister{}, false,
+	)
+	installConfig.Spec.Storage.Swift.Container = "a-container"
+
+	err := drv.CreateStorage(&installConfig)
+	th.AssertNoErr(t, err)
+
+	spec := installConfig.Spec.Storage.Swift
+	status := installConfig.Status.Storage.Swift
+	if !reflect.DeepEqual(spec, status) {
+		t.Error("status does not reflect spec:")
+		spew.Dump(spec)
+		spew.Dump(status)
+	}
+
+	th.TeardownHTTP()
+
+	th.SetupHTTP()
+	handleAuthentication(t, "container")
+	th.Mux.HandleFunc("/", httpHandler.request)
+
+	// change the authentication url to a new endpoint
+	installConfig.Spec.Storage.Swift.AuthURL = th.Endpoint() + "v3"
+
+	err = drv.CreateStorage(&installConfig)
+	th.AssertNoErr(t, err)
+
+	spec = installConfig.Spec.Storage.Swift
+	status = installConfig.Status.Storage.Swift
+	if !reflect.DeepEqual(spec, status) {
+		t.Error("status does not reflect spec:")
+		spew.Dump(spec)
+		spew.Dump(status)
+	}
 }


### PR DESCRIPTION
This commit makes Status.Storage.Swift to reflect Spec.Storage.Swift
when the provided container already exists. Prior to this status was
only kept in sync when the container was created.