### PR TITLE
[release-4.5] Bug 1916859: Sync status to spec with regards to Swift config

### DIFF
--- a/pkg/storage/swift/swift.go
+++ b/pkg/storage/swift/swift.go
@@ -416,6 +416,9 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 		// we can skip the create
 		if !generatedName && err == nil {
 			util.UpdateCondition(cr, defaults.StorageExists, operatorapi.ConditionTrue, "Container exists", "User supplied container already exists")
+			cr.Status.Storage = imageregistryv1.ImageRegistryConfigStorage{
+				Swift: d.Config.DeepCopy(),
+			}
 			break
 		}
 		// If we generated a container name and it exists


### PR DESCRIPTION
**This is a copy of https://github.com/openshift/cluster-image-registry-operator/pull/653 test code was different, requiring some adjustments**

This commit makes Status.Storage.Swift to reflect Spec.Storage.Swift
when the provided container already exists. Prior to this status was
only kept in sync when the container was created.