### PR TITLE
Bug 1914407: Explicitly set node-ca runAsUser and runAsGroup

### DIFF
--- a/bindata/nodecadaemon.yaml
+++ b/bindata/nodecadaemon.yaml
@@ -23,6 +23,8 @@ spec:
       - name: node-ca
         securityContext:
           privileged: true
+          runAsUser: 1001
+          runAsGroup: 0
         image: docker.io/openshift/origin-cluster-image-registry-operator:latest
         resources:
           requests:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -79,6 +79,8 @@ spec:
       - name: node-ca
         securityContext:
           privileged: true
+          runAsUser: 1001
+          runAsGroup: 0
         image: docker.io/openshift/origin-cluster-image-registry-operator:latest
         resources:
           requests:


### PR DESCRIPTION
This commit adds runAsUser and runAsGroup directives to the node-ca daemonset configuration.