### PR TITLE
Mark emptyDir as not Upgradeable configuration

### DIFF
--- a/pkg/resource/clusteroperator.go
+++ b/pkg/resource/clusteroperator.go
@@ -222,6 +222,7 @@ func (gco *generatorClusterOperator) syncConditions(op *configv1.ClusterOperator
 	configv1helpers.SetStatusCondition(&op.Status.Conditions, unionCondition("Available", operatorv1.ConditionTrue, conditions))
 	configv1helpers.SetStatusCondition(&op.Status.Conditions, unionCondition("Progressing", operatorv1.ConditionFalse, conditions))
 	configv1helpers.SetStatusCondition(&op.Status.Conditions, unionCondition("Degraded", operatorv1.ConditionFalse, conditions))
+	configv1helpers.SetStatusCondition(&op.Status.Conditions, unionCondition("Upgradeable", operatorv1.ConditionTrue, conditions))
 	return !equality.Semantic.DeepEqual(oldStatus, &op.Status)
 }
 

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -83,6 +83,16 @@ func TestAWSDefaults(t *testing.T) {
 	framework.EnsureServiceCAConfigMap(te)
 	framework.EnsureNodeCADaemonSetIsAvailable(te)
 
+	framework.CheckClusterOperatorCondition(te, "image-registry", configapiv1.OperatorUpgradeable, func(cond *configapiv1.ClusterOperatorStatusCondition, found bool) error {
+		if !found {
+			return fmt.Errorf("condition is not set")
+		}
+		if cond.Status != configapiv1.ConditionTrue {
+			return fmt.Errorf("got %s, want %s", cond.Status, configapiv1.ConditionTrue)
+		}
+		return nil
+	})
+
 	s3Driver := storages3.NewDriver(context.Background(), nil, mockLister)
 	cfg, err := s3Driver.UpdateEffectiveConfig()
 	if err != nil {

--- a/test/e2e/emptydir_test.go
+++ b/test/e2e/emptydir_test.go
@@ -2,13 +2,15 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	configv1 "github.com/openshift/api/config/v1"
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
-	operatorapi "github.com/openshift/api/operator/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 
 	"github.com/openshift/cluster-image-registry-operator/pkg/defaults"
 	"github.com/openshift/cluster-image-registry-operator/test/framework"
@@ -16,7 +18,7 @@ import (
 
 func TestBasicEmptyDir(t *testing.T) {
 	te := framework.SetupAvailableImageRegistry(t, &imageregistryv1.ImageRegistrySpec{
-		ManagementState: operatorapi.Managed,
+		ManagementState: operatorv1.Managed,
 		Storage: imageregistryv1.ImageRegistryConfigStorage{
 			EmptyDir: &imageregistryv1.ImageRegistryConfigStorageEmptyDir{},
 		},
@@ -55,4 +57,14 @@ func TestBasicEmptyDir(t *testing.T) {
 	if !logs.Contains(regexp.MustCompile(`object changed`)) {
 		t.Error("error: the log doesn't contain changes")
 	}
+
+	framework.CheckClusterOperatorCondition(te, "image-registry", configv1.OperatorUpgradeable, func(cond *configv1.ClusterOperatorStatusCondition, found bool) error {
+		if !found {
+			return fmt.Errorf("condition is not set")
+		}
+		if cond.Status != configv1.ConditionFalse {
+			return fmt.Errorf("got %s, want %s", cond.Status, configv1.ConditionFalse)
+		}
+		return nil
+	})
 }


### PR DESCRIPTION
When the registry uses emptyDir, it cannot be upgraded without losing its data.