### PR TITLE
Add service account names to credentials request manifest

### DIFF
--- a/manifests/01-registry-credentials-request.yaml
+++ b/manifests/01-registry-credentials-request.yaml
@@ -38,3 +38,6 @@ spec:
       - s3:AbortMultipartUpload
       - s3:ListMultipartUploadParts
       resource: "*"
+  serviceAccountNames:
+  - cluster-image-registry-operator
+  - registry


### PR DESCRIPTION
For a new way of managing OpenShift credentials on AWS to work, using Security
Token Service, we need external tooling to know the service account names from
the Credentials Request manifest so that it can create IAM Roles that can be
assumed only by those specific service accounts.

Managing credentials using STS ref: https://github.com/openshift/cloud-credential-operator/blob/master/docs/sts.md
Tooling design ref: https://issues.redhat.com/browse/CCO-60

/cc @joelddiaz 