### PR TITLE
Bug 1929654: Creating StorageAccount V2 instead of V1

### DIFF
--- a/pkg/storage/azure/azure.go
+++ b/pkg/storage/azure/azure.go
@@ -161,7 +161,7 @@ func (d *driver) createStorageAccount(storageAccountsClient storage.AccountsClie
 		resourceGroupName,
 		accountName,
 		storage.AccountCreateParameters{
-			Kind:     storage.Storage,
+			Kind:     storage.StorageV2,
 			Location: to.StringPtr(location),
 			Sku: &storage.Sku{
 				Name: storage.StandardLRS,


### PR DESCRIPTION
Storage accounts V1 are being deprecated by Azure. This commit makes
this operator to create a V2 account instead. Registry is version
agnostic and works with both StorageAccounts V1 or V2.

CheckNameAvailability returns false if an account exists with the same
name in any of the versions, this allows cluster updates to move on.