### PR TITLE
Bug 1933180: Allow more node-ca unavailable replicas during upgrade

### DIFF
--- a/bindata/nodecadaemon.yaml
+++ b/bindata/nodecadaemon.yaml
@@ -7,6 +7,10 @@ spec:
   selector:
     matchLabels:
       name: node-ca
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
   template:
     metadata:
       labels:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -63,6 +63,10 @@ spec:
   selector:
     matchLabels:
       name: node-ca
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
   template:
     metadata:
       labels:


### PR DESCRIPTION
This PR changes maxUnavailable for the node-ca daemon set, and also adds a new Available condition for this daemon set.