### PR TITLE
Bug 1918376: Allowing system:registry to list ICSP rules

### DIFF
--- a/pkg/resource/clusterrole.go
+++ b/pkg/resource/clusterrole.go
@@ -88,6 +88,13 @@ func (gcr *generatorClusterRole) expected() (runtime.Object, error) {
 					"imagestreammappings",
 				},
 			},
+			{
+				Verbs:     []string{"list"},
+				APIGroups: []string{"operator.openshift.io"},
+				Resources: []string{
+					"imagecontentsourcepolicies",
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
Allows service account used by image-registry to access ICSP objects.