### PR TITLE
Bug 1937464: Swift: Do not modify driver config

### DIFF
--- a/pkg/storage/swift/swift_test.go
+++ b/pkg/storage/swift/swift_test.go
@@ -798,12 +798,8 @@ func TestSwiftEnsureAuthURLHasAPIVersion(t *testing.T) {
 	}
 
 	for _, config := range configListShouldPass {
-		d := driver{
-			Config: &config,
-		}
-		err := d.ensureAuthURLHasAPIVersion()
+		_, err := ensureAuthURLHasAPIVersion(config.AuthURL, config.AuthVersion)
 		th.AssertNoErr(t, err)
-		th.AssertEquals(t, config.AuthURL, d.Config.AuthURL)
 	}
 
 	configListShouldFail := []imageregistryv1.ImageRegistryConfigStorageSwift{
@@ -822,10 +818,7 @@ func TestSwiftEnsureAuthURLHasAPIVersion(t *testing.T) {
 	}
 
 	for _, config := range configListShouldFail {
-		d := driver{
-			Config: &config,
-		}
-		err := d.ensureAuthURLHasAPIVersion()
+		_, err := ensureAuthURLHasAPIVersion(config.AuthURL, config.AuthVersion)
 		th.AssertEquals(t, true, err != nil)
 	}
 }


### PR DESCRIPTION
Driver config must be used for user input only and the operator shouldn't modify it using values from clouds.yaml.

This commit ensures that driver config stays unchanged, and it's used just to update default values provided by clouds.yaml.