### PR TITLE
Add management workload annotations

### DIFF
--- a/bindata/nodecadaemon.yaml
+++ b/bindata/nodecadaemon.yaml
@@ -13,6 +13,8 @@ spec:
       maxUnavailable: 10%
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: node-ca
     spec:

--- a/manifests/01-namespace.yaml
+++ b/manifests/01-namespace.yaml
@@ -8,6 +8,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
     include.release.openshift.io/single-node-developer: "true"
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"
 spec:

--- a/manifests/07-operator-ibm-cloud-managed.yaml
+++ b/manifests/07-operator-ibm-cloud-managed.yaml
@@ -13,6 +13,8 @@ spec:
       name: cluster-image-registry-operator
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: cluster-image-registry-operator
     spec:

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -15,6 +15,8 @@ spec:
       name: cluster-image-registry-operator
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: cluster-image-registry-operator
     spec:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -69,6 +69,8 @@ spec:
       maxUnavailable: 10%
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: node-ca
     spec:

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -118,5 +118,8 @@ const (
 )
 
 var (
-	DeploymentLabels = map[string]string{"docker-registry": "default"}
+	DeploymentLabels      = map[string]string{"docker-registry": "default"}
+	DeploymentAnnotations = map[string]string{
+		"target.workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
+	}
 )

--- a/pkg/resource/podtemplatespec.go
+++ b/pkg/resource/podtemplatespec.go
@@ -400,7 +400,8 @@ func makePodTemplateSpec(coreClient coreset.CoreV1Interface, proxyLister configl
 
 	spec := corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: defaults.DeploymentLabels,
+			Labels:      defaults.DeploymentLabels,
+			Annotations: defaults.DeploymentAnnotations,
 		},
 		Spec: corev1.PodSpec{
 			Tolerations:       cr.Spec.Tolerations,


### PR DESCRIPTION
In support of the workload partitioning feature
(https://github.com/openshift/enhancements/pull/703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.