### PR TITLE
Bug 1945387: Setting required pod anti-affinity rules

### DIFF
--- a/pkg/resource/podtemplatespec.go
+++ b/pkg/resource/podtemplatespec.go
@@ -367,26 +367,45 @@ func makePodTemplateSpec(coreClient coreset.CoreV1Interface, proxyLister configl
 		resources = *cr.Spec.Resources
 	}
 
-	var affinity *corev1.Affinity
-	if cr.Spec.Affinity != nil {
-		affinity = cr.Spec.Affinity
-	} else {
+	// if user has provided an affinity through config spec we use it here, if not
+	// then we fallback to a preferred affinity configuration. we only require a
+	// certain affinity during schedule if the number of replicas is defined to two.
+	affinity := cr.Spec.Affinity
+	if affinity == nil {
 		affinity = &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
 				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
 					{
 						Weight: 100,
 						PodAffinityTerm: corev1.PodAffinityTerm{
-							//TODO godoc for this field says it cannot be empty, but the doc at
-							// https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#an-example-of-a-pod-that-uses-pod-affinity
-							// talks about using an empty topologyKey with anti-affinity as signifying "all topologies",
-							// That said, the standard kubernetes.io/hostname has appeared sufficient in testing on AWS clusters with 3 worker nodes
 							TopologyKey: "kubernetes.io/hostname",
-							Namespaces:  []string{defaults.ImageRegistryOperatorNamespace},
+							Namespaces: []string{
+								defaults.ImageRegistryOperatorNamespace,
+							},
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: defaults.DeploymentLabels,
+							},
 						},
 					},
 				},
 			},
+		}
+		if cr.Spec.Replicas == 2 {
+			affinity = &corev1.Affinity{
+				PodAntiAffinity: &corev1.PodAntiAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+						{
+							TopologyKey: "kubernetes.io/hostname",
+							Namespaces: []string{
+								defaults.ImageRegistryOperatorNamespace,
+							},
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: defaults.DeploymentLabels,
+							},
+						},
+					},
+				},
+			}
 		}
 	}
 


### PR DESCRIPTION
Instead of using Preferred we now use Required pod anti-affinity. This
way we can enforce image-registry pods to do not run on the same node
at the same time, this at a price of restricting the max number of pods
to to the total amount of worker nodes.