### PR TITLE
Bug 1955879: Setting user tags always when Storage is Managed

### DIFF
--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -474,7 +474,6 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 
 	}
 
-	bucketCreatedByOperator := false
 	if len(d.Config.Bucket) != 0 && bucketExists {
 		if cr.Spec.Storage.ManagementState == "" {
 			cr.Spec.Storage.ManagementState = imageregistryv1.StorageManagementStateUnmanaged
@@ -524,7 +523,6 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 				S3: d.Config.DeepCopy(),
 			}
 			cr.Spec.Storage.S3 = d.Config.DeepCopy()
-			bucketCreatedByOperator = true
 			util.UpdateCondition(cr, defaults.StorageExists, operatorapi.ConditionTrue, "Creation Successful", "S3 bucket was successfully created")
 
 			break
@@ -593,7 +591,7 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 		// at this stage we are not keeping user tags in sync. as per enhancement proposal
 		// we only set user provided tags when we created the bucket.
 		hasAWSStatus := infra.Status.PlatformStatus != nil && infra.Status.PlatformStatus.AWS != nil
-		if bucketCreatedByOperator && hasAWSStatus {
+		if hasAWSStatus {
 			klog.Infof("user provided %d tags", len(infra.Status.PlatformStatus.AWS.ResourceTags))
 			for _, tag := range infra.Status.PlatformStatus.AWS.ResourceTags {
 				klog.Infof("user provided bucket tag: %s: %s", tag.Key, tag.Value)


### PR DESCRIPTION
If user specifies that the storage is Managed in spec.storage we should
always set the user provided tags as we already do with our default
bucket tags.

**Note for QE**

Now whenever `spec.storage.ManagementState` is `Managed` we set the
tags on the bucket, this may cause some changes on the tests designed
to validate this feature. We made this change so we comply with what we
currently have with regards to default bucket tags.