### PR TITLE
Bug 1954891: Setting PriorityClassName for pruner cronjob

### DIFF
--- a/pkg/resource/prunercronjob.go
+++ b/pkg/resource/prunercronjob.go
@@ -123,6 +123,7 @@ func (gcj *generatorPrunerCronJob) expected() (runtime.Object, error) {
 						Spec: kcorev1.PodSpec{
 							RestartPolicy:      kcorev1.RestartPolicyNever,
 							ServiceAccountName: "pruner",
+							PriorityClassName:  "system-cluster-critical",
 							Affinity:           gcj.getAffinity(cr),
 							NodeSelector:       gcj.getNodeSelector(cr),
 							Tolerations:        gcj.getTolerations(cr),


### PR DESCRIPTION
Following other components of this operator we start setting the
priority class name to "system-cluster-critical".