### PR TITLE
Bug 1960330: manifests: fix selector in image-registry-operator

### DIFF
--- a/manifests/0000_90_cluster-image-registry-operator_02_operator-servicemonitor.yaml
+++ b/manifests/0000_90_cluster-image-registry-operator_02_operator-servicemonitor.yaml
@@ -18,4 +18,5 @@ spec:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       serverName: image-registry-operator.openshift-image-registry.svc
   selector:
-    name: image-registry-operator
+    matchLabels:
+      name: image-registry-operator


### PR DESCRIPTION
Invalid selector makes CVO apply this manifest on every sync iteration