### PR TITLE
[release-4.6] Bug 1959563: Using http.DefaultTransport timeouts

### DIFF
--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -3,9 +3,11 @@ package s3
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"reflect"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -146,6 +148,16 @@ func (d *driver) getS3Service() (*s3.S3, error) {
 		Region:      &d.Config.Region,
 		HTTPClient: &http.Client{
 			Transport: &http.Transport{
+				DialContext: (&net.Dialer{
+					Timeout:   30 * time.Second,
+					KeepAlive: 30 * time.Second,
+					DualStack: true,
+				}).DialContext,
+				ForceAttemptHTTP2:     true,
+				MaxIdleConns:          100,
+				IdleConnTimeout:       90 * time.Second,
+				TLSHandshakeTimeout:   10 * time.Second,
+				ExpectContinueTimeout: 1 * time.Second,
 				Proxy: func(req *http.Request) (*url.URL, error) {
 					return httpproxy.FromEnvironment().ProxyFunc()(req.URL)
 				},


### PR DESCRIPTION
**Due to conflicts this is a manual backport of https://github.com/openshift/cluster-image-registry-operator/pull/648**

Using the very same timeouts present on http.DefaultTransport into our
custom http client Transport.