### PR TITLE
Bug 1966459: Use batch/v1 and policy/v1

### DIFF
--- a/pkg/client/clients.go
+++ b/pkg/client/clients.go
@@ -3,8 +3,8 @@ package client
 import (
 	kubeset "k8s.io/client-go/kubernetes"
 	appsset "k8s.io/client-go/kubernetes/typed/apps/v1"
+	batchset "k8s.io/client-go/kubernetes/typed/batch/v1"
 	jobset "k8s.io/client-go/kubernetes/typed/batch/v1"
-	batchset "k8s.io/client-go/kubernetes/typed/batch/v1beta1"
 	coreset "k8s.io/client-go/kubernetes/typed/core/v1"
 	rbacset "k8s.io/client-go/kubernetes/typed/rbac/v1"
 
@@ -21,6 +21,6 @@ type Clients struct {
 	Core   coreset.CoreV1Interface
 	Apps   appsset.AppsV1Interface
 	RBAC   rbacset.RbacV1Interface
-	Batch  batchset.BatchV1beta1Interface
+	Batch  batchset.BatchV1Interface
 	Job    jobset.BatchV1Interface
 }

--- a/pkg/client/listers.go
+++ b/pkg/client/listers.go
@@ -2,10 +2,10 @@ package client
 
 import (
 	kappslisters "k8s.io/client-go/listers/apps/v1"
+	kbatchlisters "k8s.io/client-go/listers/batch/v1"
 	kjoblisters "k8s.io/client-go/listers/batch/v1"
-	kbatchlisters "k8s.io/client-go/listers/batch/v1beta1"
 	kcorelisters "k8s.io/client-go/listers/core/v1"
-	kpolicylisters "k8s.io/client-go/listers/policy/v1beta1"
+	kpolicylisters "k8s.io/client-go/listers/policy/v1"
 	krbaclisters "k8s.io/client-go/listers/rbac/v1"
 
 	configlisters "github.com/openshift/client-go/config/listers/config/v1"

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -97,7 +97,7 @@ func NewController(
 	c.clients.Route = routeClient.RouteV1()
 	c.clients.Config = configClient.ConfigV1()
 	c.clients.RegOp = imageregistryClient
-	c.clients.Batch = kubeClient.BatchV1beta1()
+	c.clients.Batch = kubeClient.BatchV1()
 
 	for _, ctor := range []func() cache.SharedIndexInformer{
 		func() cache.SharedIndexInformer {
@@ -126,7 +126,7 @@ func NewController(
 			return informer.Informer()
 		},
 		func() cache.SharedIndexInformer {
-			informer := kubeInformerFactory.Policy().V1beta1().PodDisruptionBudgets()
+			informer := kubeInformerFactory.Policy().V1().PodDisruptionBudgets()
 			c.listers.PodDisruptionBudgets = informer.Lister().PodDisruptionBudgets(defaults.ImageRegistryOperatorNamespace)
 			return informer.Informer()
 		},

--- a/pkg/operator/controllerimagepruner.go
+++ b/pkg/operator/controllerimagepruner.go
@@ -70,7 +70,7 @@ func NewImagePrunerController(
 	c.clients.RBAC = kubeClient.RbacV1()
 	c.clients.Kube = kubeClient
 	c.clients.RegOp = imageregistryClient
-	c.clients.Batch = kubeClient.BatchV1beta1()
+	c.clients.Batch = kubeClient.BatchV1()
 
 	for _, ctor := range []func() cache.SharedIndexInformer{
 		func() cache.SharedIndexInformer {
@@ -99,7 +99,7 @@ func NewImagePrunerController(
 			return informer.Informer()
 		},
 		func() cache.SharedIndexInformer {
-			informer := kubeInformerFactory.Batch().V1beta1().CronJobs()
+			informer := kubeInformerFactory.Batch().V1().CronJobs()
 			c.listers.CronJobs = informer.Lister().CronJobs(defaults.ImageRegistryOperatorNamespace)
 			return informer.Informer()
 		},

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	appsapi "k8s.io/api/apps/v1"
+	batchapi "k8s.io/api/batch/v1"
 	batchv1 "k8s.io/api/batch/v1"
-	batchapi "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metaapi "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/pkg/resource/generator.go
+++ b/pkg/resource/generator.go
@@ -106,7 +106,7 @@ func (g *Generator) List(cr *imageregistryv1.Config) ([]Mutator, error) {
 	mutators = append(mutators, newGeneratorSecret(g.listers.Secrets, g.clients.Core, driver))
 	mutators = append(mutators, newGeneratorService(g.listers.Services, g.clients.Core))
 	mutators = append(mutators, newGeneratorDeployment(g.listers.Deployments, g.listers.ConfigMaps, g.listers.Secrets, g.listers.ProxyConfigs, g.clients.Core, g.clients.Apps, driver, cr))
-	mutators = append(mutators, newGeneratorPodDisruptionBudget(g.listers.PodDisruptionBudgets, g.clients.Kube.PolicyV1beta1(), cr))
+	mutators = append(mutators, newGeneratorPodDisruptionBudget(g.listers.PodDisruptionBudgets, g.clients.Kube.PolicyV1(), cr))
 	mutators = append(mutators, g.listRoutes(cr)...)
 
 	return mutators, nil

--- a/pkg/resource/poddisruptionbudget.go
+++ b/pkg/resource/poddisruptionbudget.go
@@ -5,23 +5,23 @@ import (
 
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/defaults"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	policyclient "k8s.io/client-go/kubernetes/typed/policy/v1beta1"
-	policylisters "k8s.io/client-go/listers/policy/v1beta1"
+	policyclient "k8s.io/client-go/kubernetes/typed/policy/v1"
+	policylisters "k8s.io/client-go/listers/policy/v1"
 )
 
 var _ Mutator = &generatorPodDisruptionBudget{}
 
 type generatorPodDisruptionBudget struct {
 	lister policylisters.PodDisruptionBudgetNamespaceLister
-	client policyclient.PolicyV1beta1Interface
+	client policyclient.PolicyV1Interface
 	cr     *imageregistryv1.Config
 }
 
-func newGeneratorPodDisruptionBudget(lister policylisters.PodDisruptionBudgetNamespaceLister, client policyclient.PolicyV1beta1Interface, cr *imageregistryv1.Config) *generatorPodDisruptionBudget {
+func newGeneratorPodDisruptionBudget(lister policylisters.PodDisruptionBudgetNamespaceLister, client policyclient.PolicyV1Interface, cr *imageregistryv1.Config) *generatorPodDisruptionBudget {
 	return &generatorPodDisruptionBudget{
 		lister: lister,
 		client: client,
@@ -30,7 +30,7 @@ func newGeneratorPodDisruptionBudget(lister policylisters.PodDisruptionBudgetNam
 }
 
 func (gpdb *generatorPodDisruptionBudget) Type() runtime.Object {
-	return &policyv1beta1.PodDisruptionBudget{}
+	return &policyv1.PodDisruptionBudget{}
 }
 
 func (gpdb *generatorPodDisruptionBudget) GetNamespace() string {
@@ -47,12 +47,12 @@ func (gpdb *generatorPodDisruptionBudget) expected() (runtime.Object, error) {
 		minAvailable = intstr.FromInt(0)
 	}
 
-	pdb := &policyv1beta1.PodDisruptionBudget{
+	pdb := &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      gpdb.GetName(),
 			Namespace: gpdb.GetNamespace(),
 		},
-		Spec: policyv1beta1.PodDisruptionBudgetSpec{
+		Spec: policyv1.PodDisruptionBudgetSpec{
 			MinAvailable: &minAvailable,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: defaults.DeploymentLabels,
@@ -70,7 +70,7 @@ func (gpdb *generatorPodDisruptionBudget) Get() (runtime.Object, error) {
 func (gpdb *generatorPodDisruptionBudget) Create() (runtime.Object, error) {
 	return commonCreate(gpdb, func(obj runtime.Object) (runtime.Object, error) {
 		return gpdb.client.PodDisruptionBudgets(gpdb.GetNamespace()).Create(
-			context.TODO(), obj.(*policyv1beta1.PodDisruptionBudget), metav1.CreateOptions{},
+			context.TODO(), obj.(*policyv1.PodDisruptionBudget), metav1.CreateOptions{},
 		)
 	})
 }
@@ -78,7 +78,7 @@ func (gpdb *generatorPodDisruptionBudget) Create() (runtime.Object, error) {
 func (gpdb *generatorPodDisruptionBudget) Update(o runtime.Object) (runtime.Object, bool, error) {
 	return commonUpdate(gpdb, o, func(obj runtime.Object) (runtime.Object, error) {
 		return gpdb.client.PodDisruptionBudgets(gpdb.GetNamespace()).Update(
-			context.TODO(), obj.(*policyv1beta1.PodDisruptionBudget), metav1.UpdateOptions{},
+			context.TODO(), obj.(*policyv1.PodDisruptionBudget), metav1.UpdateOptions{},
 		)
 	})
 }

--- a/pkg/resource/prunercronjob.go
+++ b/pkg/resource/prunercronjob.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 	"os"
 
+	batchapi "k8s.io/api/batch/v1"
 	batchv1 "k8s.io/api/batch/v1"
-	batchapi "k8s.io/api/batch/v1beta1"
 	kcorev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	batchset "k8s.io/client-go/kubernetes/typed/batch/v1beta1"
-	batchlisters "k8s.io/client-go/listers/batch/v1beta1"
+	batchset "k8s.io/client-go/kubernetes/typed/batch/v1"
+	batchlisters "k8s.io/client-go/listers/batch/v1"
 
 	imageregistryapiv1 "github.com/openshift/api/imageregistry/v1"
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
@@ -45,12 +45,12 @@ var _ Mutator = &generatorPrunerCronJob{}
 
 type generatorPrunerCronJob struct {
 	lister            batchlisters.CronJobNamespaceLister
-	client            batchset.BatchV1beta1Interface
+	client            batchset.BatchV1Interface
 	prunerLister      imageregistryv1listers.ImagePrunerLister
 	imageConfigLister configv1listers.ImageLister
 }
 
-func newGeneratorPrunerCronJob(lister batchlisters.CronJobNamespaceLister, client batchset.BatchV1beta1Interface, prunerLister imageregistryv1listers.ImagePrunerLister, imageConfigLister configv1listers.ImageLister) *generatorPrunerCronJob {
+func newGeneratorPrunerCronJob(lister batchlisters.CronJobNamespaceLister, client batchset.BatchV1Interface, prunerLister imageregistryv1listers.ImagePrunerLister, imageConfigLister configv1listers.ImageLister) *generatorPrunerCronJob {
 	return &generatorPrunerCronJob{
 		lister:            lister,
 		client:            client,


### PR DESCRIPTION
'policy/v1beta1 PodDisruptionBudget' and 'batch/v1beta1 CronJob' are deprecated, so we need to migrate to their v1 versions.