### PR TITLE
Bug 1973318: Properly set custom tolerations

### DIFF
--- a/pkg/resource/prunercronjob.go
+++ b/pkg/resource/prunercronjob.go
@@ -195,7 +195,7 @@ func (gcj *generatorPrunerCronJob) getNodeSelector(cr *imageregistryapiv1.ImageP
 }
 
 func (gcj *generatorPrunerCronJob) getTolerations(cr *imageregistryapiv1.ImagePruner) []kcorev1.Toleration {
-	if cr.Spec.NodeSelector != nil {
+	if cr.Spec.Tolerations != nil {
 		return cr.Spec.Tolerations
 	}
 	return defaultTolerations


### PR DESCRIPTION
This fixes properly setting custom tolerations defined in imagepruner CR to the CronJob spec.