### PR TITLE
Bug 1974651: Remove :apiserver_v1_image_imports:sum

### DIFF
--- a/manifests/09-prometheus-rules.yaml
+++ b/manifests/09-prometheus-rules.yaml
@@ -21,5 +21,3 @@ spec:
         message: |
           Image Registry Storage configuration has changed in the last 30
           minutes. This change may have caused data loss.
-    - expr: sum(apiserver_v1_image_imports_total)
-      record: :apiserver_v1_image_imports:sum


### PR DESCRIPTION
The metric apiserver_v1_image_imports_total is going to be removed from the API server by https://github.com/openshift/openshift-apiserver/pull/222