### PR TITLE
e2e: Dump build information on failure

### DIFF
--- a/test/e2e/removed_test.go
+++ b/test/e2e/removed_test.go
@@ -44,6 +44,18 @@ func TestImageRegistryRemovedWithImages(t *testing.T) {
 		}
 	}()
 
+	if buildName, err := runTestBuild(ctx, te, nsName); err != nil {
+		te.Error(err)
+		dumpBuildInfo(ctx, te, nsName, buildName)
+	}
+
+	// This ensures that we can remove the image registry
+	framework.RemoveImageRegistry(te)
+}
+
+// runTestBuild runs a build which pushes an image to an imagestream.
+// Returns the name of the build, and an error if any.
+func runTestBuild(ctx context.Context, te framework.TestEnv, nsName string) (string, error) {
 	te.Logf("creating build output imagestream")
 	outputIs := &imagev1.ImageStream{
 		ObjectMeta: metav1.ObjectMeta{
@@ -51,9 +63,9 @@ func TestImageRegistryRemovedWithImages(t *testing.T) {
 			Namespace: nsName,
 		},
 	}
-	_, err = te.Client().ImageInterface.ImageStreams(nsName).Create(ctx, outputIs, metav1.CreateOptions{})
+	_, err := te.Client().ImageInterface.ImageStreams(nsName).Create(ctx, outputIs, metav1.CreateOptions{})
 	if err != nil {
-		te.Errorf("failed to create build output imagestream: %v", err)
+		return "", fmt.Errorf("failed to create build output imagestream: %v", err)
 	}
 
 	te.Logf("starting build")
@@ -89,7 +101,7 @@ func TestImageRegistryRemovedWithImages(t *testing.T) {
 	}
 	_, err = te.Client().BuildInterface.Builds(nsName).Create(ctx, build, metav1.CreateOptions{})
 	if err != nil {
-		te.Errorf("failed to create build %s/%s: %v", nsName, build.Name, err)
+		return "", fmt.Errorf("failed to create build %s/%s: %v", nsName, build.Name, err)
 	}
 
 	te.Logf("waiting for build %s/%s to complete", build.Namespace, build.Name)
@@ -106,19 +118,58 @@ func TestImageRegistryRemovedWithImages(t *testing.T) {
 		return false, nil
 	})
 	if err != nil {
-		te.Errorf("error waiting for build to complete: %v", err)
-		buildLogs, err := framework.GetLogsForPod(te.Client(), build.Namespace, fmt.Sprintf("%s-build", build.Name))
-		if err != nil {
-			te.Logf("failed to get build logs: %v", err)
-		} else {
-			framework.DumpPodLogs(te, buildLogs)
-		}
-	}
-	finishedBuild, err := te.Client().BuildInterface.Builds(nsName).Get(ctx, build.Name, metav1.GetOptions{})
-	if finishedBuild.Status.Phase == buildv1.BuildPhaseError || finishedBuild.Status.Phase == buildv1.BuildPhaseFailed {
-		te.Errorf("build %s/%s failed with message: %s", finishedBuild.Namespace, finishedBuild.Name, finishedBuild.Status.Message)
+		return build.Name, fmt.Errorf("error waiting for build to complete: %v", err)
 	}
 
-	// This ensures that we can remove the image registry
-	framework.RemoveImageRegistry(te)
+	finishedBuild, err := te.Client().BuildInterface.Builds(nsName).Get(ctx, build.Name, metav1.GetOptions{})
+	if err != nil {
+		return build.Name, fmt.Errorf("failed to get finished build %s/%s: %v", nsName, build.Name, err)
+	}
+
+	if finishedBuild.Status.Phase == buildv1.BuildPhaseError || finishedBuild.Status.Phase == buildv1.BuildPhaseFailed {
+		return build.Name, fmt.Errorf("build %s/%s failed with message: %s", finishedBuild.Namespace, finishedBuild.Name, finishedBuild.Status.Message)
+	}
+
+	return build.Name, nil
+}
+
+// dumpBuildInfo dumps build related information to the log. Includes the following:
+//
+// 1. Build logs
+// 2. Build pod YAML
+// 3. ConfigMaps in the build's namespace
+func dumpBuildInfo(ctx context.Context, te framework.TestEnv, nsName string, buildName string) {
+	if buildName == "" {
+		return
+	}
+	te.Log("attempting to dump build information")
+	buildPodName := fmt.Sprintf("%s-build", buildName)
+	buildLogs, err := framework.GetLogsForPod(te.Client(), nsName, buildPodName)
+	if err != nil {
+		te.Logf("failed to get build logs: %v", err)
+	} else {
+		te.Logf("Build logs:")
+		framework.DumpPodLogs(te, buildLogs)
+	}
+
+	build, err := te.Client().BuildInterface.Builds(nsName).Get(ctx, buildName, metav1.GetOptions{})
+	if err != nil {
+		te.Logf("failed to get build YAML: %v", err)
+	} else {
+		framework.DumpYAML(te, "build YAML", build)
+	}
+
+	buildPod, err := te.Client().CoreV1Interface.Pods(nsName).Get(ctx, buildPodName, metav1.GetOptions{})
+	if err != nil {
+		te.Logf("failed to get build pod YAML: %v", err)
+	} else {
+		framework.DumpYAML(te, "build pod YAML", buildPod)
+	}
+
+	configMaps, err := te.Client().CoreV1Interface.ConfigMaps(nsName).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		te.Logf("failed to get ConfigMaps: %v", err)
+	} else {
+		framework.DumpYAML(te, "build ConfigMaps", configMaps)
+	}
 }


### PR DESCRIPTION
If the test build fails, dump relevant build information to the log.