### PR TITLE
podsecurity: enforce privileged for openshift-image-registry namespace

### DIFF
--- a/manifests/01-namespace.yaml
+++ b/manifests/01-namespace.yaml
@@ -11,6 +11,9 @@ metadata:
     workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
 spec:
   finalizers:
   - kubernetes


### PR DESCRIPTION
Starting with OpenShift 4.10 we are introducing PodSecurity admission (https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/2579-psp-replacement).

Currently, all pods are marked as privileged, however, over time we want to enforce at least baseline, admirably restricted as default. In order not to break control plane workloads this allows workloads in `openshift-image-registry` namespace to run privileged pods.

See https://github.com/openshift/enhancements/pull/899 for more details (and excuse the eventual consistency of updates).

/cc @stlaz 
