### PR TITLE
no CredentialsRequests in ibm-cloud-managed

### DIFF
--- a/manifests/01-registry-credentials-request-alibaba.yaml
+++ b/manifests/01-registry-credentials-request-alibaba.yaml
@@ -6,7 +6,6 @@ metadata:
   name: openshift-image-registry-alibaba
   namespace: openshift-cloud-credential-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:

--- a/manifests/01-registry-credentials-request-azure.yaml
+++ b/manifests/01-registry-credentials-request-azure.yaml
@@ -6,7 +6,6 @@ metadata:
   name: openshift-image-registry-azure
   namespace: openshift-cloud-credential-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:

--- a/manifests/01-registry-credentials-request-gcs.yaml
+++ b/manifests/01-registry-credentials-request-gcs.yaml
@@ -6,7 +6,6 @@ metadata:
   name: openshift-image-registry-gcs
   namespace: openshift-cloud-credential-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:

--- a/manifests/01-registry-credentials-request-ibmcos.yaml
+++ b/manifests/01-registry-credentials-request-ibmcos.yaml
@@ -6,7 +6,6 @@ metadata:
   name: openshift-image-registry-ibmcos
   namespace: openshift-cloud-credential-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:

--- a/manifests/01-registry-credentials-request-openstack.yaml
+++ b/manifests/01-registry-credentials-request-openstack.yaml
@@ -6,7 +6,6 @@ metadata:
   name: openshift-image-registry-openstack
   namespace: openshift-cloud-credential-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:

--- a/manifests/01-registry-credentials-request.yaml
+++ b/manifests/01-registry-credentials-request.yaml
@@ -6,7 +6,6 @@ metadata:
   name: openshift-image-registry
   namespace: openshift-cloud-credential-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:

--- a/manifests/ibm-cloud-managed-cleanup.yaml
+++ b/manifests/ibm-cloud-managed-cleanup.yaml
@@ -1,0 +1,53 @@
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: openshift-image-registry-alibaba
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"
+---
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: openshift-image-registry-azure
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"
+---
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: openshift-image-registry-gcs
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"
+---
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: openshift-image-registry-ibmcos
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"
+---
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: openshift-image-registry-openstack
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"
+---
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: openshift-image-registry
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"


### PR DESCRIPTION
The ibm-cloud-managed profile doesn't use the cloud-credential-operator.
The CredentialsRequest CRs should not be installed in that environment.

Unmark the existing CredentialsRequests so they are no longer installed
in ibm-cloud-managed.

Create a list of previously-installed CredentialsRequests so that they
are cleaned up by the CVO only on the ibm-cloud-managed profile.

xref: https://issues.redhat.com/browse/CCO-177