### PR TITLE
Bug 2039170: Change log level for debug messages

### DIFF
--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -377,7 +377,7 @@ func (c *Controller) handler() cache.ResourceEventHandlerFuncs {
 			if obj.GetNamespace() == kubeSystemNamespace && obj.GetName() != defaults.ClusterConfigName {
 				return
 			}
-			klog.V(1).Infof("add event to workqueue due to %s (add)", utilObjectInfo(o))
+			klog.V(4).Infof("add event to workqueue due to %s (add)", utilObjectInfo(o))
 			c.workqueue.Add(workqueueKey)
 		},
 		UpdateFunc: func(o, n interface{}) {
@@ -400,7 +400,7 @@ func (c *Controller) handler() cache.ResourceEventHandlerFuncs {
 			if obj.GetNamespace() == kubeSystemNamespace && obj.GetName() != defaults.ClusterConfigName {
 				return
 			}
-			klog.V(1).Infof("add event to workqueue due to %s (update)", utilObjectInfo(n))
+			klog.V(4).Infof("add event to workqueue due to %s (update)", utilObjectInfo(n))
 			c.workqueue.Add(workqueueKey)
 		},
 		DeleteFunc: func(o interface{}) {
@@ -421,7 +421,7 @@ func (c *Controller) handler() cache.ResourceEventHandlerFuncs {
 			if object.GetNamespace() == kubeSystemNamespace && object.GetName() != defaults.ClusterConfigName {
 				return
 			}
-			klog.V(1).Infof("add event to workqueue due to %s (delete)", utilObjectInfo(object))
+			klog.V(4).Infof("add event to workqueue due to %s (delete)", utilObjectInfo(object))
 			c.workqueue.Add(workqueueKey)
 		},
 	}

--- a/pkg/operator/controllerimagepruner.go
+++ b/pkg/operator/controllerimagepruner.go
@@ -329,7 +329,7 @@ func (c *ImagePrunerController) eventProcessor() {
 func (c *ImagePrunerController) handler() cache.ResourceEventHandlerFuncs {
 	return cache.ResourceEventHandlerFuncs{
 		AddFunc: func(o interface{}) {
-			klog.V(1).Infof("add event to image pruner workqueue due to %s (add)", utilObjectInfo(o))
+			klog.V(4).Infof("add event to image pruner workqueue due to %s (add)", utilObjectInfo(o))
 			c.workqueue.Add(imagePrunerWorkQueueKey)
 		},
 		UpdateFunc: func(o, n interface{}) {
@@ -348,7 +348,7 @@ func (c *ImagePrunerController) handler() cache.ResourceEventHandlerFuncs {
 				// Two different versions of the same resource will always have different RVs.
 				return
 			}
-			klog.V(1).Infof("add event to image pruner workqueue due to %s (update)", utilObjectInfo(n))
+			klog.V(4).Infof("add event to image pruner workqueue due to %s (update)", utilObjectInfo(n))
 			c.workqueue.Add(imagePrunerWorkQueueKey)
 		},
 		DeleteFunc: func(o interface{}) {
@@ -366,7 +366,7 @@ func (c *ImagePrunerController) handler() cache.ResourceEventHandlerFuncs {
 				}
 				klog.V(4).Infof("recovered deleted object %q from tombstone", object.GetName())
 			}
-			klog.V(1).Infof("add event to image pruner workqueue due to %s (delete)", utilObjectInfo(object))
+			klog.V(4).Infof("add event to image pruner workqueue due to %s (delete)", utilObjectInfo(object))
 			c.workqueue.Add(imagePrunerWorkQueueKey)
 		},
 	}

--- a/pkg/resource/caconfig.go
+++ b/pkg/resource/caconfig.go
@@ -62,7 +62,7 @@ func (gcac *generatorCAConfig) expected() (runtime.Object, error) {
 
 	serviceCA, err := gcac.lister.Get(defaults.ServiceCAName)
 	if errors.IsNotFound(err) {
-		klog.V(1).Infof("missing the service CA configmap: %s", err)
+		klog.V(4).Infof("missing the service CA configmap: %s", err)
 	} else if err != nil {
 		return cm, err
 	} else {
@@ -85,7 +85,7 @@ func (gcac *generatorCAConfig) expected() (runtime.Object, error) {
 
 	imageConfig, err := gcac.imageConfigLister.Get(defaults.ImageConfigName)
 	if errors.IsNotFound(err) {
-		klog.V(1).Infof("missing the image config: %s", err)
+		klog.V(4).Infof("missing the image config: %s", err)
 	} else if err != nil {
 		return cm, err
 	} else if caConfigName := imageConfig.Spec.AdditionalTrustedCA.Name; caConfigName != "" {
@@ -104,7 +104,7 @@ func (gcac *generatorCAConfig) expected() (runtime.Object, error) {
 
 	cp_ca, err := gcac.openshiftConfigLister.Get("cloud-provider-config")
 	if errors.IsNotFound(err) {
-		klog.V(1).Infof("missing the cloud-provider-config configmap: %s", err)
+		klog.V(4).Infof("missing the cloud-provider-config configmap: %s", err)
 	} else if err != nil {
 		return cm, err
 	} else {


### PR DESCRIPTION
The operator used to be run with loglevel 0, but the current default is
2. This change updates loglevel for debug messages to keep them hidden
by default.