### PR TITLE
Bug 2067995: Use OnRootMismatch for fsGroupChangePolicy

### DIFF
--- a/pkg/resource/podtemplatespec.go
+++ b/pkg/resource/podtemplatespec.go
@@ -95,8 +95,11 @@ func generateSecurityContext(coreClient coreset.CoreV1Interface, namespace strin
 		return nil, fmt.Errorf("unable to parse annotation %s in namespace %q: %s", defaults.SupplementalGroupsAnnotation, namespace, err)
 	}
 
+	fsGroupChangePolicy := corev1.FSGroupChangeOnRootMismatch
+
 	return &corev1.PodSecurityContext{
-		FSGroup: &gid,
+		FSGroup:             &gid,
+		FSGroupChangePolicy: &fsGroupChangePolicy,
 	}, nil
 }
 

--- a/pkg/resource/podtemplatespec_test.go
+++ b/pkg/resource/podtemplatespec_test.go
@@ -173,6 +173,10 @@ func TestMakePodTemplateSpec(t *testing.T) {
 		}
 	}
 
+	fsGroupChangePolicy := pod.Spec.SecurityContext.FSGroupChangePolicy
+	if fsGroupChangePolicy == nil || *fsGroupChangePolicy != corev1.FSGroupChangeOnRootMismatch {
+		t.Errorf("expected FSGroupChangePolicy to be set to OnRootMismatch")
+	}
 }
 
 func verifyVolume(volume corev1.Volume, expected *volumeMount, t *testing.T) {


### PR DESCRIPTION
This should help on installations that have millions of files on the registry volume.