### PR TITLE
Bug 2067995: Deployment annotations, runtimeClassName override and fs policy change

### DIFF
--- a/pkg/resource/configoverrides.go
+++ b/pkg/resource/configoverrides.go
@@ -1,0 +1,13 @@
+package resource
+
+// ConfigOverrides holds data users can set to override default object configurations created
+// by this operator. This is stored in the registry Config.Spec.UnsupportedConfigOverrides.
+type ConfigOverrides struct {
+	Deployment *DeploymentOverrides `json:"deployment,omitempty"`
+}
+
+// DeploymentOverrides holds items that can be overwriten in the image registry deployment.
+type DeploymentOverrides struct {
+	Annotations      map[string]string `json:"annotations,omitempty"`
+	RuntimeClassName *string           `json:"runtimeClassName,omitempty"`
+}

--- a/pkg/resource/podtemplatespec.go
+++ b/pkg/resource/podtemplatespec.go
@@ -95,8 +95,10 @@ func generateSecurityContext(coreClient coreset.CoreV1Interface, namespace strin
 		return nil, fmt.Errorf("unable to parse annotation %s in namespace %q: %s", defaults.SupplementalGroupsAnnotation, namespace, err)
 	}
 
+	fsGroupChangePolicy := corev1.FSGroupChangeOnRootMismatch
 	return &corev1.PodSecurityContext{
-		FSGroup: &gid,
+		FSGroup:             &gid,
+		FSGroupChangePolicy: &fsGroupChangePolicy,
 	}, nil
 }
 

--- a/pkg/resource/podtemplatespec_test.go
+++ b/pkg/resource/podtemplatespec_test.go
@@ -173,6 +173,10 @@ func TestMakePodTemplateSpec(t *testing.T) {
 		}
 	}
 
+	fsGroupChangePolicy := pod.Spec.SecurityContext.FSGroupChangePolicy
+	if fsGroupChangePolicy == nil || *fsGroupChangePolicy != corev1.FSGroupChangeOnRootMismatch {
+		t.Errorf("expected FSGroupChangePolicy to be set to OnRootMismatch")
+	}
 }
 
 func verifyVolume(volume corev1.Volume, expected *volumeMount, t *testing.T) {


### PR DESCRIPTION
We are using config.spec.unsupportedConfigOverrides to allow users to override image registry runtimeClass and annotations. This commit also uses OnRootMismatch for fsGroupChangePolicy in the registry deployment.