### PR TITLE
Bug 2082492: IBMCloud: Add admin permissions to CR

### DIFF
--- a/manifests/01-registry-credentials-request-ibmcos.yaml
+++ b/manifests/01-registry-credentials-request-ibmcos.yaml
@@ -24,6 +24,7 @@ spec:
       - crn:v1:bluemix:public:iam::::role:Viewer
       - crn:v1:bluemix:public:iam::::role:Operator
       - crn:v1:bluemix:public:iam::::role:Editor
+      - crn:v1:bluemix:public:iam::::role:Administrator
       - crn:v1:bluemix:public:iam::::serviceRole:Reader
       - crn:v1:bluemix:public:iam::::serviceRole:Writer
     - attributes:


### PR DESCRIPTION
IBM Cloud COS now requires access to Admin level role in order to
access COS HMAC keys during image-registry COS resource creation.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2082492