### PR TITLE
Bug 2093440: Use actualDaemonSet for SetDaemonSetGeneration

### DIFF
--- a/pkg/operator/nodecadaemon.go
+++ b/pkg/operator/nodecadaemon.go
@@ -80,7 +80,16 @@ func (c *NodeCADaemonController) processNextWorkItem() bool {
 	}
 	defer c.queue.Done(obj)
 
-	klog.V(4).Infof("get event from workqueue")
+	klog.V(4).Infof("get event from workqueue: %s", obj)
+
+	// the workqueueKey we reference here is different than the one we use in eventHandler
+	// use that to identify we are processing an item that was added back to the queue
+	// can remove if not useful but curious why this didn't seem to be working for the
+	// caches not synced error
+	if obj == workqueueKey {
+		klog.V(2).Infof("NodeCADaemonController processing requeued item  %s", obj)
+	}
+
 	if err := c.sync(); err != nil {
 		c.queue.AddRateLimited(workqueueKey)
 		klog.Errorf("NodeCADaemonController: unable to sync: %s, requeuing", err)


### PR DESCRIPTION
Continue to see failures in Managed cluster should start all core operator due to NodeCADaemonControllerDegraded.  Adding logging to investigate further

https://sippy.dptools.openshift.org/sippy-ng/jobs/4.12/runs?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22failed_test_names%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22%5Bsig-arch%5D%5BEarly%5D%20Managed%20cluster%20should%20start%20all%20core%20operators%20%5BSkipped%3ADisconnected%5D%20%5BSuite%3Aopenshift%2Fconformance%2Fparallel%5D%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22never-stable%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22techpreview%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D&sortField=timestamp&sort=desc