### PR TITLE
Bug OCPBUGS-716: Add support for kube event recorder

### DIFF
--- a/manifests/07-operator-ibm-cloud-managed.yaml
+++ b/manifests/07-operator-ibm-cloud-managed.yaml
@@ -31,6 +31,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: cluster-image-registry-operator
         - name: IMAGE

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -59,6 +59,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name                   
             - name: OPERATOR_NAME
               value: "cluster-image-registry-operator"
             - name: IMAGE

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -28,6 +28,7 @@ import (
 	imageregistryinformers "github.com/openshift/client-go/imageregistry/informers/externalversions"
 	routeclient "github.com/openshift/client-go/route/clientset/versioned"
 	routeinformers "github.com/openshift/client-go/route/informers/externalversions"
+	"github.com/openshift/library-go/pkg/operator/events"
 
 	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
 	"github.com/openshift/cluster-image-registry-operator/pkg/defaults"
@@ -64,6 +65,7 @@ func (e permanentError) Error() string {
 // This controller keeps track of resources needed in order to have openshift
 // internal registry working.
 func NewController(
+	eventRecorder events.Recorder,
 	kubeconfig *restclient.Config,
 	kubeClient kubeclient.Interface,
 	configClient configclient.Interface,
@@ -81,7 +83,7 @@ func NewController(
 	clients := &regopclient.Clients{}
 	c := &Controller{
 		kubeconfig: kubeconfig,
-		generator:  resource.NewGenerator(kubeconfig, clients, listers),
+		generator:  resource.NewGenerator(eventRecorder, kubeconfig, clients, listers),
 		workqueue:  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Changes"),
 		listers:    listers,
 		clients:    clients,

--- a/pkg/resource/deployment.go
+++ b/pkg/resource/deployment.go
@@ -30,7 +30,7 @@ import (
 var _ Mutator = &generatorDeployment{}
 
 type generatorDeployment struct {
-	recorder        events.Recorder
+	eventRecorder   events.Recorder
 	lister          appslisters.DeploymentNamespaceLister
 	configMapLister corelisters.ConfigMapNamespaceLister
 	secretLister    corelisters.SecretNamespaceLister
@@ -41,9 +41,9 @@ type generatorDeployment struct {
 	cr              *imageregistryv1.Config
 }
 
-func newGeneratorDeployment(lister appslisters.DeploymentNamespaceLister, configMapLister corelisters.ConfigMapNamespaceLister, secretLister corelisters.SecretNamespaceLister, proxyLister configlisters.ProxyLister, coreClient coreset.CoreV1Interface, client appsset.AppsV1Interface, driver storage.Driver, cr *imageregistryv1.Config) *generatorDeployment {
+func newGeneratorDeployment(eventRecorder events.Recorder, lister appslisters.DeploymentNamespaceLister, configMapLister corelisters.ConfigMapNamespaceLister, secretLister corelisters.SecretNamespaceLister, proxyLister configlisters.ProxyLister, coreClient coreset.CoreV1Interface, client appsset.AppsV1Interface, driver storage.Driver, cr *imageregistryv1.Config) *generatorDeployment {
 	return &generatorDeployment{
-		recorder:        events.NewLoggingEventRecorder("image-registry-operator"),
+		eventRecorder:   eventRecorder,
 		lister:          lister,
 		configMapLister: configMapLister,
 		secretLister:    secretLister,
@@ -193,7 +193,7 @@ func (gd *generatorDeployment) Create() (runtime.Object, error) {
 	}
 
 	dep, _, err := resourceapply.ApplyDeployment(
-		context.TODO(), gd.client, gd.recorder, exp.(*appsapi.Deployment), -1,
+		context.TODO(), gd.client, gd.eventRecorder, exp.(*appsapi.Deployment), -1,
 	)
 	if err != nil {
 		return nil, err
@@ -210,7 +210,7 @@ func (gd *generatorDeployment) Update(o runtime.Object) (runtime.Object, bool, e
 	}
 
 	dep, updated, err := resourceapply.ApplyDeployment(
-		context.TODO(), gd.client, gd.recorder, exp.(*appsapi.Deployment), gd.LastGeneration(),
+		context.TODO(), gd.client, gd.eventRecorder, exp.(*appsapi.Deployment), gd.LastGeneration(),
 	)
 	if err != nil {
 		return o, false, err

--- a/pkg/resource/nodecadaemon.go
+++ b/pkg/resource/nodecadaemon.go
@@ -25,16 +25,16 @@ import (
 var _ Mutator = &generatorNodeCADaemonSet{}
 
 type generatorNodeCADaemonSet struct {
-	recorder        events.Recorder
+	eventRecorder   events.Recorder
 	daemonSetLister appsv1listers.DaemonSetNamespaceLister
 	serviceLister   corev1listers.ServiceNamespaceLister
 	client          appsv1client.AppsV1Interface
 	operatorClient  v1helpers.OperatorClient
 }
 
-func NewGeneratorNodeCADaemonSet(daemonSetLister appsv1listers.DaemonSetNamespaceLister, serviceLister corev1listers.ServiceNamespaceLister, client appsv1client.AppsV1Interface, operatorClient v1helpers.OperatorClient) Mutator {
+func NewGeneratorNodeCADaemonSet(eventRecorder events.Recorder, daemonSetLister appsv1listers.DaemonSetNamespaceLister, serviceLister corev1listers.ServiceNamespaceLister, client appsv1client.AppsV1Interface, operatorClient v1helpers.OperatorClient) Mutator {
 	return &generatorNodeCADaemonSet{
-		recorder:        events.NewLoggingEventRecorder("image-registry-operator"),
+		eventRecorder:   eventRecorder,
 		daemonSetLister: daemonSetLister,
 		serviceLister:   serviceLister,
 		client:          client,
@@ -79,7 +79,7 @@ func (ds *generatorNodeCADaemonSet) Update(o runtime.Object) (runtime.Object, bo
 	actualDaemonSet, updated, err := resourceapply.ApplyDaemonSet(
 		context.TODO(),
 		ds.client,
-		ds.recorder,
+		ds.eventRecorder,
 		desiredDaemonSet,
 		resourcemerge.ExpectedDaemonSetGeneration(desiredDaemonSet, opStatus.Generations),
 	)

--- a/pkg/resource/nodecadaemon_test.go
+++ b/pkg/resource/nodecadaemon_test.go
@@ -14,6 +14,7 @@ import (
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	imageregistryfake "github.com/openshift/client-go/imageregistry/clientset/versioned/fake"
 	imageregistryinformers "github.com/openshift/client-go/imageregistry/informers/externalversions"
+	"github.com/openshift/library-go/pkg/operator/events"
 
 	"github.com/openshift/cluster-image-registry-operator/pkg/client"
 )
@@ -52,7 +53,7 @@ func TestNodeCADaemon(t *testing.T) {
 	imageregistryInformers.Start(ctx.Done())
 	imageregistryInformers.WaitForCacheSync(ctx.Done())
 
-	g := NewGeneratorNodeCADaemonSet(nil, nil, clientset.AppsV1(), operatorClient)
+	g := NewGeneratorNodeCADaemonSet(events.NewInMemoryRecorder("image-registry-operator"), nil, nil, clientset.AppsV1(), operatorClient)
 	obj, err := g.Create()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
While investigating caches not synched error it was noted that the code was using a logging event recorder.  A request was made at that time to update the event recorder to increase observability and CI signal as we likely would have caught the frequent updating vi our CI testing.