### PR TITLE
OCPBUGS-2941: Bump gophercloud

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/go-cmp v0.5.8
 	github.com/google/uuid v1.2.0
-	github.com/gophercloud/gophercloud v0.17.0
+	github.com/gophercloud/gophercloud v0.18.0
 	github.com/gophercloud/utils v0.0.0-20210323225332-7b186010c04f
 	github.com/goware/urlx v0.3.1
 	github.com/openshift/api v0.0.0-20221004161420-ef2c62cf20d0

--- a/go.sum
+++ b/go.sum
@@ -470,8 +470,8 @@ github.com/googleapis/gnostic v0.1.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTV
 github.com/googleapis/gnostic v0.2.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gophercloud/gophercloud v0.15.1-0.20210202035223-633d73521055/go.mod h1:wRtmUelyIIv3CSSDI47aUwbs075O6i+LY+pXsKCBsb4=
-github.com/gophercloud/gophercloud v0.17.0 h1:BgVw0saxyeHWH5us/SQe1ltp0GRnytjmOLXDA8pO77E=
-github.com/gophercloud/gophercloud v0.17.0/go.mod h1:wRtmUelyIIv3CSSDI47aUwbs075O6i+LY+pXsKCBsb4=
+github.com/gophercloud/gophercloud v0.18.0 h1:V6hcuMPmjXg+js9flU8T3RIHDCjV7F5CG5GD0MRhP/w=
+github.com/gophercloud/gophercloud v0.18.0/go.mod h1:wRtmUelyIIv3CSSDI47aUwbs075O6i+LY+pXsKCBsb4=
 github.com/gophercloud/utils v0.0.0-20210323225332-7b186010c04f h1:+SO5iEqu9QjNWL9TfAmOE5u0Uizv1T3jpBuMJfMOVJ0=
 github.com/gophercloud/utils v0.0.0-20210323225332-7b186010c04f/go.mod h1:wx8HMD8oQD0Ryhz6+6ykq75PJ79iPyEqYHfwZ4l7OsA=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=

--- a/vendor/github.com/gophercloud/gophercloud/.zuul.yaml
+++ b/vendor/github.com/gophercloud/gophercloud/.zuul.yaml
@@ -13,7 +13,7 @@
       Run gophercloud acceptance test on master branch
     run: .zuul/playbooks/gophercloud-acceptance-test/run.yaml
     timeout: 18000 # 5 hours
-    nodeset: ubuntu-bionic
+    nodeset: ubuntu-focal
 
 - job:
     name: gophercloud-acceptance-test-ironic
@@ -21,7 +21,7 @@
     description: |
       Run gophercloud ironic acceptance test on master branch
     run: .zuul/playbooks/gophercloud-acceptance-test-ironic/run.yaml
-    nodeset: ubuntu-bionic
+    nodeset: ubuntu-focal
 
 - job:
     name: gophercloud-acceptance-test-ussuri

--- a/vendor/github.com/gophercloud/gophercloud/CHANGELOG.md
+++ b/vendor/github.com/gophercloud/gophercloud/CHANGELOG.md
@@ -1,4 +1,44 @@
-## 0.18.0 (Unreleased)
+## 0.19.0 (Unreleased)
+
+## 0.18.0 (June 11, 2021)
+
+NOTES / BREAKING CHANGES
+
+* As of [GH-2160](https://github.com/gophercloud/gophercloud/pull/2160), Gophercloud no longer URL encodes Object Storage containers and object names. You can still encode them yourself before passing the names to the Object Storage functions.
+
+* `baremetal/v1/nodes.ListBIOSSettings` now takes three parameters. The third, new, parameter is `ListBIOSSettingsOptsBuilder` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+
+BUG FIXES
+
+* Fixed expected OK codes to use default codes [GH-2173](https://github.com/gophercloud/gophercloud/pull/2173)
+* Fixed inablity to create sub-containers (objects with `/` in their name) [GH-2160](https://github.com/gophercloud/gophercloud/pull/2160)
+
+IMPROVEMENTS
+
+* Added `orchestration/v1/stacks.ListOpts.ShowHidden` [GH-2104](https://github.com/gophercloud/gophercloud/pull/2104)
+* Added `loadbalancer/v2/listeners.ProtocolSCTP` [GH-2149](https://github.com/gophercloud/gophercloud/pull/2149)
+* Added `loadbalancer/v2/listeners.CreateOpts.TLSVersions` [GH-2150](https://github.com/gophercloud/gophercloud/pull/2150)
+* Added `loadbalancer/v2/listeners.UpdateOpts.TLSVersions` [GH-2150](https://github.com/gophercloud/gophercloud/pull/2150)
+* Added `baremetal/v1/nodes.CreateOpts.NetworkData` [GH-2154](https://github.com/gophercloud/gophercloud/pull/2154)
+* Added `baremetal/v1/nodes.Node.NetworkData` [GH-2154](https://github.com/gophercloud/gophercloud/pull/2154)
+* Added `loadbalancer/v2/pools.ProtocolPROXYV2` [GH-2158](https://github.com/gophercloud/gophercloud/pull/2158)
+* Added `loadbalancer/v2/pools.ProtocolSCTP` [GH-2158](https://github.com/gophercloud/gophercloud/pull/2158)
+* Added `placement/v1/resourceproviders.GetAllocations` [GH-2162](https://github.com/gophercloud/gophercloud/pull/2162)
+* Added `baremetal/v1/nodes.CreateOpts.BIOSInterface` [GH-2164](https://github.com/gophercloud/gophercloud/pull/2164)
+* Added `baremetal/v1/nodes.Node.BIOSInterface` [GH-2164](https://github.com/gophercloud/gophercloud/pull/2164)
+* Added `baremetal/v1/nodes.NodeValidation.BIOS` [GH-2164](https://github.com/gophercloud/gophercloud/pull/2164)
+* Added `baremetal/v1/nodes.ListBIOSSettings` [GH-2171](https://github.com/gophercloud/gophercloud/pull/2171)
+* Added `baremetal/v1/nodes.GetBIOSSetting` [GH-2171](https://github.com/gophercloud/gophercloud/pull/2171)
+* Added `baremetal/v1/nodes.ListBIOSSettingsOpts` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+* Added `baremetal/v1/nodes.BIOSSetting.AttributeType` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+* Added `baremetal/v1/nodes.BIOSSetting.AllowableValues` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+* Added `baremetal/v1/nodes.BIOSSetting.LowerBound` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+* Added `baremetal/v1/nodes.BIOSSetting.UpperBound` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+* Added `baremetal/v1/nodes.BIOSSetting.MinLength` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+* Added `baremetal/v1/nodes.BIOSSetting.MaxLength` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+* Added `baremetal/v1/nodes.BIOSSetting.ReadOnly` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+* Added `baremetal/v1/nodes.BIOSSetting.ResetRequired` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+* Added `baremetal/v1/nodes.BIOSSetting.Unique` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
 
 ## 0.17.0 (April 9, 2021)
 

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers/requests.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"net/url"
 	"strings"
 
 	"github.com/gophercloud/gophercloud"
@@ -108,7 +107,7 @@ func Create(c *gophercloud.ServiceClient, containerName string, opts CreateOptsB
 			h[k] = v
 		}
 	}
-	resp, err := c.Request("PUT", createURL(c, url.QueryEscape(containerName)), &gophercloud.RequestOpts{
+	resp, err := c.Request("PUT", createURL(c, containerName), &gophercloud.RequestOpts{
 		MoreHeaders: h,
 		OkCodes:     []int{201, 202, 204},
 	})
@@ -123,7 +122,7 @@ func BulkDelete(c *gophercloud.ServiceClient, containers []string) (r BulkDelete
 	// https://github.com/openstack/swift/blob/stable/train/swift/common/swob.py#L302
 	encodedContainers := make([]string, len(containers))
 	for i, v := range containers {
-		encodedContainers[i] = url.QueryEscape(v)
+		encodedContainers[i] = v
 	}
 	b := strings.NewReader(strings.Join(encodedContainers, "\n") + "\n")
 	resp, err := c.Post(bulkDeleteURL(c), b, &r.Body, &gophercloud.RequestOpts{
@@ -139,7 +138,7 @@ func BulkDelete(c *gophercloud.ServiceClient, containers []string) (r BulkDelete
 
 // Delete is a function that deletes a container.
 func Delete(c *gophercloud.ServiceClient, containerName string) (r DeleteResult) {
-	resp, err := c.Delete(deleteURL(c, url.QueryEscape(containerName)), nil)
+	resp, err := c.Delete(deleteURL(c, containerName), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
@@ -202,7 +201,7 @@ func Update(c *gophercloud.ServiceClient, containerName string, opts UpdateOptsB
 			h[k] = v
 		}
 	}
-	resp, err := c.Request("POST", updateURL(c, url.QueryEscape(containerName)), &gophercloud.RequestOpts{
+	resp, err := c.Request("POST", updateURL(c, containerName), &gophercloud.RequestOpts{
 		MoreHeaders: h,
 		OkCodes:     []int{201, 202, 204},
 	})
@@ -242,7 +241,7 @@ func Get(c *gophercloud.ServiceClient, containerName string, opts GetOptsBuilder
 			h[k] = v
 		}
 	}
-	resp, err := c.Head(getURL(c, url.QueryEscape(containerName)), &gophercloud.RequestOpts{
+	resp, err := c.Head(getURL(c, containerName), &gophercloud.RequestOpts{
 		MoreHeaders: h,
 		OkCodes:     []int{200, 204},
 	})

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers/results.go
@@ -72,7 +72,7 @@ func ExtractNames(page pagination.Page) ([]string, error) {
 			names = append(names, container.Name)
 		}
 		return names, nil
-	case strings.HasPrefix(ct, "text/plain"):
+	case strings.HasPrefix(ct, "text/plain") || ct == "":
 		names := make([]string, 0, 50)
 
 		body := string(page.(ContainerPage).Body.([]uint8))

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects/requests.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net/url"
 	"strings"
 	"time"
 
@@ -54,7 +53,7 @@ func (opts ListOpts) ToObjectListParams() (bool, string, error) {
 func List(c *gophercloud.ServiceClient, containerName string, opts ListOptsBuilder) pagination.Pager {
 	headers := map[string]string{"Accept": "text/plain", "Content-Type": "text/plain"}
 
-	url := listURL(c, url.QueryEscape(containerName))
+	url := listURL(c, containerName)
 	if opts != nil {
 		full, query, err := opts.ToObjectListParams()
 		if err != nil {
@@ -119,7 +118,7 @@ func (opts DownloadOpts) ToObjectDownloadParams() (map[string]string, string, er
 // To extract just the content, pass the DownloadResult response to the
 // ExtractContent function.
 func Download(c *gophercloud.ServiceClient, containerName, objectName string, opts DownloadOptsBuilder) (r DownloadResult) {
-	url := downloadURL(c, url.QueryEscape(containerName), url.QueryEscape(objectName))
+	url := downloadURL(c, containerName, objectName)
 	h := make(map[string]string)
 	if opts != nil {
 		headers, query, err := opts.ToObjectDownloadParams()
@@ -225,7 +224,7 @@ func (opts CreateOpts) ToObjectCreateParams() (io.Reader, map[string]string, str
 // checksum, the failed request will automatically be retried up to a maximum
 // of 3 times.
 func Create(c *gophercloud.ServiceClient, containerName, objectName string, opts CreateOptsBuilder) (r CreateResult) {
-	url := createURL(c, url.QueryEscape(containerName), url.QueryEscape(objectName))
+	url := createURL(c, containerName, objectName)
 	h := make(map[string]string)
 	var b io.Reader
 	if opts != nil {
@@ -289,7 +288,7 @@ func Copy(c *gophercloud.ServiceClient, containerName, objectName string, opts C
 		h[k] = v
 	}
 
-	url := copyURL(c, url.QueryEscape(containerName), url.QueryEscape(objectName))
+	url := copyURL(c, containerName, objectName)
 	resp, err := c.Request("COPY", url, &gophercloud.RequestOpts{
 		MoreHeaders: h,
 		OkCodes:     []int{201},
@@ -317,7 +316,7 @@ func (opts DeleteOpts) ToObjectDeleteQuery() (string, error) {
 
 // Delete is a function that deletes an object.
 func Delete(c *gophercloud.ServiceClient, containerName, objectName string, opts DeleteOptsBuilder) (r DeleteResult) {
-	url := deleteURL(c, url.QueryEscape(containerName), url.QueryEscape(objectName))
+	url := deleteURL(c, containerName, objectName)
 	if opts != nil {
 		query, err := opts.ToObjectDeleteQuery()
 		if err != nil {
@@ -362,7 +361,7 @@ func (opts GetOpts) ToObjectGetParams() (map[string]string, string, error) {
 // the custom metadata, pass the GetResult response to the ExtractMetadata
 // function.
 func Get(c *gophercloud.ServiceClient, containerName, objectName string, opts GetOptsBuilder) (r GetResult) {
-	url := getURL(c, url.QueryEscape(containerName), url.QueryEscape(objectName))
+	url := getURL(c, containerName, objectName)
 	h := make(map[string]string)
 	if opts != nil {
 		headers, query, err := opts.ToObjectGetParams()
@@ -434,7 +433,7 @@ func Update(c *gophercloud.ServiceClient, containerName, objectName string, opts
 			h[k] = v
 		}
 	}
-	url := updateURL(c, url.QueryEscape(containerName), url.QueryEscape(objectName))
+	url := updateURL(c, containerName, objectName)
 	resp, err := c.Post(url, nil, nil, &gophercloud.RequestOpts{
 		MoreHeaders: h,
 	})
@@ -489,7 +488,7 @@ func CreateTempURL(c *gophercloud.ServiceClient, containerName, objectName strin
 
 	duration := time.Duration(opts.TTL) * time.Second
 	expiry := date.Add(duration).Unix()
-	getHeader, err := containers.Get(c, url.QueryEscape(containerName), nil).Extract()
+	getHeader, err := containers.Get(c, containerName, nil).Extract()
 	if err != nil {
 		return "", err
 	}
@@ -521,10 +520,7 @@ func BulkDelete(c *gophercloud.ServiceClient, container string, objects []string
 	// https://github.com/openstack/swift/blob/stable/train/swift/common/swob.py#L302
 	encodedObjects := make([]string, len(objects))
 	for i, v := range objects {
-		encodedObjects[i] = strings.Join([]string{
-			url.QueryEscape(container),
-			url.QueryEscape(v)},
-			"/")
+		encodedObjects[i] = strings.Join([]string{container, v}, "/")
 	}
 	b := strings.NewReader(strings.Join(encodedObjects, "\n") + "\n")
 	resp, err := c.Post(bulkDeleteURL(c), b, &r.Body, &gophercloud.RequestOpts{

--- a/vendor/github.com/gophercloud/gophercloud/provider_client.go
+++ b/vendor/github.com/gophercloud/gophercloud/provider_client.go
@@ -440,7 +440,7 @@ func (client *ProviderClient) doRequest(method, url string, options *RequestOpts
 		respErr := ErrUnexpectedResponseCode{
 			URL:            url,
 			Method:         method,
-			Expected:       options.OkCodes,
+			Expected:       okc,
 			Actual:         resp.StatusCode,
 			Body:           body,
 			ResponseHeader: resp.Header,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -306,7 +306,7 @@ github.com/google/uuid
 github.com/googleapis/gax-go/v2
 github.com/googleapis/gax-go/v2/apierror
 github.com/googleapis/gax-go/v2/apierror/internal/proto
-# github.com/gophercloud/gophercloud v0.17.0
+# github.com/gophercloud/gophercloud v0.18.0
 ## explicit; go 1.13
 github.com/gophercloud/gophercloud
 github.com/gophercloud/gophercloud/openstack


### PR DESCRIPTION
Gophercloud v0.17.0 has an issue that causes it to fail when talking to a swift endpoint speaking HTTP2. This prevented CIRO from properly detecting available swift service, and thus forced it to failover to a cinder volume even when swift was available to the tenant.

Bumping gophercloud to v0.18.0 fixes the issue.