### PR TITLE
Revert "IR-295: upgrade to Go 1.19"

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.19-openshift-4.12
+  tag: rhel-8-release-golang-1.18-openshift-4.12

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-image-registry-operator
 COPY . .
 RUN make build

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PROG  := cluster-image-registry-operator
 
 GOLANGCI_LINT = _output/tools/golangci-lint
 GOLANGCI_LINT_CACHE = $(PWD)/_output/golangci-lint-cache
-GOLANGCI_LINT_VERSION = v1.50.0
+GOLANGCI_LINT_VERSION = v1.46.2
 
 GO_REQUIRED_MIN_VERSION = 1.16
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -23,7 +23,7 @@ const (
 // GetConfig creates a *rest.Config for talking to a Kubernetes apiserver.
 // Otherwise will assume running in cluster and use the cluster provided kubeconfig.
 //
-// # Config precedence
+// Config precedence
 //
 // * KUBECONFIG environment variable pointing at a file
 //

--- a/pkg/metrics/server_test.go
+++ b/pkg/metrics/server_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"io"
+	"io/ioutil"
 	"log"
 	"math/big"
 	"net/http"
@@ -63,7 +64,7 @@ func generateTempCertificates() (string, string, error) {
 		return "", "", err
 	}
 
-	cert, err := os.CreateTemp("", "testcert-")
+	cert, err := ioutil.TempFile("", "testcert-")
 	if err != nil {
 		return "", "", err
 	}
@@ -76,7 +77,7 @@ func generateTempCertificates() (string, string, error) {
 		return "", "", err
 	}
 
-	keyPath, err := os.CreateTemp("", "testkey-")
+	keyPath, err := ioutil.TempFile("", "testkey-")
 	if err != nil {
 		return "", "", err
 	}

--- a/pkg/operator/azurestackcloud.go
+++ b/pkg/operator/azurestackcloud.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -109,7 +110,7 @@ func (c *AzureStackCloudController) syncConfig() error {
 		return err
 	}
 
-	f, err := os.CreateTemp(filepath.Dir(filename), "azurestackcloud")
+	f, err := ioutil.TempFile(filepath.Dir(filename), "azurestackcloud")
 	if err != nil {
 		return err
 	}

--- a/pkg/resource/generator.go
+++ b/pkg/resource/generator.go
@@ -118,9 +118,8 @@ func (g *Generator) List(cr *imageregistryv1.Config) ([]Mutator, error) {
 // syncStorage checks:
 // 1.)  to make sure that an existing storage medium still exists and we can access it
 // 2.)  to see if the storage medium name changed and we need to:
-//
-//	a.) check to make sure that we can access the storage or
-//	b.) see if we need to try to create the new storage
+//      a.) check to make sure that we can access the storage or
+//      b.) see if we need to try to create the new storage
 func (g *Generator) syncStorage(cr *imageregistryv1.Config) error {
 	var runCreate bool
 	// Create a driver with the current configuration

--- a/pkg/storage/gcs/gcs_test.go
+++ b/pkg/storage/gcs/gcs_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
+	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -32,7 +32,7 @@ func (r *tripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	}()
 	return &http.Response{
 		StatusCode: r.responseCodes[r.req],
-		Body:       io.NopCloser(bytes.NewBufferString(r.responseBodies[r.req])),
+		Body:       ioutil.NopCloser(bytes.NewBufferString(r.responseBodies[r.req])),
 	}, nil
 }
 

--- a/pkg/storage/ibmcos/ibmcos_test.go
+++ b/pkg/storage/ibmcos/ibmcos_test.go
@@ -3,7 +3,7 @@ package ibmcos
 import (
 	"bytes"
 	"context"
-	"io"
+	"io/ioutil"
 	"net/http"
 	"path/filepath"
 	"testing"
@@ -361,7 +361,7 @@ func (r *tripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	return &http.Response{
 		StatusCode: r.responseCodes[r.req],
 		Header:     http.Header{"Content-Type": {"application/json"}},
-		Body:       io.NopCloser(bytes.NewBufferString(r.responseBodies[r.req])),
+		Body:       ioutil.NopCloser(bytes.NewBufferString(r.responseBodies[r.req])),
 	}, nil
 }
 

--- a/pkg/storage/oss/oss_test.go
+++ b/pkg/storage/oss/oss_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
+	"io/ioutil"
 	"net/http"
 	"reflect"
 	"testing"
@@ -251,7 +251,7 @@ func (r *tripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	}()
 
 	if req.Body != nil {
-		dt, err := io.ReadAll(req.Body)
+		dt, err := ioutil.ReadAll(req.Body)
 		if err != nil {
 			return nil, err
 		}
@@ -269,7 +269,7 @@ func (r *tripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 	return &http.Response{
 		StatusCode: code,
-		Body:       io.NopCloser(bytes.NewBufferString(respBody)),
+		Body:       ioutil.NopCloser(bytes.NewBufferString(respBody)),
 	}, nil
 }
 

--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -169,18 +170,14 @@ func (d *driver) UpdateEffectiveConfig() error {
 // GetCredentialsFile will create and return the location of an AWS config file that can
 // be used to create AWS clients with. Caller is responsible for cleaning up the file.
 // sharedCredentialsFile, err := d.GetCredentialsFile()
-//
-//	if err != nil {
-//		// handle error
-//	}
-//
+// if err != nil {
+// 	// handle error
+// }
 // defer os.Remove(sharedCredentialsFile)
-//
-//	options := session.Options{
-//		SharedConfigState: session.SharedConfigEnable,
-//		SharedConfigFiles: []string{sharedCredentialsFile},
-//	}
-//
+// options := session.Options{
+// 	SharedConfigState: session.SharedConfigEnable,
+// 	SharedConfigFiles: []string{sharedCredentialsFile},
+// }
 // sess := session.Must(session.NewSessionWithOptions(options))
 func (d *driver) GetCredentialsFile() (string, error) {
 	data, err := d.getCredentialsConfigData()
@@ -935,7 +932,7 @@ func (d *driver) ID() string {
 // an AWS ini-style credentials configuration file.
 // Caller is responsible for cleaning up the created file.
 func saveSharedCredentialsFile(data []byte) (string, error) {
-	f, err := os.CreateTemp("", "aws-shared-credentials")
+	f, err := ioutil.TempFile("", "aws-shared-credentials")
 	if err != nil {
 		return "", fmt.Errorf("failed to create file for shared credentials: %v", err)
 	}

--- a/pkg/storage/s3/s3_test.go
+++ b/pkg/storage/s3/s3_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/xml"
-	"io"
+	"io/ioutil"
 	"net/http"
 	"path/filepath"
 	"reflect"
@@ -362,7 +362,7 @@ func (r *tripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	}()
 
 	if req.Body != nil {
-		dt, err := io.ReadAll(req.Body)
+		dt, err := ioutil.ReadAll(req.Body)
 		if err != nil {
 			return nil, err
 		}
@@ -376,7 +376,7 @@ func (r *tripper) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	return &http.Response{
 		StatusCode: code,
-		Body:       io.NopCloser(bytes.NewBufferString("{}")),
+		Body:       ioutil.NopCloser(bytes.NewBufferString("{}")),
 	}, nil
 }
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -160,14 +160,14 @@ func NewDriver(cfg *imageregistryv1.ImageRegistryConfigStorage, kubeconfig *rest
 // replicas for this platform.
 //
 // Following rules apply:
-//   - If it is a known platform for which we have a backend implementation (e.g.
-//     AWS) we return a storage configuration that uses that implementation.
-//   - If it is a known platform and it doesn't provide any backend implementation,
-//     we return an empty storage configuration.
-//   - If it is a unknown platform we return a storage configuration with EmptyDir.
-//     This is useful as it easily allows other teams to experiment with OpenShift
-//     in new platforms, if it is LibVirt platform we also return EmptyDir for
-//     historical reasons.
+//  - If it is a known platform for which we have a backend implementation (e.g.
+//    AWS) we return a storage configuration that uses that implementation.
+//  - If it is a known platform and it doesn't provide any backend implementation,
+//    we return an empty storage configuration.
+//  - If it is a unknown platform we return a storage configuration with EmptyDir.
+//    This is useful as it easily allows other teams to experiment with OpenShift
+//    in new platforms, if it is LibVirt platform we also return EmptyDir for
+//    historical reasons.
 func GetPlatformStorage(listers *regopclient.StorageListers) (imageregistryv1.ImageRegistryConfigStorage, int32, error) {
 	var cfg imageregistryv1.ImageRegistryConfigStorage
 	replicas := int32(1)

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -427,7 +428,7 @@ func TestAWSUpdateCredentials(t *testing.T) {
 	}
 	defer os.Remove(sharedCredentialsFile)
 
-	credsBytes, err := os.ReadFile(sharedCredentialsFile)
+	credsBytes, err := ioutil.ReadFile(sharedCredentialsFile)
 	if err != nil {
 		t.Fatalf("failed to read in S3 driver's AWS configuration file: %s", err)
 	}
@@ -801,7 +802,7 @@ func createAWSConfigFile(awsSecret *corev1.Secret, kubeClient *framework.Clients
 		}
 
 		var tokenTempFile *os.File
-		if tokenTempFile, err = os.CreateTemp("", "cluster-image-registry-operator-test-token"); err != nil {
+		if tokenTempFile, err = ioutil.TempFile("", "cluster-image-registry-operator-test-token"); err != nil {
 			return
 		}
 		defer tokenTempFile.Close()
@@ -813,7 +814,7 @@ func createAWSConfigFile(awsSecret *corev1.Secret, kubeClient *framework.Clients
 		}
 
 		// create AWS config file pointing to token file
-		if awsConfigTempFile, err = os.CreateTemp("", "cluster-image-registry-operator-test-awsconfig"); err != nil {
+		if awsConfigTempFile, err = ioutil.TempFile("", "cluster-image-registry-operator-test-awsconfig"); err != nil {
 			return
 		}
 		defer awsConfigTempFile.Close()
@@ -830,7 +831,7 @@ func createAWSConfigFile(awsSecret *corev1.Secret, kubeClient *framework.Clients
 
 	} else {
 		// just use the Secret contents as-is
-		if awsConfigTempFile, err = os.CreateTemp("", "cluster-image-registry-operator-test-awsconfig"); err != nil {
+		if awsConfigTempFile, err = ioutil.TempFile("", "cluster-image-registry-operator-test-awsconfig"); err != nil {
 			return
 		}
 		defer awsConfigTempFile.Close()


### PR DESCRIPTION
Reverts openshift/cluster-image-registry-operator#805

At present this is a test revert to see if this PR might be the cause of https://issues.redhat.com/browse/OCPBUGS-3016