### PR TITLE
OCPBUGS-3974: check for nil pointer before dereferencing

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -176,7 +176,7 @@ func (c *ImagePrunerController) syncPrunerStatus(cr *imageregistryv1.ImagePruner
 		updatePrunerCondition(cr, "Failed", prunerLastJobStatus)
 	}
 
-	if *cr.Spec.Suspend {
+	if cr.Spec.Suspend != nil && *cr.Spec.Suspend {
 		prunerJobScheduled := operatorapiv1.OperatorCondition{
 			Status:  operatorapiv1.ConditionFalse,
 			Message: "The pruner job has been suspended",


### PR DESCRIPTION
a customer reported seeing this on OCP 4.10 - not sure why it hasn't shown up before tbh