### PR TITLE
[release-4.10] OCPBUGS-5974: swift: Retry connecting to OpenStack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PROG  := cluster-image-registry-operator
 
 GOLANGCI_LINT = _output/tools/golangci-lint
 GOLANGCI_LINT_CACHE = $(PWD)/_output/golangci-lint-cache
-GOLANGCI_LINT_VERSION = v1.24.0
+GOLANGCI_LINT_VERSION = v1.46.2
 
 GO_REQUIRED_MIN_VERSION = 1.16
 
@@ -43,7 +43,10 @@ verify: verify-gofmt verify-deps
 .PHONY: verify
 
 $(GOLANGCI_LINT):
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(dir $@) $(GOLANGCI_LINT_VERSION)
+	if [ ! -e $@ ] || ! $@ --version | grep -q $(patsubst v%,%,$(GOLANGCI_LINT_VERSION)); then \
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(dir $@) $(GOLANGCI_LINT_VERSION); \
+	fi
+.PHONY: $(GOLANGCI_LINT)
 
 verify-golangci-lint: $(GOLANGCI_LINT)
 	GOLANGCI_LINT_CACHE=$(GOLANGCI_LINT_CACHE) $(GOLANGCI_LINT) run --timeout=300s ./cmd/... ./pkg/... ./test/...

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -168,7 +168,11 @@ func GetPlatformStorage(listers *regopclient.Listers) (imageregistryv1.ImageRegi
 		cfg.IBMCOS = &imageregistryv1.ImageRegistryConfigStorageIBMCOS{}
 		replicas = 2
 	case configapiv1.OpenStackPlatformType:
-		if swift.IsSwiftEnabled(listers) {
+		swiftEnabled, err := swift.IsSwiftEnabled(listers)
+		if err != nil {
+			return cfg, 0, err
+		}
+		if swiftEnabled {
 			cfg.Swift = &imageregistryv1.ImageRegistryConfigStorageSwift{}
 			replicas = 2
 			break

--- a/pkg/storage/swift/swift_test.go
+++ b/pkg/storage/swift/swift_test.go
@@ -2,6 +2,7 @@ package swift
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -910,7 +911,9 @@ func TestSwiftIsAvailable(t *testing.T) {
 		Infrastructures: fakeInfrastructureLister(cloudName),
 		OpenShiftConfig: MockConfigMapNamespaceLister{},
 	}
-	th.AssertEquals(t, true, IsSwiftEnabled(listers))
+	isSwiftEnabled, err := IsSwiftEnabled(listers)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, true, isSwiftEnabled)
 }
 
 func TestSwiftIsNotAvailable(t *testing.T) {
@@ -953,8 +956,11 @@ func TestSwiftIsNotAvailable(t *testing.T) {
 
 	_, err := d.getSwiftClient()
 	// if Swift endpoint is not registered, getSwiftClient should return *ErrEndpointNotFound
-	_, ok := err.(*gophercloud.ErrEndpointNotFound)
-	th.AssertEquals(t, true, ok)
+	gophercloudNotFound := new(gophercloud.ErrEndpointNotFound)
+	th.AssertEquals(t, true, errors.As(err, &gophercloudNotFound))
+
+	// ...which should be reported as the sentinel error type ErrContainerEndpointNotFound
+	th.AssertEquals(t, true, errors.As(err, &ErrContainerEndpointNotFound{}))
 
 	// IsSwiftEnabled should return false in this case
 	listers := &regopclient.Listers{
@@ -962,7 +968,9 @@ func TestSwiftIsNotAvailable(t *testing.T) {
 		Infrastructures: fakeInfrastructureLister(cloudName),
 		OpenShiftConfig: MockConfigMapNamespaceLister{},
 	}
-	th.AssertEquals(t, false, IsSwiftEnabled(listers))
+	isSwiftEnabled, err := IsSwiftEnabled(listers)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, false, isSwiftEnabled)
 }
 
 func TestNoPermissionsKeystone(t *testing.T) {
@@ -1012,7 +1020,9 @@ func TestNoPermissionsKeystone(t *testing.T) {
 		Infrastructures: fakeInfrastructureLister(cloudName),
 		OpenShiftConfig: MockConfigMapNamespaceLister{},
 	}
-	th.AssertEquals(t, false, IsSwiftEnabled(listers))
+	isSwiftEnabled, err := IsSwiftEnabled(listers)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, false, isSwiftEnabled)
 }
 
 func TestNoPermissionsSwauth(t *testing.T) {
@@ -1062,7 +1072,9 @@ func TestNoPermissionsSwauth(t *testing.T) {
 		Infrastructures: fakeInfrastructureLister(cloudName),
 		OpenShiftConfig: MockConfigMapNamespaceLister{},
 	}
-	th.AssertEquals(t, false, IsSwiftEnabled(listers))
+	isSwiftEnabled, err := IsSwiftEnabled(listers)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, false, isSwiftEnabled)
 }
 
 func TestConfigStatusUpdate(t *testing.T) {


### PR DESCRIPTION
This is a cherry-pick of https://github.com/openshift/cluster-image-registry-operator/pull/830
This PR also cherry-picks https://github.com/openshift/cluster-image-registry-operator/pull/783 because older versions of `gosimple` trigger errors on my code, requiring it to be less explicit.

---

The function IsSwiftEnabled probes a connection to Swift to determine whether CIRO should fall back to using a persistent volume claim as a storage backend. This function runs on the OpenStack platform to provide an alternative solution for when Swift is not available.

Before this patch, any failure to communicate with Swift would make CIRO fall back to using a PVC. However, a failure to probing Swift could come from a temporary failure to reach the OpenStack API.

With this patch, when an issue with the connection to the OpenStack identity service is not allowing CIRO to probe Swift, the probing reports an error instead of directly falling back to Swift.

As a consequence, after this patch, temporary failures in early steps of the connection to Swift do not make CIRO fall back to using persistent volume claims when object storage might be available in OpenStack.