### PR TITLE
OCPBUGS-6175: OpenStack: Add support for Proxy

### DIFF
--- a/pkg/storage/swift/swift.go
+++ b/pkg/storage/swift/swift.go
@@ -248,6 +248,7 @@ func (d *driver) getSwiftClient() (*gophercloud.ServiceClient, error) {
 		certPool.AppendCertsFromPEM([]byte(cert))
 		client := http.Client{
 			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
 				TLSClientConfig: &tls.Config{
 					RootCAs: certPool,
 				},


### PR DESCRIPTION
This commit makes sure the Proxy env vars
are used when authenticating with OpenStack
API.