### PR TITLE
OCPBUGS-7371: swift: Retry connecting to OpenStack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PROG  := cluster-image-registry-operator
 
 GOLANGCI_LINT = _output/tools/golangci-lint
 GOLANGCI_LINT_CACHE = $(PWD)/_output/golangci-lint-cache
-GOLANGCI_LINT_VERSION = v1.24
+GOLANGCI_LINT_VERSION = v1.46.2
 
 GO_REQUIRED_MIN_VERSION = 1.16
 
@@ -44,7 +44,10 @@ verify: verify-fmt
 .PHONY: verify-fmt
 
 $(GOLANGCI_LINT):
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(dir $@) v1.24.0
+	if [ ! -e $@ ] || ! $@ --version | grep -q $(patsubst v%,%,$(GOLANGCI_LINT_VERSION)); then \
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(dir $@) $(GOLANGCI_LINT_VERSION); \
+	fi
+.PHONY: $(GOLANGCI_LINT)
 
 verify-golangci-lint: $(GOLANGCI_LINT)
 	GOLANGCI_LINT_CACHE=$(GOLANGCI_LINT_CACHE) $(GOLANGCI_LINT) run --timeout=300s ./cmd/... ./pkg/... ./test/...

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -159,7 +159,11 @@ func GetPlatformStorage(listers *regopclient.Listers) (imageregistryv1.ImageRegi
 		cfg.IBMCOS = &imageregistryv1.ImageRegistryConfigStorageIBMCOS{}
 		replicas = 2
 	case configapiv1.OpenStackPlatformType:
-		if swift.IsSwiftEnabled(listers) {
+		swiftEnabled, err := swift.IsSwiftEnabled(listers)
+		if err != nil {
+			return cfg, 0, err
+		}
+		if swiftEnabled {
 			cfg.Swift = &imageregistryv1.ImageRegistryConfigStorageSwift{}
 			replicas = 2
 			break

--- a/pkg/storage/swift/swift.go
+++ b/pkg/storage/swift/swift.go
@@ -3,6 +3,7 @@ package swift
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -19,7 +20,7 @@ import (
 	yamlv2 "gopkg.in/yaml.v2"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
 	k8sutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 
@@ -60,19 +61,26 @@ func replaceEmpty(a string, b string) string {
 }
 
 // IsSwiftEnabled checks if Swift service is available for OpenStack platform
-func IsSwiftEnabled(listers *regopclient.Listers) bool {
+func IsSwiftEnabled(listers *regopclient.Listers) (bool, error) {
 	driver := NewDriver(&imageregistryv1.ImageRegistryConfigStorageSwift{}, listers)
 	conn, err := driver.getSwiftClient()
 	if err != nil {
-		klog.Errorf("swift storage inaccessible: %v", err)
-		return false
+		if errors.As(err, &ErrContainerEndpointNotFound{}) {
+			klog.Errorf("error connecting to Swift: %v", err)
+			return false, nil
+		}
+		klog.Errorf("error connecting to OpenStack: %v", err)
+		return false, err
 	}
+
 	// Try to list containers to make sure the user has required permissions to do that
-	if _, err = containers.List(conn, containers.ListOpts{}).AllPages(); err != nil {
+	if err := containers.List(conn, containers.ListOpts{}).EachPage(func(_ pagination.Page) (bool, error) {
+		return false, nil
+	}); err != nil {
 		klog.Errorf("error listing swift containers: %v", err)
-		return false
+		return false, nil
 	}
-	return true
+	return true, nil
 }
 
 // GetConfig reads credentials
@@ -81,7 +89,7 @@ func GetConfig(listers *regopclient.Listers) (*Swift, error) {
 
 	// Look for a user defined secret to get the Swift credentials
 	sec, err := listers.Secrets.Get(defaults.ImageRegistryPrivateConfigurationUser)
-	if err != nil && errors.IsNotFound(err) {
+	if err != nil && apimachineryerrors.IsNotFound(err) {
 		// If no user defined credentials were provided, then try to find them in the secret,
 		// created by cloud-credential-operator.
 		sec, err = listers.Secrets.Get(defaults.CloudCredentialsName)
@@ -100,7 +108,7 @@ func GetConfig(listers *regopclient.Listers) (*Swift, error) {
 			var cloudName string
 			cloudInfra, err := util.GetInfrastructure(listers)
 			if err != nil {
-				if !errors.IsNotFound(err) {
+				if !apimachineryerrors.IsNotFound(err) {
 					return nil, fmt.Errorf("failed to get cluster infrastructure info: %v", err)
 				}
 			}
@@ -159,6 +167,15 @@ func getCloudProviderCert(listers *regopclient.Listers) (string, error) {
 	return string(cm.Data["ca-bundle.pem"]), nil
 }
 
+type ErrContainerEndpointNotFound struct {
+	wrapped error
+}
+
+func (err ErrContainerEndpointNotFound) Unwrap() error { return err.wrapped }
+func (err ErrContainerEndpointNotFound) Error() string {
+	return fmt.Sprintf("container endpoint not found in the OpenStack catalog: %v", err.wrapped)
+}
+
 // getSwiftClient returns a client that allows to interact with the OpenStack Swift service
 func (d *driver) getSwiftClient() (*gophercloud.ServiceClient, error) {
 	cfg, err := GetConfig(d.Listers)
@@ -185,18 +202,18 @@ func (d *driver) getSwiftClient() (*gophercloud.ServiceClient, error) {
 
 	provider, err := openstack.NewClient(opts.IdentityEndpoint)
 	if err != nil {
-		return nil, fmt.Errorf("Create new provider client failed: %v", err)
+		return nil, fmt.Errorf("failed to create a new OpenStack provider client: %w", err)
 	}
 
 	cert, err := getCloudProviderCert(d.Listers)
-	if err != nil && !errors.IsNotFound(err) {
+	if err != nil && !apimachineryerrors.IsNotFound(err) {
 		return nil, fmt.Errorf("Failed to get cloud provider CA certificate: %v", err)
 	}
 
 	if cert != "" {
 		certPool, err := x509.SystemCertPool()
 		if err != nil {
-			return nil, fmt.Errorf("Create system cert pool failed: %v", err)
+			return nil, fmt.Errorf("failed to read the system cert pool: %w", err)
 		}
 		certPool.AppendCertsFromPEM([]byte(cert))
 		client := http.Client{
@@ -211,7 +228,7 @@ func (d *driver) getSwiftClient() (*gophercloud.ServiceClient, error) {
 
 	err = openstack.Authenticate(provider, *opts)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to authenticate provider client: %v", err)
+		return nil, fmt.Errorf("failed to authenticate against OpenStack: %w", err)
 	}
 
 	endpointOpts := gophercloud.EndpointOpts{
@@ -219,16 +236,34 @@ func (d *driver) getSwiftClient() (*gophercloud.ServiceClient, error) {
 		Name:   "swift",
 	}
 
-	var client *gophercloud.ServiceClient
-	client, err = openstack.NewContainerV1(provider, endpointOpts)
-	if _, ok := err.(*gophercloud.ErrEndpointNotFound); ok {
-		endpointOpts.Type = "object-store"
-		client, err = openstack.NewContainerV1(provider, endpointOpts)
-		if err != nil {
-			return nil, err
+	client, err := openstack.NewContainerV1(provider, endpointOpts)
+	if err != nil {
+		if _, ok := err.(*gophercloud.ErrEndpointNotFound); ok {
+			// In gophercloud the default endpoint type for
+			// containers is "container". However, some OpenStack
+			// clouds are deployed with a single endpoint type for
+			// all Swift entities - "object-store".
+			//
+			// If a "container" endpoint is not found, then try
+			// "object-store".
+			endpointOpts.Type = "object-store"
+
+			var errOnAlternativeEndpoint error
+			client, errOnAlternativeEndpoint = openstack.NewContainerV1(provider, endpointOpts)
+			if errOnAlternativeEndpoint != nil {
+				if _, ok := errOnAlternativeEndpoint.(*gophercloud.ErrEndpointNotFound); ok {
+					// If none of the endpoints is found, then
+					// return the error we got on the default one
+					// so that we limit confusion on the error
+					// trace.
+					return nil, ErrContainerEndpointNotFound{err}
+				} else {
+					return nil, fmt.Errorf("failed to get the object storage alternative endpoint: %w", errOnAlternativeEndpoint)
+				}
+			}
+			return client, nil
 		}
-	} else if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get the object storage endpoint: %w", err)
 	}
 
 	return client, nil


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/cluster-image-registry-operator/pull/832

---

The function IsSwiftEnabled probes a connection to Swift to determine whether CIRO should fall back to using a persistent volume claim as a storage backend. This function runs on the OpenStack platform to provide an alternative solution for when Swift is not available.

Before this patch, any failure to communicate with Swift would make CIRO fall back to using a PVC. However, a failure to probing Swift could come from a temporary failure to reach the OpenStack API.

With this patch, when an issue with the connection to the OpenStack identity service is not allowing CIRO to probe Swift, the probing reports an error instead of directly falling back to Swift.

As a consequence, after this patch, temporary failures in early steps of the connection to Swift do not make CIRO fall back to using persistent volume claims when object storage might be available in OpenStack.

---

/jira cherrypick OCPBUGS-5974