### PR TITLE
OCPBUGS-12132: Updating ose-cluster-image-registry-operator images to be consistent with ART

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.19-openshift-4.14
+  tag: rhel-8-release-golang-1.20-openshift-4.14

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-image-registry-operator
 COPY . .
 RUN make build

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PROG  := cluster-image-registry-operator
 
 GOLANGCI_LINT = _output/tools/golangci-lint
 GOLANGCI_LINT_CACHE = $(PWD)/_output/golangci-lint-cache
-GOLANGCI_LINT_VERSION = v1.50.1
+GOLANGCI_LINT_VERSION = v1.51.0
 
 GO_REQUIRED_MIN_VERSION = 1.16
 

--- a/cmd/cluster-image-registry-operator/main.go
+++ b/cmd/cluster-image-registry-operator/main.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"flag"
 	"log"
-	"math/rand"
 	"os"
 	"runtime"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -63,7 +61,6 @@ func main() {
 				func(ctx context.Context, cctx *controllercmd.ControllerContext) error {
 					printVersion()
 					klog.Infof("Watching files %v...", filesToWatch)
-					rand.Seed(time.Now().UnixNano())
 					go metrics.RunServer(metricsPort)
 					return operator.RunOperator(ctx, cctx.KubeConfig)
 				},


### PR DESCRIPTION
Also bump golangci-lint, and fix a deprecation error.

* golangci-lint bug that required upgrade: https://github.com/golangci/golangci-lint/issues/3565
* deprecation error and the choice to simply removed the call: https://pkg.go.dev/math/rand#Seed