### PR TITLE
OCPVE-632: add capability annotations to manifests

### DIFF
--- a/manifests/0000_90_cluster-image-registry-operator_00_servicemonitor-rbac.yaml
+++ b/manifests/0000_90_cluster-image-registry-operator_00_servicemonitor-rbac.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: registry-monitoring
   annotations:
+    capability.openshift.io/name: ImageRegistry
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -20,6 +21,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: registry-monitoring
   annotations:
+    capability.openshift.io/name: ImageRegistry
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -39,6 +41,7 @@ metadata:
   name: prometheus-k8s
   namespace: openshift-image-registry
   annotations:
+    capability.openshift.io/name: ImageRegistry
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -60,6 +63,7 @@ metadata:
   name: prometheus-k8s
   namespace: openshift-image-registry
   annotations:
+    capability.openshift.io/name: ImageRegistry
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/0000_90_cluster-image-registry-operator_01_operand-servicemonitor.yaml
+++ b/manifests/0000_90_cluster-image-registry-operator_01_operand-servicemonitor.yaml
@@ -5,6 +5,7 @@ metadata:
   name: image-registry
   namespace: openshift-image-registry
   annotations:
+    capability.openshift.io/name: ImageRegistry
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/0000_90_cluster-image-registry-operator_02_operator-servicemonitor.yaml
+++ b/manifests/0000_90_cluster-image-registry-operator_02_operator-servicemonitor.yaml
@@ -5,6 +5,7 @@ metadata:
   name: image-registry-operator
   namespace: openshift-image-registry
   annotations:
+    capability.openshift.io/name: ImageRegistry
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/01-namespace.yaml
+++ b/manifests/01-namespace.yaml
@@ -4,6 +4,7 @@ kind: Namespace
 metadata:
   name: openshift-image-registry
   annotations:
+    capability.openshift.io/name: ImageRegistry
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""

--- a/manifests/01-registry-credentials-request-alibaba.yaml
+++ b/manifests/01-registry-credentials-request-alibaba.yaml
@@ -6,6 +6,7 @@ metadata:
   name: openshift-image-registry-alibaba
   namespace: openshift-cloud-credential-operator
   annotations:
+    capability.openshift.io/name: ImageRegistry
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/01-registry-credentials-request-azure.yaml
+++ b/manifests/01-registry-credentials-request-azure.yaml
@@ -6,6 +6,7 @@ metadata:
   name: openshift-image-registry-azure
   namespace: openshift-cloud-credential-operator
   annotations:
+    capability.openshift.io/name: ImageRegistry
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/01-registry-credentials-request-gcs.yaml
+++ b/manifests/01-registry-credentials-request-gcs.yaml
@@ -6,6 +6,7 @@ metadata:
   name: openshift-image-registry-gcs
   namespace: openshift-cloud-credential-operator
   annotations:
+    capability.openshift.io/name: ImageRegistry
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/01-registry-credentials-request-ibmcos.yaml
+++ b/manifests/01-registry-credentials-request-ibmcos.yaml
@@ -6,6 +6,7 @@ metadata:
   name: openshift-image-registry-ibmcos
   namespace: openshift-cloud-credential-operator
   annotations:
+    capability.openshift.io/name: ImageRegistry
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/01-registry-credentials-request-openstack.yaml
+++ b/manifests/01-registry-credentials-request-openstack.yaml
@@ -6,6 +6,7 @@ metadata:
   name: openshift-image-registry-openstack
   namespace: openshift-cloud-credential-operator
   annotations:
+    capability.openshift.io/name: ImageRegistry
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/01-registry-credentials-request-powervs.yaml
+++ b/manifests/01-registry-credentials-request-powervs.yaml
@@ -6,6 +6,7 @@ metadata:
   name: openshift-image-registry-ibmcos-powervs
   namespace: openshift-cloud-credential-operator
   annotations:
+    capability.openshift.io/name: ImageRegistry
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/01-registry-credentials-request.yaml
+++ b/manifests/01-registry-credentials-request.yaml
@@ -6,6 +6,7 @@ metadata:
   name: openshift-image-registry
   namespace: openshift-cloud-credential-operator
   annotations:
+    capability.openshift.io/name: ImageRegistry
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/02-rbac.yaml
+++ b/manifests/02-rbac.yaml
@@ -4,6 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cluster-image-registry-operator
   annotations:
+    capability.openshift.io/name: ImageRegistry
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -104,6 +105,7 @@ metadata:
   name: cluster-image-registry-operator
   namespace: openshift-image-registry
   annotations:
+    capability.openshift.io/name: ImageRegistry
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -142,6 +144,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: default-account-cluster-image-registry-operator
   annotations:
+    capability.openshift.io/name: ImageRegistry
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -160,6 +163,7 @@ metadata:
   name: cluster-image-registry-operator
   namespace: openshift-image-registry
   annotations:
+    capability.openshift.io/name: ImageRegistry
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/03-sa.yaml
+++ b/manifests/03-sa.yaml
@@ -5,6 +5,7 @@ metadata:
   name: cluster-image-registry-operator
   namespace: openshift-image-registry
   annotations:
+    capability.openshift.io/name: ImageRegistry
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/04-ca-trusted.yaml
+++ b/manifests/04-ca-trusted.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   annotations:
+    capability.openshift.io/name: ImageRegistry
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"

--- a/manifests/05-ca-rbac.yaml
+++ b/manifests/05-ca-rbac.yaml
@@ -5,6 +5,7 @@ metadata:
   name: node-ca
   namespace: openshift-image-registry
   annotations:
+    capability.openshift.io/name: ImageRegistry
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -24,6 +25,7 @@ metadata:
   name: node-ca
   namespace: openshift-image-registry
   annotations:
+    capability.openshift.io/name: ImageRegistry
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/06-ca-serviceaccount.yaml
+++ b/manifests/06-ca-serviceaccount.yaml
@@ -5,6 +5,7 @@ metadata:
   name: node-ca
   namespace: openshift-image-registry
   annotations:
+    capability.openshift.io/name: ImageRegistry
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/07-operator-ibm-cloud-managed.yaml
+++ b/manifests/07-operator-ibm-cloud-managed.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
+    capability.openshift.io/name: ImageRegistry
     config.openshift.io/inject-proxy: cluster-image-registry-operator
     include.release.openshift.io/ibm-cloud-managed: "true"
   name: cluster-image-registry-operator

--- a/manifests/07-operator-service.yaml
+++ b/manifests/07-operator-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
+    capability.openshift.io/name: ImageRegistry
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     service.alpha.openshift.io/serving-cert-secret-name: image-registry-operator-tls

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -5,6 +5,7 @@ metadata:
   name: cluster-image-registry-operator
   namespace: openshift-image-registry
   annotations:
+    capability.openshift.io/name: ImageRegistry
     config.openshift.io/inject-proxy: cluster-image-registry-operator
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/08-clusteroperator.yaml
+++ b/manifests/08-clusteroperator.yaml
@@ -3,6 +3,7 @@ kind: ClusterOperator
 metadata:
   name: image-registry
   annotations:
+    capability.openshift.io/name: ImageRegistry
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/09-prometheus-rules-imagestreams.yaml
+++ b/manifests/09-prometheus-rules-imagestreams.yaml
@@ -4,6 +4,7 @@ metadata:
   name: imagestreams-rules
   namespace: openshift-image-registry
   annotations:
+    capability.openshift.io/name: ImageRegistry
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/09-prometheus-rules-registry-operations.yaml
+++ b/manifests/09-prometheus-rules-registry-operations.yaml
@@ -4,6 +4,7 @@ metadata:
   name: image-registry-rules
   namespace: openshift-image-registry
   annotations:
+    capability.openshift.io/name: ImageRegistry
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/09-prometheus-rules.yaml
+++ b/manifests/09-prometheus-rules.yaml
@@ -4,6 +4,7 @@ metadata:
   name: image-registry-operator-alerts
   namespace: openshift-image-registry
   annotations:
+    capability.openshift.io/name: ImageRegistry
     release.openshift.io/delete: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -1,5 +1,8 @@
 kind: ImageStream
 apiVersion: image.openshift.io/v1
+metadata:
+  annotations:
+    capability.openshift.io/name: ImageRegistry
 spec:
   tags:
   - name: cluster-image-registry-operator

--- a/profile-patches/ibm-cloud-managed/07-operator.yaml-patch
+++ b/profile-patches/ibm-cloud-managed/07-operator.yaml-patch
@@ -1,6 +1,7 @@
 - op: replace
   path: /metadata/annotations
   value:
+    capability.openshift.io/name: ImageRegistry
     config.openshift.io/inject-proxy: cluster-image-registry-operator
     include.release.openshift.io/ibm-cloud-managed: "true"
 - op: remove


### PR DESCRIPTION
Add capability annotation to manifests to make image registry optional