### PR TITLE
.github: configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    assignees:
+      - flavianmissi
+    open-pull-requests-limit: 1


### PR DESCRIPTION
There's no way I know to check that enabling dependabot this way will work without any settings change (although github docs suggest it will work). I tested this on my fork and it happily created a PR so it works there at least (it is disabled on forks by default tho, for obvious reasons).