### PR TITLE
IR-390: Make a configmap for MCO to consume CAs

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -29,6 +29,12 @@ const (
 	// CAs to be trusted during image pullthrough
 	ImageRegistryCertificatesName = "image-registry-certificates"
 
+	// ImageRegistryCAName is the name of the configmap managed by the registry operator
+	// on the openshift-config-managed namespace. This config map is nearly identical to
+	// ImageRegistryCertificatesName, but it does not include the additionalTrustedCA
+	// from images.config.openshift.io/cluster.
+	ImageRegistryCAName = "image-registry-ca"
+
 	// ImageRegistryPrivateConfiguration is the name of a secret that is managed by the
 	// registry operator and which provides credentials to the registry for things like
 	// accessing S3 storage

--- a/pkg/operator/imageregistrycertificates.go
+++ b/pkg/operator/imageregistrycertificates.go
@@ -32,6 +32,7 @@ type ImageRegistryCertificatesController struct {
 	coreClient                corev1client.CoreV1Interface
 	operatorClient            v1helpers.OperatorClient
 	configMapLister           corev1listers.ConfigMapNamespaceLister
+	configMapManagedLister    corev1listers.ConfigMapNamespaceLister
 	serviceLister             corev1listers.ServiceNamespaceLister
 	imageConfigLister         configv1listers.ImageLister
 	openshiftConfigLister     corev1listers.ConfigMapNamespaceLister
@@ -60,6 +61,7 @@ func NewImageRegistryCertificatesController(
 		coreClient:                coreClient,
 		operatorClient:            operatorClient,
 		configMapLister:           configMapInformer.Lister().ConfigMaps(defaults.ImageRegistryOperatorNamespace),
+		configMapManagedLister:    configMapInformer.Lister().ConfigMaps(defaults.OpenShiftConfigManagedNamespace),
 		serviceLister:             serviceInformer.Lister().Services(defaults.ImageRegistryOperatorNamespace),
 		imageConfigLister:         imageConfigInformer.Lister(),
 		openshiftConfigLister:     openshiftConfigInformer.Lister().ConfigMaps(defaults.OpenShiftConfigNamespace),
@@ -149,6 +151,30 @@ func (c *ImageRegistryCertificatesController) sync() error {
 
 	g := resource.NewGeneratorCAConfig(c.configMapLister, c.imageConfigLister, c.openshiftConfigLister, c.serviceLister, c.imageRegistryConfigLister, c.storageListers, c.kubeconfig, c.coreClient)
 	err := resource.ApplyMutator(g)
+	if err != nil {
+		_, _, updateError := v1helpers.UpdateStatus(
+			ctx,
+			c.operatorClient,
+			v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
+				Type:    "ImageRegistryCertificatesControllerDegraded",
+				Status:  operatorv1.ConditionTrue,
+				Reason:  "Error",
+				Message: err.Error(),
+			}))
+		return utilerrors.NewAggregate([]error{err, updateError})
+	}
+
+	g = resource.NewGeneratorImageRegistryCA(
+		c.configMapManagedLister,
+		c.imageConfigLister,
+		c.openshiftConfigLister,
+		c.serviceLister,
+		c.imageRegistryConfigLister,
+		c.storageListers,
+		c.kubeconfig,
+		c.coreClient,
+	)
+	err = resource.ApplyMutator(g)
 	if err != nil {
 		_, _, updateError := v1helpers.UpdateStatus(
 			ctx,

--- a/pkg/operator/imageregistrycertificates.go
+++ b/pkg/operator/imageregistrycertificates.go
@@ -32,7 +32,7 @@ type ImageRegistryCertificatesController struct {
 	coreClient                corev1client.CoreV1Interface
 	operatorClient            v1helpers.OperatorClient
 	configMapLister           corev1listers.ConfigMapNamespaceLister
-	configMapManagedLister    corev1listers.ConfigMapNamespaceLister
+	configMapManagedLister    corev1listers.ConfigMapLister
 	serviceLister             corev1listers.ServiceNamespaceLister
 	imageConfigLister         configv1listers.ImageLister
 	openshiftConfigLister     corev1listers.ConfigMapNamespaceLister
@@ -61,7 +61,7 @@ func NewImageRegistryCertificatesController(
 		coreClient:                coreClient,
 		operatorClient:            operatorClient,
 		configMapLister:           configMapInformer.Lister().ConfigMaps(defaults.ImageRegistryOperatorNamespace),
-		configMapManagedLister:    configMapInformer.Lister().ConfigMaps(defaults.OpenShiftConfigManagedNamespace),
+		configMapManagedLister:    openshiftConfigManagedInformer.Lister(),
 		serviceLister:             serviceInformer.Lister().Services(defaults.ImageRegistryOperatorNamespace),
 		imageConfigLister:         imageConfigInformer.Lister(),
 		openshiftConfigLister:     openshiftConfigInformer.Lister().ConfigMaps(defaults.OpenShiftConfigNamespace),
@@ -165,6 +165,7 @@ func (c *ImageRegistryCertificatesController) sync() error {
 	}
 
 	g = resource.NewGeneratorImageRegistryCA(
+		c.configMapLister,
 		c.configMapManagedLister,
 		c.imageConfigLister,
 		c.openshiftConfigLister,

--- a/pkg/resource/generator.go
+++ b/pkg/resource/generator.go
@@ -44,6 +44,7 @@ func ApplyMutator(gen Mutator) error {
 
 			klog.Infof("object %s created: %s", Name(gen), str)
 			return nil
+
 		}
 
 		n, updated, err := gen.Update(o.DeepCopyObject())

--- a/pkg/resource/imageregistryca.go
+++ b/pkg/resource/imageregistryca.go
@@ -27,6 +27,7 @@ var _ Mutator = &generatorImageRegistryCA{}
 
 type generatorImageRegistryCA struct {
 	lister                    corelisters.ConfigMapNamespaceLister
+	managedLister             corelisters.ConfigMapLister
 	imageConfigLister         configlisters.ImageLister
 	openshiftConfigLister     corelisters.ConfigMapNamespaceLister
 	serviceLister             corelisters.ServiceNamespaceLister
@@ -38,6 +39,7 @@ type generatorImageRegistryCA struct {
 
 func NewGeneratorImageRegistryCA(
 	lister corelisters.ConfigMapNamespaceLister,
+	managedLister corelisters.ConfigMapLister,
 	imageConfigLister configlisters.ImageLister,
 	openshiftConfigLister corelisters.ConfigMapNamespaceLister,
 	serviceLister corelisters.ServiceNamespaceLister,
@@ -48,6 +50,7 @@ func NewGeneratorImageRegistryCA(
 ) Mutator {
 	return &generatorImageRegistryCA{
 		lister:                    lister,
+		managedLister:             managedLister,
 		imageConfigLister:         imageConfigLister,
 		openshiftConfigLister:     openshiftConfigLister,
 		serviceLister:             serviceLister,
@@ -157,7 +160,7 @@ func (girca *generatorImageRegistryCA) expected() (runtime.Object, error) {
 }
 
 func (girca *generatorImageRegistryCA) Get() (runtime.Object, error) {
-	return girca.lister.Get(girca.GetName())
+	return girca.managedLister.ConfigMaps(defaults.OpenShiftConfigManagedNamespace).Get(girca.GetName())
 }
 
 func (girca *generatorImageRegistryCA) Create() (runtime.Object, error) {

--- a/pkg/resource/imageregistryca.go
+++ b/pkg/resource/imageregistryca.go
@@ -23,9 +23,9 @@ import (
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage"
 )
 
-var _ Mutator = &generatorCAConfig{}
+var _ Mutator = &generatorImageRegistryCA{}
 
-type generatorCAConfig struct {
+type generatorImageRegistryCA struct {
 	lister                    corelisters.ConfigMapNamespaceLister
 	imageConfigLister         configlisters.ImageLister
 	openshiftConfigLister     corelisters.ConfigMapNamespaceLister
@@ -36,7 +36,7 @@ type generatorCAConfig struct {
 	client                    coreset.CoreV1Interface
 }
 
-func NewGeneratorCAConfig(
+func NewGeneratorImageRegistryCA(
 	lister corelisters.ConfigMapNamespaceLister,
 	imageConfigLister configlisters.ImageLister,
 	openshiftConfigLister corelisters.ConfigMapNamespaceLister,
@@ -46,7 +46,7 @@ func NewGeneratorCAConfig(
 	kubeconfig *restclient.Config,
 	client coreset.CoreV1Interface,
 ) Mutator {
-	return &generatorCAConfig{
+	return &generatorImageRegistryCA{
 		lister:                    lister,
 		imageConfigLister:         imageConfigLister,
 		openshiftConfigLister:     openshiftConfigLister,
@@ -58,20 +58,20 @@ func NewGeneratorCAConfig(
 	}
 }
 
-func (gcac *generatorCAConfig) Type() runtime.Object {
+func (girca *generatorImageRegistryCA) Type() runtime.Object {
 	return &corev1.ConfigMap{}
 }
 
-func (gcac *generatorCAConfig) GetNamespace() string {
-	return defaults.ImageRegistryOperatorNamespace
+func (girca *generatorImageRegistryCA) GetNamespace() string {
+	return defaults.OpenShiftConfigManagedNamespace
 }
 
-func (gcac *generatorCAConfig) GetName() string {
-	return defaults.ImageRegistryCertificatesName
+func (girca *generatorImageRegistryCA) GetName() string {
+	return defaults.ImageRegistryCAName
 }
 
-func (gcac *generatorCAConfig) storageDriver() (storage.Driver, bool, error) {
-	imageRegistryConfig, err := gcac.imageRegistryConfigLister.Get("cluster")
+func (girca *generatorImageRegistryCA) storageDriver() (storage.Driver, bool, error) {
+	imageRegistryConfig, err := girca.imageRegistryConfigLister.Get("cluster")
 	if errors.IsNotFound(err) {
 		return nil, false, nil
 	} else if err != nil {
@@ -84,7 +84,7 @@ func (gcac *generatorCAConfig) storageDriver() (storage.Driver, bool, error) {
 		return nil, false, nil
 	}
 
-	driver, err := storage.NewDriver(&imageRegistryConfig.Spec.Storage, gcac.kubeconfig, gcac.storageListers)
+	driver, err := storage.NewDriver(&imageRegistryConfig.Spec.Storage, girca.kubeconfig, girca.storageListers)
 	if err == storage.ErrStorageNotConfigured || storage.IsMultiStoragesError(err) {
 		return nil, false, nil
 	} else if err != nil {
@@ -96,11 +96,11 @@ func (gcac *generatorCAConfig) storageDriver() (storage.Driver, bool, error) {
 	return driver, canRedirect, nil
 }
 
-func (gcac *generatorCAConfig) expected() (runtime.Object, error) {
+func (girca *generatorImageRegistryCA) expected() (runtime.Object, error) {
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      gcac.GetName(),
-			Namespace: gcac.GetNamespace(),
+			Name:      girca.GetName(),
+			Namespace: girca.GetNamespace(),
 		},
 		Data:       map[string]string{},
 		BinaryData: map[string][]byte{},
@@ -108,16 +108,16 @@ func (gcac *generatorCAConfig) expected() (runtime.Object, error) {
 
 	var ownHostnameKeys []string
 
-	serviceCA, err := gcac.lister.Get(defaults.ServiceCAName)
+	serviceCA, err := girca.lister.Get(defaults.ServiceCAName)
 	if errors.IsNotFound(err) {
 		klog.V(4).Infof("missing the service CA configmap: %s", err)
 	} else if err != nil {
-		return cm, fmt.Errorf("%s: %s", gcac.GetName(), err)
+		return cm, fmt.Errorf("%s: %s", girca.GetName(), err)
 	} else {
 		if cert, ok := serviceCA.Data["service-ca.crt"]; ok {
-			internalHostnames, err := getServiceHostnames(gcac.serviceLister, defaults.ServiceName)
+			internalHostnames, err := getServiceHostnames(girca.serviceLister, defaults.ServiceName)
 			if err != nil {
-				return cm, fmt.Errorf("%s: %s", gcac.GetName(), err)
+				return cm, fmt.Errorf("%s: %s", girca.GetName(), err)
 			}
 			if len(internalHostnames) == 0 {
 				klog.Infof("unable to get the service name to add service-ca.crt")
@@ -133,37 +133,17 @@ func (gcac *generatorCAConfig) expected() (runtime.Object, error) {
 		}
 	}
 
-	imageConfig, err := gcac.imageConfigLister.Get(defaults.ImageConfigName)
-	if errors.IsNotFound(err) {
-		klog.V(4).Infof("missing the image config: %s", err)
-	} else if err != nil {
-		return cm, fmt.Errorf("%s: %s", gcac.GetName(), err)
-	} else if caConfigName := imageConfig.Spec.AdditionalTrustedCA.Name; caConfigName != "" {
-		upstreamConfig, err := gcac.openshiftConfigLister.Get(caConfigName)
-		if err != nil {
-			return nil, fmt.Errorf("%s: %s", gcac.GetName(), err)
-		}
-
-		for k, v := range upstreamConfig.Data {
-			cm.Data[k] = v
-		}
-		for k, v := range upstreamConfig.BinaryData {
-			cm.BinaryData[k] = v
-		}
-	}
-
-	driver, canRedirect, err := gcac.storageDriver()
+	driver, canRedirect, err := girca.storageDriver()
 	if err != nil {
-		return cm, fmt.Errorf("%s: %s", gcac.GetName(), err)
+		return cm, fmt.Errorf("%s: %s", girca.GetName(), err)
 	}
 	if driver != nil {
 		storageCABundle, _, err := driver.CABundle()
 		if err != nil {
-			return cm, fmt.Errorf("%s: %s", gcac.GetName(), err)
+			return cm, fmt.Errorf("%s: %s", girca.GetName(), err)
 		}
 		if storageCABundle != "" {
 			klog.V(4).Infof("using storage ca bundle (%d bytes)", len(storageCABundle))
-			cm.Data["storage-ca-bundle.pem"] = storageCABundle
 			if canRedirect {
 				klog.V(4).Infof("injecting storage ca bundle into registry certificates...")
 				for _, key := range ownHostnameKeys {
@@ -176,51 +156,32 @@ func (gcac *generatorCAConfig) expected() (runtime.Object, error) {
 	return cm, nil
 }
 
-func (gcac *generatorCAConfig) Get() (runtime.Object, error) {
-	return gcac.lister.Get(gcac.GetName())
+func (girca *generatorImageRegistryCA) Get() (runtime.Object, error) {
+	return girca.lister.Get(girca.GetName())
 }
 
-func (gcac *generatorCAConfig) Create() (runtime.Object, error) {
-	return commonCreate(gcac, func(obj runtime.Object) (runtime.Object, error) {
-		return gcac.client.ConfigMaps(gcac.GetNamespace()).Create(
+func (girca *generatorImageRegistryCA) Create() (runtime.Object, error) {
+	return commonCreate(girca, func(obj runtime.Object) (runtime.Object, error) {
+		return girca.client.ConfigMaps(girca.GetNamespace()).Create(
 			context.TODO(), obj.(*corev1.ConfigMap), metav1.CreateOptions{},
 		)
 	})
 }
 
-func (gcac *generatorCAConfig) Update(o runtime.Object) (runtime.Object, bool, error) {
-	return commonUpdate(gcac, o, func(obj runtime.Object) (runtime.Object, error) {
-		return gcac.client.ConfigMaps(gcac.GetNamespace()).Update(
+func (girca *generatorImageRegistryCA) Update(o runtime.Object) (runtime.Object, bool, error) {
+	return commonUpdate(girca, o, func(obj runtime.Object) (runtime.Object, error) {
+		return girca.client.ConfigMaps(girca.GetNamespace()).Update(
 			context.TODO(), obj.(*corev1.ConfigMap), metav1.UpdateOptions{},
 		)
 	})
 }
 
-func (gcac *generatorCAConfig) Delete(opts metav1.DeleteOptions) error {
-	return gcac.client.ConfigMaps(gcac.GetNamespace()).Delete(
-		context.TODO(), gcac.GetName(), opts,
+func (girca *generatorImageRegistryCA) Delete(opts metav1.DeleteOptions) error {
+	return girca.client.ConfigMaps(girca.GetNamespace()).Delete(
+		context.TODO(), girca.GetName(), opts,
 	)
 }
 
-func (g *generatorCAConfig) Owned() bool {
+func (g *generatorImageRegistryCA) Owned() bool {
 	return true
-}
-
-func getServiceHostnames(serviceLister corelisters.ServiceNamespaceLister, serviceName string) ([]string, error) {
-	svc, err := serviceLister.Get(serviceName)
-	if errors.IsNotFound(err) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	port := ""
-	if svc.Spec.Ports[0].Port != 443 {
-		port = fmt.Sprintf(":%d", svc.Spec.Ports[0].Port)
-	}
-	return []string{
-		fmt.Sprintf("%s.%s.svc%s", svc.Name, svc.Namespace, port),
-		fmt.Sprintf("%s.%s.svc.cluster.local%s", svc.Name, svc.Namespace, port),
-	}, nil
 }


### PR DESCRIPTION
Took Flavian's work on the current PR, and fixed the configmap already exists bug. This should be good to go in tandem with:  https://github.com/openshift/machine-config-operator/pull/3770