### PR TITLE
IR-363: Update Azure Credentials Request manifest of the Cluster Image Registry Operator to use new API field for requesting permissions

### DIFF
--- a/manifests/01-registry-credentials-request-azure.yaml
+++ b/manifests/01-registry-credentials-request-azure.yaml
@@ -19,6 +19,19 @@ spec:
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: AzureProviderSpec
-    roleBindings:
-    - role: Storage Blob Data Contributor
-    - role: Contributor
+    permissions:
+      - Microsoft.Storage/storageAccounts/blobServices/read
+      - Microsoft.Storage/storageAccounts/blobServices/containers/read
+      - Microsoft.Storage/storageAccounts/blobServices/containers/write
+      - Microsoft.Storage/storageAccounts/blobServices/generateUserDelegationKey/action
+      - Microsoft.Storage/storageAccounts/read
+      - Microsoft.Storage/storageAccounts/write
+      - Microsoft.Storage/storageAccounts/delete
+      - Microsoft.Storage/storageAccounts/listKeys/action
+      - Microsoft.Resources/tags/write
+    dataPermissions:
+      - Microsoft.Storage/storageAccounts/blobServices/containers/blobs/delete
+      - Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write
+      - Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read
+      - Microsoft.Storage/storageAccounts/blobServices/containers/blobs/add/action
+      - Microsoft.Storage/storageAccounts/blobServices/containers/blobs/move/action


### PR DESCRIPTION
Utilizes new `CredentialsRequests` API field `dataPermissions` for necessary blob data actions as per the `Storage Blob Data Contributor` Azure built-in role.

[IR-363](https://issues.redhat.com//browse/IR-363)
supersedes #859