### PR TITLE
OCPBUGS-17882: Add rbac permission IDMS, ITMS

### DIFF
--- a/pkg/resource/clusterrole.go
+++ b/pkg/resource/clusterrole.go
@@ -95,6 +95,14 @@ func (gcr *generatorClusterRole) expected() (runtime.Object, error) {
 					"imagecontentsourcepolicies",
 				},
 			},
+			{
+				Verbs:     []string{"list"},
+				APIGroups: []string{"config.openshift.io"},
+				Resources: []string{
+					"imagedigestmirrorsets",
+					"imagetagmirrorsets",
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
Fix the permission [failure](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.14-e2e-metal-ipi-ovn-ipv6/1683491930010292224/artifacts/e2e-metal-ipi-ovn-ipv6/gather-extra/artifacts/pods/openshift-image-registry_image-registry-6c5b5c794b-6nn7w_registry.log) caused by https://github.com/openshift/image-registry/pull/346