### PR TITLE
TRT-1193: Revert "IR-373: remove node-ca daemon"

### DIFF
--- a/bindata/assets.go
+++ b/bindata/assets.go
@@ -1,0 +1,19 @@
+package assets
+
+import (
+	"embed"
+)
+
+//go:embed *.yaml
+var f embed.FS
+
+// MustAsset reads and returns the content of the named file or panics
+// if something went wrong.
+func MustAsset(name string) []byte {
+	data, err := f.ReadFile(name)
+	if err != nil {
+		panic(err)
+	}
+
+	return data
+}

--- a/bindata/nodecadaemon.yaml
+++ b/bindata/nodecadaemon.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-ca
+  namespace: openshift-image-registry
+spec:
+  selector:
+    matchLabels:
+      name: node-ca
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
+  template:
+    metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      labels:
+        name: node-ca
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-cluster-critical
+      tolerations:
+      - operator: Exists
+      hostNetwork: true # run as host network to tolerate unready networks
+      serviceAccountName: node-ca
+      containers:
+      - name: node-ca
+        securityContext:
+          privileged: true
+          runAsUser: 1001
+          runAsGroup: 0
+        image: docker.io/openshift/origin-cluster-image-registry-operator:latest
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        command:
+        - "/bin/sh"
+        - "-c"
+        - |
+          trap 'jobs -p | xargs -r kill; echo shutting down node-ca; exit 0' TERM
+          while [ true ];
+          do
+            for f in $(ls /tmp/serviceca); do
+                echo $f
+                ca_file_path="/tmp/serviceca/${f}"
+                f=$(echo $f | sed  -r 's/(.*)\.\./\1:/')
+                reg_dir_path="/etc/docker/certs.d/${f}"
+                if [ -e "${reg_dir_path}" ]; then
+                    cp -u $ca_file_path $reg_dir_path/ca.crt
+                else
+                    mkdir $reg_dir_path
+                    cp $ca_file_path $reg_dir_path/ca.crt
+                fi
+            done
+            for d in $(ls /etc/docker/certs.d); do
+                echo $d
+                dp=$(echo $d | sed  -r 's/(.*):/\1\.\./')
+                reg_conf_path="/tmp/serviceca/${dp}"
+                if [ ! -e "${reg_conf_path}" ]; then
+                    rm -rf /etc/docker/certs.d/$d
+                fi
+            done
+            sleep 60 & wait ${!}
+          done
+        volumeMounts:
+        - name: serviceca
+          mountPath: /tmp/serviceca
+        - name: host
+          mountPath: /etc/docker/certs.d
+      volumes:
+      - name: host
+        hostPath:
+          path: /etc/docker/certs.d
+      - name: serviceca
+        configMap:
+          name: image-registry-certificates

--- a/pkg/resource/nodecadaemon.go
+++ b/pkg/resource/nodecadaemon.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"context"
+	"os"
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -10,9 +11,14 @@ import (
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
+	assets "github.com/openshift/cluster-image-registry-operator/bindata"
 	"github.com/openshift/cluster-image-registry-operator/pkg/defaults"
 )
 
@@ -52,12 +58,52 @@ func (ds *generatorNodeCADaemonSet) Get() (runtime.Object, error) {
 	return ds.daemonSetLister.Get(ds.GetName())
 }
 
+func (ds *generatorNodeCADaemonSet) expected() *appsv1.DaemonSet {
+	daemonSet := resourceread.ReadDaemonSetV1OrDie(assets.MustAsset("nodecadaemon.yaml"))
+	daemonSet.Spec.Template.Spec.Containers[0].Image = os.Getenv("IMAGE")
+	return daemonSet
+}
+
 func (ds *generatorNodeCADaemonSet) Create() (runtime.Object, error) {
-	return nil, nil
+	dep, _, err := ds.Update(nil)
+	return dep, err
 }
 
 func (ds *generatorNodeCADaemonSet) Update(o runtime.Object) (runtime.Object, bool, error) {
-	return nil, false, nil
+	desiredDaemonSet := ds.expected()
+
+	_, opStatus, _, err := ds.operatorClient.GetOperatorState()
+	if err != nil {
+		return nil, false, err
+	}
+	actualDaemonSet, updated, err := resourceapply.ApplyDaemonSet(
+		context.TODO(),
+		ds.client,
+		ds.eventRecorder,
+		desiredDaemonSet,
+		resourcemerge.ExpectedDaemonSetGeneration(desiredDaemonSet, opStatus.Generations),
+	)
+	if err != nil {
+		return o, updated, err
+	}
+
+	if updated {
+		updateStatusFn := func(newStatus *operatorv1.OperatorStatus) error {
+			resourcemerge.SetDaemonSetGeneration(&newStatus.Generations, actualDaemonSet)
+			return nil
+		}
+
+		_, _, err = v1helpers.UpdateStatus(
+			context.TODO(),
+			ds.operatorClient,
+			updateStatusFn,
+		)
+		if err != nil {
+			return actualDaemonSet, updated, err
+		}
+	}
+
+	return actualDaemonSet, updated, nil
 }
 
 func (ds *generatorNodeCADaemonSet) Delete(opts metav1.DeleteOptions) error {

--- a/pkg/resource/nodecadaemon_test.go
+++ b/pkg/resource/nodecadaemon_test.go
@@ -1,0 +1,69 @@
+package resource
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kfake "k8s.io/client-go/kubernetes/fake"
+
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+	imageregistryfake "github.com/openshift/client-go/imageregistry/clientset/versioned/fake"
+	imageregistryinformers "github.com/openshift/client-go/imageregistry/informers/externalversions"
+	"github.com/openshift/library-go/pkg/operator/events"
+
+	"github.com/openshift/cluster-image-registry-operator/pkg/client"
+)
+
+func findToleration(list []corev1.Toleration, cond func(toleration corev1.Toleration) bool) *corev1.Toleration {
+	for i, t := range list {
+		if cond(t) {
+			return &list[i]
+		}
+	}
+	return nil
+}
+
+func TestNodeCADaemon(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	imageregistryObjects := []runtime.Object{
+		&imageregistryv1.Config{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cluster",
+			},
+		},
+	}
+
+	clientset := kfake.NewSimpleClientset()
+	imageregistryClient := imageregistryfake.NewSimpleClientset(imageregistryObjects...)
+
+	imageregistryInformers := imageregistryinformers.NewSharedInformerFactory(imageregistryClient, time.Minute)
+
+	operatorClient := client.NewConfigOperatorClient(
+		imageregistryClient.ImageregistryV1().Configs(),
+		imageregistryInformers.Imageregistry().V1().Configs(),
+	)
+
+	imageregistryInformers.Start(ctx.Done())
+	imageregistryInformers.WaitForCacheSync(ctx.Done())
+
+	g := NewGeneratorNodeCADaemonSet(events.NewInMemoryRecorder("image-registry-operator"), nil, nil, clientset.AppsV1(), operatorClient)
+	obj, err := g.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ds := obj.(*appsv1.DaemonSet)
+	noScheduleToleration := findToleration(ds.Spec.Template.Spec.Tolerations, func(tol corev1.Toleration) bool {
+		return tol.Key == "" && tol.Operator == "Exists" && tol.Value == "" && tol.Effect == ""
+	})
+	if noScheduleToleration == nil {
+		t.Errorf("unable to find toleration for all taints, %#+v", ds.Spec.Template.Spec.Tolerations)
+	}
+}

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -78,6 +78,7 @@ func TestAWSDefaults(t *testing.T) {
 	framework.EnsureClusterOperatorStatusIsNormal(te)
 	framework.EnsureOperatorIsNotHotLooping(te)
 	framework.EnsureServiceCAConfigMap(te)
+	framework.EnsureNodeCADaemonSetIsAvailable(te)
 
 	s3Driver := storages3.NewDriver(context.Background(), nil, &mockLister.StorageListers)
 	err = s3Driver.UpdateEffectiveConfig()

--- a/test/e2e/graceful_shutdown_test.go
+++ b/test/e2e/graceful_shutdown_test.go
@@ -9,9 +9,92 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	imageregistryapiv1 "github.com/openshift/api/imageregistry/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+
 	"github.com/openshift/cluster-image-registry-operator/pkg/defaults"
 	"github.com/openshift/cluster-image-registry-operator/test/framework"
 )
+
+func TestNodeCAGracefulShutdown(t *testing.T) {
+	te := framework.Setup(t)
+
+	framework.DeployImageRegistry(te, &imageregistryapiv1.ImageRegistrySpec{
+		OperatorSpec: operatorv1.OperatorSpec{
+			ManagementState: operatorv1.Removed,
+		},
+	})
+	defer framework.TeardownImageRegistry(te)
+
+	framework.WaitUntilImageRegistryIsAvailable(te)
+	framework.EnsureNodeCADaemonSetIsAvailable(te)
+
+	pods, err := te.Client().Pods(defaults.ImageRegistryOperatorNamespace).List(
+		context.Background(), metav1.ListOptions{
+			LabelSelector: "name=node-ca",
+		},
+	)
+	if err != nil {
+		t.Fatalf("unable to list pods: %v", err)
+	}
+
+	if len(pods.Items) == 0 {
+		t.Fatalf("no node-ca pods found")
+	}
+
+	var pod *corev1.Pod
+	var logch <-chan string
+	var errch <-chan error
+	for _, p := range pods.Items {
+		if p.Status.Phase != "Running" {
+			t.Logf("skipping pod %s: phase=%s", p.Name, p.Status.Phase)
+			continue
+		}
+
+		if logch, errch, err = framework.FollowPodLog(te.Client(), p); err != nil {
+			t.Logf("unable to follow log on pod %s: %v", p.Name, err)
+			continue
+		}
+
+		pod = &p
+		break
+	}
+	if pod == nil {
+		t.Fatal("unable to attach to any pod log stream")
+	}
+
+	if err := te.Client().Pods(defaults.ImageRegistryOperatorNamespace).Delete(
+		context.Background(), pod.Name, metav1.DeleteOptions{},
+	); err != nil {
+		t.Fatalf("error deleting pod: %v", err)
+	}
+
+	timeout := time.NewTimer(time.Minute)
+	defer timeout.Stop()
+	for {
+		select {
+		case <-timeout.C:
+			t.Fatal("timeout awaiting for pod to die.")
+		case err, more := <-errch:
+			if !more {
+				errch = nil
+				break
+			}
+			t.Fatalf("error reading pod log: %v", err)
+		case line, more := <-logch:
+			if !more {
+				t.Fatal("pod died, no graceful message found.")
+			}
+			// this is the log line node-ca pods print when they
+			// gorgeously die, if we find this it means that the
+			// pod had manage to exit properly so we can end this
+			// test successfully.
+			if strings.HasPrefix(line, "shutting down node-ca") {
+				return
+			}
+		}
+	}
+}
 
 func TestImageRegistryGracefulShutdown(t *testing.T) {
 	te := framework.SetupAvailableImageRegistry(t, nil)

--- a/test/e2e/nodecadaemon_test.go
+++ b/test/e2e/nodecadaemon_test.go
@@ -1,0 +1,129 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/cluster-image-registry-operator/pkg/defaults"
+	"github.com/openshift/cluster-image-registry-operator/test/framework"
+)
+
+func TestNodeCADaemonAlwaysDeployed(t *testing.T) {
+	te := framework.Setup(t)
+	defer framework.TeardownImageRegistry(te)
+
+	framework.DeployImageRegistry(te, &imageregistryv1.ImageRegistrySpec{
+		OperatorSpec: operatorv1.OperatorSpec{
+			ManagementState: operatorv1.Removed,
+		},
+		Replicas: 1,
+	})
+	framework.WaitUntilImageRegistryIsAvailable(te)
+
+	t.Log("waiting until the node-ca daemon is deployed")
+	err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, framework.AsyncOperationTimeout, false,
+		func(ctx context.Context) (stop bool, err error) {
+			ds, err := te.Client().DaemonSets(defaults.ImageRegistryOperatorNamespace).Get(
+				ctx, "node-ca", metav1.GetOptions{},
+			)
+			if errors.IsNotFound(err) {
+				t.Logf("ds/node-ca has not been created yet: %s", err)
+				return false, nil
+			} else if err != nil {
+				return false, err
+			}
+
+			if ds.Status.NumberAvailable == 0 {
+				t.Logf("ds/node-ca has no available replicas")
+				return false, nil
+			}
+
+			return true, nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNodeCADaemonChangesReverted(t *testing.T) {
+	te := framework.SetupAvailableImageRegistry(t, &imageregistryv1.ImageRegistrySpec{
+		OperatorSpec: operatorv1.OperatorSpec{
+			ManagementState: operatorv1.Managed,
+		},
+		Storage: imageregistryv1.ImageRegistryConfigStorage{
+			EmptyDir: &imageregistryv1.ImageRegistryConfigStorageEmptyDir{},
+		},
+		Replicas: 1,
+	})
+	defer framework.TeardownImageRegistry(te)
+
+	t.Log("waiting until the node-ca daemonset is created")
+	err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, framework.AsyncOperationTimeout, false,
+		func(ctx context.Context) (stop bool, err error) {
+			_, err = te.Client().DaemonSets(defaults.ImageRegistryOperatorNamespace).Get(
+				ctx, "node-ca", metav1.GetOptions{},
+			)
+			if errors.IsNotFound(err) {
+				t.Logf("ds/node-ca has not been created yet: %s", err)
+				return false, nil
+			} else if err != nil {
+				return false, err
+			}
+
+			return true, nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("changing the node-ca daemonset")
+	if _, err := te.Client().DaemonSets(defaults.ImageRegistryOperatorNamespace).Patch(
+		context.Background(),
+		"node-ca",
+		types.JSONPatchType,
+		framework.MarshalJSON([]framework.JSONPatch{
+			{
+				Op:   "remove",
+				Path: "/spec/template/spec/tolerations",
+			},
+		}),
+		metav1.PatchOptions{},
+	); err != nil {
+		t.Fatalf("unable to remove tolerations from node-ca: %s", err)
+	}
+
+	if err := wait.PollUntilContextTimeout(context.Background(), time.Second, framework.AsyncOperationTimeout, false,
+		func(ctx context.Context) (stop bool, err error) {
+			ds, err := te.Client().DaemonSets(defaults.ImageRegistryOperatorNamespace).Get(
+				ctx, "node-ca", metav1.GetOptions{},
+			)
+			if err != nil {
+				return false, fmt.Errorf("unable to get node-ca: %s", err)
+			}
+
+			t.Logf("node-ca tolerations: %#v", ds.Spec.Template.Spec.Tolerations)
+
+			return reflect.DeepEqual(
+				ds.Spec.Template.Spec.Tolerations,
+				[]corev1.Toleration{
+					{Operator: corev1.TolerationOpExists},
+				},
+			), nil
+		}); err != nil {
+		t.Fatalf("failed to wait until node-ca is restored: %s", err)
+	}
+}

--- a/test/e2e/pruner_test.go
+++ b/test/e2e/pruner_test.go
@@ -35,6 +35,7 @@ func TestPruneRegistryFlag(t *testing.T) {
 	framework.EnsureInternalRegistryHostnameIsSet(te)
 	framework.EnsureOperatorIsNotHotLooping(te)
 	framework.EnsureServiceCAConfigMap(te)
+	framework.EnsureNodeCADaemonSetIsAvailable(te)
 
 	cr, err := te.Client().Configs().Get(
 		context.Background(), defaults.ImageRegistryResourceName, metav1.GetOptions{},
@@ -118,6 +119,7 @@ func TestPruner(t *testing.T) {
 	framework.EnsureInternalRegistryHostnameIsSet(te)
 	framework.EnsureOperatorIsNotHotLooping(te)
 	framework.EnsureServiceCAConfigMap(te)
+	framework.EnsureNodeCADaemonSetIsAvailable(te)
 
 	// Check that the pruner custom resource was created
 	cr, err := te.Client().ImagePruners().Get(

--- a/test/framework/daemonset.go
+++ b/test/framework/daemonset.go
@@ -1,0 +1,49 @@
+package framework
+
+import (
+	"context"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/openshift/cluster-image-registry-operator/pkg/defaults"
+)
+
+func EnsureNodeCADaemonSetIsAvailable(te TestEnv) {
+	_, err := WaitForNodeCADaemonSet(te.Client())
+	if err != nil {
+		te.Fatal(err)
+	}
+}
+
+func WaitForNodeCADaemonSet(client *Clientset) (*appsv1.DaemonSet, error) {
+	var ds *appsv1.DaemonSet
+	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, AsyncOperationTimeout, false,
+		func(ctx context.Context) (stop bool, err error) {
+			ds, err = client.DaemonSets(defaults.ImageRegistryOperatorNamespace).Get(
+				ctx, "node-ca", metav1.GetOptions{},
+			)
+			if err == nil {
+				return ds.Status.NumberAvailable > 0, nil
+			}
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		},
+	)
+	return ds, err
+}
+
+func DumpNodeCADaemonSet(te TestEnv) {
+	ds, err := te.Client().DaemonSets(OperatorDeploymentNamespace).Get(
+		context.Background(), "node-ca", metav1.GetOptions{},
+	)
+	if err != nil {
+		te.Logf("failed to get the node-ca daemonset: %v", err)
+	}
+	DumpYAML(te, "the node-ca daemonset", ds)
+}


### PR DESCRIPTION
Reverts openshift/cluster-image-registry-operator#867

I think Hypershift conformance is breaking on this https://issues.redhat.com/browse/TRT-1193 blocking nightlies

https://testgrid.k8s.io/redhat-hypershift#4.14-aws-ovn-conformance&width=20

Images failing to pull from the local registry during conformance tests.

`registry` pod logs show lots of `remote error: tls: bad certificate` where there were none before.