### PR TITLE
OCPBUGS-18469: increase storage account key cache expiration

### DIFF
--- a/pkg/storage/azure/cached_key.go
+++ b/pkg/storage/azure/cached_key.go
@@ -10,6 +10,9 @@ import (
 	"github.com/openshift/cluster-image-registry-operator/pkg/metrics"
 )
 
+// cacheExpiration is the cache expiration duration in minutes.
+const cacheExpiration time.Duration = 20 * time.Minute
+
 // primaryKey keeps account primary key in a cache.
 var primaryKey cachedKey
 
@@ -44,6 +47,6 @@ func (k *cachedKey) get(
 	k.resourceGroup = resourceGroup
 	k.account = account
 	k.value = *(*keysResponse.Keys)[0].Value
-	k.expire = time.Now().Add(5 * time.Minute)
+	k.expire = time.Now().Add(cacheExpiration)
 	return k.value, nil
 }


### PR DESCRIPTION
make it 20 minutes instead of 5.

Azure has an api limit for storage account list (which apparently listing keys uses behind the scenes) of 100 calls / 5 minutes. if a project has a lot of clusters, this limit might be hit.