### PR TITLE
OCPBUGS-21853: disable http2 for metrics endpoint

### DIFF
--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net/http"
 
@@ -32,8 +33,9 @@ func RunServer(port int) {
 	router := http.NewServeMux()
 	router.Handle("/metrics", handler)
 	srv := &http.Server{
-		Addr:    bindAddr,
-		Handler: router,
+		Addr:         bindAddr,
+		Handler:      router,
+		TLSNextProto: map[string]func(*http.Server, *tls.Conn, http.Handler){}, // disable HTTP/2
 	}
 
 	if err := srv.ListenAndServeTLS(tlsCRT, tlsKey); err != nil {


### PR DESCRIPTION
Looks like [CVE-2023-39325](https://github.com/advisories/GHSA-4374-p667-p6c8) and [CVE-2023-44487](https://github.com/advisories/GHSA-qppj-fm5r-hxr3) may not have been fully mitigated by recent go patches (see https://github.com/golang/go/issues/63417#issuecomment-1758858612).

From [Go docs](https://pkg.go.dev/net/http#hdr-HTTP_2):

> Starting with Go 1.6, the http package has transparent support for the HTTP/2 protocol when using HTTPS. Programs that must disable HTTP/2 can do so by setting Transport.TLSNextProto (for clients) or Server.TLSNextProto (for servers) to a non-nil, empty map.

To minimize risk, we're disabling HTTP/2 in the metrics endpoint.