### PR TITLE
OCPBUGS-28230: add FallbackToLogsOnError for easier debugging

### DIFF
--- a/bindata/nodecadaemon.yaml
+++ b/bindata/nodecadaemon.yaml
@@ -65,6 +65,7 @@ spec:
             done
             sleep 60 & wait ${!}
           done
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: serviceca
           mountPath: /tmp/serviceca

--- a/manifests/07-operator-ibm-cloud-managed.yaml
+++ b/manifests/07-operator-ibm-cloud-managed.yaml
@@ -56,6 +56,7 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/configmaps/trusted-ca/
           name: trusted-ca

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -74,6 +74,7 @@ spec:
               value: quay.io/openshift/origin-cli:v4.0
             - name: AZURE_ENVIRONMENT_FILEPATH
               value: /tmp/azurestackcloud.json
+          terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - name: trusted-ca
               mountPath: /var/run/configmaps/trusted-ca/

--- a/pkg/resource/podtemplatespec.go
+++ b/pkg/resource/podtemplatespec.go
@@ -510,6 +510,7 @@ func makePodTemplateSpec(coreClient coreset.CoreV1Interface, proxyLister configl
 							},
 						},
 					},
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 				},
 			},
 			Volumes:                       volumes,


### PR DESCRIPTION
All openshift operators must include FallbackToLogsOnError to ease debugging.