### PR TITLE
OCPBUGS-28225: pkg/storage/s3: enable bucket key on encryption settings

### DIFF
--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -794,12 +794,14 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 			encryptionType = s3.ServerSideEncryptionAes256
 		}
 
+		enableBucketKey := true
 		_, err = svc.PutBucketEncryptionWithContext(d.Context, &s3.PutBucketEncryptionInput{
 			Bucket: aws.String(d.Config.Bucket),
 			ServerSideEncryptionConfiguration: &s3.ServerSideEncryptionConfiguration{
 				Rules: []*s3.ServerSideEncryptionRule{
 					{
 						ApplyServerSideEncryptionByDefault: encryption,
+						BucketKeyEnabled:                   &enableBucketKey,
 					},
 				},
 			},

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -226,7 +226,7 @@ func TestAWSDefaults(t *testing.T) {
 					ApplyServerSideEncryptionByDefault: &s3.ServerSideEncryptionByDefault{
 						SSEAlgorithm: aws.String(s3.ServerSideEncryptionAes256),
 					},
-					BucketKeyEnabled: aws.Bool(false),
+					BucketKeyEnabled: aws.Bool(true),
 				},
 			},
 		}
@@ -552,7 +552,7 @@ func TestAWSChangeS3Encryption(t *testing.T) {
 				ApplyServerSideEncryptionByDefault: &s3.ServerSideEncryptionByDefault{
 					SSEAlgorithm: aws.String(s3.ServerSideEncryptionAes256),
 				},
-				BucketKeyEnabled: aws.Bool(false),
+				BucketKeyEnabled: aws.Bool(true),
 			},
 		},
 	}
@@ -602,7 +602,7 @@ func TestAWSChangeS3Encryption(t *testing.T) {
 							SSEAlgorithm:   aws.String(s3.ServerSideEncryptionAwsKms),
 							KMSMasterKeyID: aws.String("testKey"),
 						},
-						BucketKeyEnabled: aws.Bool(false),
+						BucketKeyEnabled: aws.Bool(true),
 					},
 				},
 			}


### PR DESCRIPTION
using this setting enables a key to be used for the entire bucket instead of AWS creating one key per object.
for more info see
https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-key.html.

---

## testing

### setting up your environment

* create a cluster (don't use cluster-bot unless you can access the AWS console for it)
* create a KMS key (use the defaults)
* copy the key id (ARN)
* add the registry IAM users to the list of users in your KMS key (if you skip this step you will get 500 Internal Server Error from the registry when you try to push images!)
* edit the operator config and set .spec.storage.s3.keyID to your key id,
  mine was "arn:aws:kms:ap-northeast-1:942491940283:key/da77a03c-692e-497d-bef6-d5da91e50f58", yours will be different.

### verify it works

* verify that the bucket "Bucket Key" is "Enabled" by going to the bucket on AWS console
* under the "Properties" tab, look for "Default encryption"
* the last field under "Default encryption" is "Bucket Key" - make sure it says "Enabled" under it

this PR enables bucket key for all types of encryption (SSE:KMS and SSE:S3) so
please also verify that only `encrypt: true` works (without specifying a `keyID`, this will use SSE:S3)
