### PR TITLE
[release-4.13] OCPBUGS-29935: pkg/storage/s3: enable bucket key on encryption settings

### DIFF
--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -794,12 +794,14 @@ func (d *driver) CreateStorage(cr *imageregistryv1.Config) error {
 			encryptionType = s3.ServerSideEncryptionAes256
 		}
 
+		enableBucketKey := true
 		_, err = svc.PutBucketEncryptionWithContext(d.Context, &s3.PutBucketEncryptionInput{
 			Bucket: aws.String(d.Config.Bucket),
 			ServerSideEncryptionConfiguration: &s3.ServerSideEncryptionConfiguration{
 				Rules: []*s3.ServerSideEncryptionRule{
 					{
 						ApplyServerSideEncryptionByDefault: encryption,
+						BucketKeyEnabled:                   &enableBucketKey,
 					},
 				},
 			},

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -226,7 +226,7 @@ func TestAWSDefaults(t *testing.T) {
 					ApplyServerSideEncryptionByDefault: &s3.ServerSideEncryptionByDefault{
 						SSEAlgorithm: aws.String(s3.ServerSideEncryptionAes256),
 					},
-					BucketKeyEnabled: aws.Bool(false),
+					BucketKeyEnabled: aws.Bool(true),
 				},
 			},
 		}
@@ -550,7 +550,7 @@ func TestAWSChangeS3Encryption(t *testing.T) {
 				ApplyServerSideEncryptionByDefault: &s3.ServerSideEncryptionByDefault{
 					SSEAlgorithm: aws.String(s3.ServerSideEncryptionAes256),
 				},
-				BucketKeyEnabled: aws.Bool(false),
+				BucketKeyEnabled: aws.Bool(true),
 			},
 		},
 	}
@@ -599,7 +599,7 @@ func TestAWSChangeS3Encryption(t *testing.T) {
 						SSEAlgorithm:   aws.String(s3.ServerSideEncryptionAwsKms),
 						KMSMasterKeyID: aws.String("testKey"),
 					},
-					BucketKeyEnabled: aws.Bool(false),
+					BucketKeyEnabled: aws.Bool(true),
 				},
 			},
 		}


### PR DESCRIPTION
Cherry-picking https://github.com/openshift/cluster-image-registry-operator/pull/995 ended in conflict, so a manual cherry-pick was required.

Note that we're back-porting this as far as 4.13 because it's for ROSA, and they don't have 4.14 yet.

/assign @dmage 