### PR TITLE
OCPBUGS-34399: Exposing chunksize variable to utilize docker registry config

### DIFF
--- a/manifests/02-rbac.yaml
+++ b/manifests/02-rbac.yaml
@@ -40,6 +40,8 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - clusterversions
+  - featuregates
   - infrastructures
   verbs:
   - get

--- a/manifests/07-operator-ibm-cloud-managed.yaml
+++ b/manifests/07-operator-ibm-cloud-managed.yaml
@@ -50,6 +50,8 @@ spec:
           value: quay.io/openshift/origin-cli:v4.0
         - name: AZURE_ENVIRONMENT_FILEPATH
           value: /tmp/azurestackcloud.json
+        - name: OPERATOR_IMAGE_VERSION
+          value: 0.0.1-snapshot
         image: docker.io/openshift/origin-cluster-image-registry-operator:latest
         imagePullPolicy: IfNotPresent
         name: cluster-image-registry-operator

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -77,6 +77,8 @@ spec:
               value: quay.io/openshift/origin-cli:v4.0
             - name: AZURE_ENVIRONMENT_FILEPATH
               value: /tmp/azurestackcloud.json
+            - name: OPERATOR_IMAGE_VERSION
+              value: 0.0.1-snapshot
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - name: trusted-ca

--- a/pkg/operator/azurepathfixcontroller.go
+++ b/pkg/operator/azurepathfixcontroller.go
@@ -30,6 +30,7 @@ import (
 	configlisters "github.com/openshift/client-go/config/listers/config/v1"
 	imageregistryv1informers "github.com/openshift/client-go/imageregistry/informers/externalversions/imageregistry/v1"
 	imageregistryv1listers "github.com/openshift/client-go/imageregistry/listers/imageregistry/v1"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
 	"github.com/openshift/cluster-image-registry-operator/pkg/defaults"
@@ -51,6 +52,8 @@ type AzurePathFixController struct {
 
 	cachesToSync []cache.InformerSynced
 	queue        workqueue.RateLimitingInterface
+
+	featureGateAccessor featuregates.FeatureGateAccess
 }
 
 func NewAzurePathFixController(
@@ -64,6 +67,7 @@ func NewAzurePathFixController(
 	proxyInformer configv1informers.ProxyInformer,
 	openshiftConfigInformer corev1informers.ConfigMapInformer,
 	podInformer corev1informers.PodInformer,
+	featureGateAccessor featuregates.FeatureGateAccess,
 ) (*AzurePathFixController, error) {
 	c := &AzurePathFixController{
 		batchClient:               batchClient,
@@ -77,6 +81,7 @@ func NewAzurePathFixController(
 		openshiftConfigLister:     openshiftConfigInformer.Lister().ConfigMaps(defaults.OpenShiftConfigNamespace),
 		kubeconfig:                kubeconfig,
 		queue:                     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "AzurePathFixController"),
+		featureGateAccessor:       featureGateAccessor,
 	}
 
 	if _, err := jobInformer.Informer().AddEventHandler(c.eventHandler()); err != nil {

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -28,6 +28,7 @@ import (
 	imageregistryinformers "github.com/openshift/client-go/imageregistry/informers/externalversions"
 	routeclient "github.com/openshift/client-go/route/clientset/versioned"
 	routeinformers "github.com/openshift/client-go/route/informers/externalversions"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/events"
 
 	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
@@ -78,12 +79,13 @@ func NewController(
 	configInformerFactory configinformers.SharedInformerFactory,
 	regopInformerFactory imageregistryinformers.SharedInformerFactory,
 	routeInformerFactory routeinformers.SharedInformerFactory,
+	featureGateAccessor featuregates.FeatureGateAccess,
 ) (*Controller, error) {
 	listers := &regopclient.Listers{}
 	clients := &regopclient.Clients{}
 	c := &Controller{
 		kubeconfig: kubeconfig,
-		generator:  resource.NewGenerator(eventRecorder, kubeconfig, clients, listers),
+		generator:  resource.NewGenerator(eventRecorder, kubeconfig, clients, listers, featureGateAccessor),
 		workqueue:  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Changes"),
 		listers:    listers,
 		clients:    clients,

--- a/pkg/operator/imageregistrycertificates.go
+++ b/pkg/operator/imageregistrycertificates.go
@@ -20,6 +20,7 @@ import (
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
 	imageregistryv1informers "github.com/openshift/client-go/imageregistry/informers/externalversions/imageregistry/v1"
 	imageregistryv1listers "github.com/openshift/client-go/imageregistry/listers/imageregistry/v1"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
 	"github.com/openshift/cluster-image-registry-operator/pkg/client"
@@ -41,6 +42,8 @@ type ImageRegistryCertificatesController struct {
 
 	cachesToSync []cache.InformerSynced
 	queue        workqueue.RateLimitingInterface
+
+	featureGateAccessor featuregates.FeatureGateAccess
 }
 
 func NewImageRegistryCertificatesController(
@@ -149,7 +152,7 @@ func (c *ImageRegistryCertificatesController) processNextWorkItem() bool {
 func (c *ImageRegistryCertificatesController) sync() error {
 	ctx := context.TODO()
 
-	g := resource.NewGeneratorCAConfig(c.configMapLister, c.imageConfigLister, c.openshiftConfigLister, c.serviceLister, c.imageRegistryConfigLister, c.storageListers, c.kubeconfig, c.coreClient)
+	g := resource.NewGeneratorCAConfig(c.configMapLister, c.imageConfigLister, c.openshiftConfigLister, c.serviceLister, c.imageRegistryConfigLister, c.storageListers, c.kubeconfig, c.coreClient, c.featureGateAccessor)
 	err := resource.ApplyMutator(g)
 	if err != nil {
 		_, _, updateError := v1helpers.UpdateStatus(
@@ -174,6 +177,7 @@ func (c *ImageRegistryCertificatesController) sync() error {
 		c.storageListers,
 		c.kubeconfig,
 		c.coreClient,
+		c.featureGateAccessor,
 	)
 	err = resource.ApplyMutator(g)
 	if err != nil {

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -202,6 +202,7 @@ func RunOperator(ctx context.Context, kubeconfig *restclient.Config) error {
 		configInformers.Config().V1().Proxies(),
 		kubeInformersForOpenShiftConfig.Core().V1().ConfigMaps(),
 		kubeInformers.Core().V1().Pods(),
+		featureGateAccessor,
 	)
 	if err != nil {
 		return err

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -2,6 +2,8 @@ package operator
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	kubeinformers "k8s.io/client-go/informers"
 	kubeclient "k8s.io/client-go/kubernetes"
@@ -17,8 +19,10 @@ import (
 	imageregistryinformers "github.com/openshift/client-go/imageregistry/informers/externalversions"
 	routeclient "github.com/openshift/client-go/route/clientset/versioned"
 	routeinformers "github.com/openshift/client-go/route/informers/externalversions"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/loglevel"
+	"github.com/openshift/library-go/pkg/operator/status"
 
 	"github.com/openshift/cluster-image-registry-operator/pkg/client"
 	"github.com/openshift/cluster-image-registry-operator/pkg/defaults"
@@ -68,6 +72,24 @@ func RunOperator(ctx context.Context, kubeconfig *restclient.Config) error {
 	}
 	eventRecorder := events.NewKubeRecorder(kubeClient.CoreV1().Events(defaults.ImageRegistryOperatorNamespace), "image-registry-operator", controllerRef)
 
+	desiredVersion := status.VersionForOperatorFromEnv()
+	missingVersion := "0.0.1-snapshot"
+
+	// By default, this will exit(0) the process if the featuregates ever change to a different set of values.
+	featureGateAccessor := featuregates.NewFeatureGateAccess(desiredVersion, missingVersion, configInformers.Config().V1().ClusterVersions(), configInformers.Config().V1().FeatureGates(), eventRecorder)
+
+	go featureGateAccessor.Run(ctx)
+	configInformers.Start(ctx.Done())
+
+	select {
+	case <-featureGateAccessor.InitialFeatureGatesObserved():
+		featureGates, _ := featureGateAccessor.CurrentFeatureGates()
+		klog.Infof("FeatureGates initialized: knownFeatureGates=%v", featureGates.KnownFeatures())
+	case <-time.After(1 * time.Minute):
+		klog.Errorf("timed out waiting for FeatureGate detection")
+		return fmt.Errorf("timed out waiting for FeatureGate detection")
+	}
+
 	controller, err := NewController(
 		eventRecorder,
 		kubeconfig,
@@ -82,6 +104,7 @@ func RunOperator(ctx context.Context, kubeconfig *restclient.Config) error {
 		configInformers,
 		imageregistryInformers,
 		routeInformers,
+		featureGateAccessor,
 	)
 	if err != nil {
 		return err

--- a/pkg/resource/generator.go
+++ b/pkg/resource/generator.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/klog/v2"
 
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/events"
 
 	"github.com/openshift/cluster-image-registry-operator/pkg/client"
@@ -65,20 +66,22 @@ func ApplyMutator(gen Mutator) error {
 	})
 }
 
-func NewGenerator(eventRecorder events.Recorder, kubeconfig *rest.Config, clients *client.Clients, listers *client.Listers) *Generator {
+func NewGenerator(eventRecorder events.Recorder, kubeconfig *rest.Config, clients *client.Clients, listers *client.Listers, featureGateAccessor featuregates.FeatureGateAccess) *Generator {
 	return &Generator{
-		eventRecorder: eventRecorder,
-		kubeconfig:    kubeconfig,
-		listers:       listers,
-		clients:       clients,
+		eventRecorder:       eventRecorder,
+		kubeconfig:          kubeconfig,
+		listers:             listers,
+		clients:             clients,
+		featureGateAccessor: featureGateAccessor,
 	}
 }
 
 type Generator struct {
-	eventRecorder events.Recorder
-	kubeconfig    *rest.Config
-	listers       *client.Listers
-	clients       *client.Clients
+	eventRecorder       events.Recorder
+	kubeconfig          *rest.Config
+	listers             *client.Listers
+	clients             *client.Clients
+	featureGateAccessor featuregates.FeatureGateAccess
 }
 
 func (g *Generator) listRoutes(cr *imageregistryv1.Config) []Mutator {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -9,6 +9,7 @@ import (
 
 	configapiv1 "github.com/openshift/api/config/v1"
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 
 	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
 	"github.com/openshift/cluster-image-registry-operator/pkg/defaults"
@@ -88,7 +89,7 @@ type Driver interface {
 	ID() string
 }
 
-func NewDriver(cfg *imageregistryv1.ImageRegistryConfigStorage, kubeconfig *rest.Config, listers *regopclient.StorageListers) (Driver, error) {
+func NewDriver(cfg *imageregistryv1.ImageRegistryConfigStorage, kubeconfig *rest.Config, listers *regopclient.StorageListers, fg featuregates.FeatureGateAccess) (Driver, error) {
 	var names []string
 	var drivers []Driver
 
@@ -100,7 +101,7 @@ func NewDriver(cfg *imageregistryv1.ImageRegistryConfigStorage, kubeconfig *rest
 	if cfg.S3 != nil {
 		names = append(names, "S3")
 		ctx := context.Background()
-		drivers = append(drivers, s3.NewDriver(ctx, cfg.S3, listers))
+		drivers = append(drivers, s3.NewDriver(ctx, cfg.S3, listers, fg))
 	}
 
 	if cfg.Swift != nil {

--- a/pkg/storage/util/util.go
+++ b/pkg/storage/util/util.go
@@ -18,6 +18,9 @@ import (
 	"github.com/openshift/cluster-image-registry-operator/pkg/defaults"
 )
 
+// ChunkSizeMiBFeatureGateName is a constant use in helper function for testing
+const ChunkSizeMiBFeatureGateName = "ChunkSizeMiB"
+
 // multiDashes is a regexp matching multiple dashes in a sequence.
 var multiDashes = regexp.MustCompile(`-{2,}`)
 

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -23,6 +23,7 @@ import (
 	configapiv1 "github.com/openshift/api/config/v1"
 	imageregistryapiv1 "github.com/openshift/api/imageregistry/v1"
 	operatorapi "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 
 	regopclient "github.com/openshift/cluster-image-registry-operator/pkg/client"
 	"github.com/openshift/cluster-image-registry-operator/pkg/defaults"
@@ -80,7 +81,11 @@ func TestAWSDefaults(t *testing.T) {
 	framework.EnsureServiceCAConfigMap(te)
 	framework.EnsureNodeCADaemonSetIsAvailable(te)
 
-	s3Driver := storages3.NewDriver(context.Background(), nil, &mockLister.StorageListers)
+	ChunkSizeMiBFeatureGateAccessor := featuregates.NewHardcodedFeatureGateAccess(
+		[]configapiv1.FeatureGateName{util.ChunkSizeMiBFeatureGateName},
+		[]configapiv1.FeatureGateName{},
+	)
+	s3Driver := storages3.NewDriver(context.Background(), nil, &mockLister.StorageListers, ChunkSizeMiBFeatureGateAccessor)
 	err = s3Driver.UpdateEffectiveConfig()
 	if err != nil {
 		t.Errorf("unable to get cluster configuration: %#v", err)
@@ -417,8 +422,12 @@ func TestAWSUpdateCredentials(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	ChunkSizeMiBFeatureGateAccessor := featuregates.NewHardcodedFeatureGateAccess(
+		[]configapiv1.FeatureGateName{util.ChunkSizeMiBFeatureGateName},
+		[]configapiv1.FeatureGateName{},
+	)
 	// Check that the user provided credentials override the system provided ones
-	s3Driver := storages3.NewDriver(context.Background(), nil, &mockLister.StorageListers)
+	s3Driver := storages3.NewDriver(context.Background(), nil, &mockLister.StorageListers, ChunkSizeMiBFeatureGateAccessor)
 
 	sharedCredentialsFile, err := s3Driver.GetCredentialsFile()
 	if err != nil {
@@ -509,7 +518,11 @@ func TestAWSChangeS3Encryption(t *testing.T) {
 	}
 	defer awsCleanup()
 
-	s3Driver := storages3.NewDriver(context.Background(), nil, &mockLister.StorageListers)
+	ChunkSizeMiBFeatureGateAccessor := featuregates.NewHardcodedFeatureGateAccess(
+		[]configapiv1.FeatureGateName{util.ChunkSizeMiBFeatureGateName},
+		[]configapiv1.FeatureGateName{},
+	)
+	s3Driver := storages3.NewDriver(context.Background(), nil, &mockLister.StorageListers, ChunkSizeMiBFeatureGateAccessor)
 	err = s3Driver.UpdateEffectiveConfig()
 	if err != nil {
 		t.Errorf("unable to get cluster configuration: %#v", err)

--- a/vendor/github.com/openshift/api/annotations/annotations.go
+++ b/vendor/github.com/openshift/api/annotations/annotations.go
@@ -1,0 +1,34 @@
+package annotations
+
+// annotation keys
+// NEVER ADD TO THIS LIST.  Annotations need to be owned in the API groups they are associated with, so these constants end
+// up nested in an API group, not top level in the OpenShift namespace.  The items located here are examples of annotations
+// claiming a global namespace key that have never achieved global reach.  In the future, names should be based on the
+// consuming component.
+const (
+	// OpenShiftDisplayName is a common, optional annotation that stores the name displayed by a UI when referencing a resource.
+	OpenShiftDisplayName = "openshift.io/display-name"
+
+	// OpenShiftProviderDisplayNameAnnotation is the name of a provider of a resource, e.g.
+	// "Red Hat, Inc."
+	OpenShiftProviderDisplayNameAnnotation = "openshift.io/provider-display-name"
+
+	// OpenShiftDocumentationURLAnnotation is the url where documentation associated with
+	// a resource can be found.
+	OpenShiftDocumentationURLAnnotation = "openshift.io/documentation-url"
+
+	// OpenShiftSupportURLAnnotation is the url where support for a template can be found.
+	OpenShiftSupportURLAnnotation = "openshift.io/support-url"
+
+	// OpenShiftDescription is a common, optional annotation that stores the description for a resource.
+	OpenShiftDescription = "openshift.io/description"
+
+	// OpenShiftLongDescriptionAnnotation is a resource's long description
+	OpenShiftLongDescriptionAnnotation = "openshift.io/long-description"
+
+	// OpenShiftComponent is a common, optional annotation that stores the owning component for a resource.
+	// The component is for whatever bug tracker we're using.  That used to be bugzilla, now it is
+	// a jira component and subcomponent in OCPBUGS.
+	// For example, "Etcd" or "Networking / ovn-kubernetes"
+	OpenShiftComponent = "openshift.io/owning-component"
+)

--- a/vendor/github.com/openshift/library-go/pkg/certs/pem.go
+++ b/vendor/github.com/openshift/library-go/pkg/certs/pem.go
@@ -1,0 +1,56 @@
+package certs
+
+import (
+	"bytes"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+)
+
+const (
+	// StringSourceEncryptedBlockType is the PEM block type used to store an encrypted string
+	StringSourceEncryptedBlockType = "ENCRYPTED STRING"
+	// StringSourceKeyBlockType is the PEM block type used to store an encrypting key
+	StringSourceKeyBlockType = "ENCRYPTING KEY"
+)
+
+func BlockFromFile(path string, blockType string) (*pem.Block, bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false, err
+	}
+	block, ok := BlockFromBytes(data, blockType)
+	return block, ok, nil
+}
+
+func BlockFromBytes(data []byte, blockType string) (*pem.Block, bool) {
+	for {
+		block, remaining := pem.Decode(data)
+		if block == nil {
+			return nil, false
+		}
+		if block.Type == blockType {
+			return block, true
+		}
+		data = remaining
+	}
+}
+
+func BlockToFile(path string, block *pem.Block, mode os.FileMode) error {
+	b, err := BlockToBytes(block)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), os.FileMode(0755)); err != nil {
+		return err
+	}
+	return os.WriteFile(path, b, mode)
+}
+
+func BlockToBytes(block *pem.Block) ([]byte, error) {
+	b := bytes.Buffer{}
+	if err := pem.Encode(&b, block); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/certs/util.go
+++ b/vendor/github.com/openshift/library-go/pkg/certs/util.go
@@ -1,0 +1,70 @@
+package certs
+
+import (
+	"crypto/x509"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const defaultOutputTimeFormat = "Jan 2 15:04:05 2006"
+
+// nowFn is used in unit test to freeze time.
+var nowFn = time.Now().UTC
+
+// CertificateToString converts a certificate into a human readable string.
+// This function should guarantee consistent output format for must-gather tooling and any code
+// that prints the certificate details.
+func CertificateToString(certificate *x509.Certificate) string {
+	humanName := certificate.Subject.CommonName
+	signerHumanName := certificate.Issuer.CommonName
+
+	if certificate.Subject.CommonName == certificate.Issuer.CommonName {
+		signerHumanName = "<self-signed>"
+	}
+
+	usages := []string{}
+	for _, curr := range certificate.ExtKeyUsage {
+		if curr == x509.ExtKeyUsageClientAuth {
+			usages = append(usages, "client")
+			continue
+		}
+		if curr == x509.ExtKeyUsageServerAuth {
+			usages = append(usages, "serving")
+			continue
+		}
+
+		usages = append(usages, fmt.Sprintf("%d", curr))
+	}
+
+	validServingNames := []string{}
+	for _, ip := range certificate.IPAddresses {
+		validServingNames = append(validServingNames, ip.String())
+	}
+	for _, dnsName := range certificate.DNSNames {
+		validServingNames = append(validServingNames, dnsName)
+	}
+
+	servingString := ""
+	if len(validServingNames) > 0 {
+		servingString = fmt.Sprintf(" validServingFor=[%s]", strings.Join(validServingNames, ","))
+	}
+
+	groupString := ""
+	if len(certificate.Subject.Organization) > 0 {
+		groupString = fmt.Sprintf(" groups=[%s]", strings.Join(certificate.Subject.Organization, ","))
+	}
+
+	return fmt.Sprintf("%q [%s]%s%s issuer=%q (%v to %v (now=%v))", humanName, strings.Join(usages, ","), groupString,
+		servingString, signerHumanName, certificate.NotBefore.UTC().Format(defaultOutputTimeFormat),
+		certificate.NotAfter.UTC().Format(defaultOutputTimeFormat), nowFn().Format(defaultOutputTimeFormat))
+}
+
+// CertificateBundleToString converts a certificate bundle into a human readable string.
+func CertificateBundleToString(bundle []*x509.Certificate) string {
+	output := []string{}
+	for i, cert := range bundle {
+		output = append(output, fmt.Sprintf("[#%d]: %s", i, CertificateToString(cert)))
+	}
+	return strings.Join(output, "\n")
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/OWNERS
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - stlaz
+approvers:
+  - stlaz

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/annotations.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/annotations.go
@@ -1,0 +1,49 @@
+package certrotation
+
+import (
+	"github.com/openshift/api/annotations"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	AutoRegenerateAfterOfflineExpiryAnnotation string = "certificates.openshift.io/auto-regenerate-after-offline-expiry"
+)
+
+type AdditionalAnnotations struct {
+	// JiraComponent annotates tls artifacts so that owner could be easily found
+	JiraComponent string
+	// Description is a human-readable one sentence description of certificate purpose
+	Description string
+	// AutoRegenerateAfterOfflineExpiry contains a link to PR and an e2e test name which verifies
+	// that TLS artifact is correctly regenerated after it has expired
+	AutoRegenerateAfterOfflineExpiry string
+}
+
+func (a AdditionalAnnotations) EnsureTLSMetadataUpdate(meta *metav1.ObjectMeta) bool {
+	modified := false
+	if meta.Annotations == nil {
+		meta.Annotations = make(map[string]string)
+	}
+	if len(a.JiraComponent) > 0 && meta.Annotations[annotations.OpenShiftComponent] != a.JiraComponent {
+		meta.Annotations[annotations.OpenShiftComponent] = a.JiraComponent
+		modified = true
+	}
+	if len(a.Description) > 0 && meta.Annotations[annotations.OpenShiftDescription] != a.Description {
+		meta.Annotations[annotations.OpenShiftDescription] = a.Description
+		modified = true
+	}
+	if len(a.AutoRegenerateAfterOfflineExpiry) > 0 && meta.Annotations[AutoRegenerateAfterOfflineExpiryAnnotation] != a.AutoRegenerateAfterOfflineExpiry {
+		meta.Annotations[AutoRegenerateAfterOfflineExpiryAnnotation] = a.AutoRegenerateAfterOfflineExpiry
+		modified = true
+	}
+	return modified
+}
+
+func NewTLSArtifactObjectMeta(name, namespace string, annotations AdditionalAnnotations) metav1.ObjectMeta {
+	meta := metav1.ObjectMeta{
+		Namespace: namespace,
+		Name:      name,
+	}
+	_ = annotations.EnsureTLSMetadataUpdate(&meta)
+	return meta
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/cabundle.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/cabundle.go
@@ -1,0 +1,150 @@
+package certrotation
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"fmt"
+	"reflect"
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/util/cert"
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/library-go/pkg/certs"
+	"github.com/openshift/library-go/pkg/crypto"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+)
+
+// CABundleConfigMap maintains a CA bundle config map, by adding new CA certs coming from RotatedSigningCASecret, and by removing expired old ones.
+type CABundleConfigMap struct {
+	// Namespace is the namespace of the ConfigMap to maintain.
+	Namespace string
+	// Name is the name of the ConfigMap to maintain.
+	Name string
+	// Owner is an optional reference to add to the secret that this rotator creates.
+	Owner *metav1.OwnerReference
+	// AdditionalAnnotations is a collection of annotations set for the secret
+	AdditionalAnnotations AdditionalAnnotations
+	// Plumbing:
+	Informer      corev1informers.ConfigMapInformer
+	Lister        corev1listers.ConfigMapLister
+	Client        corev1client.ConfigMapsGetter
+	EventRecorder events.Recorder
+}
+
+func (c CABundleConfigMap) EnsureConfigMapCABundle(ctx context.Context, signingCertKeyPair *crypto.CA) ([]*x509.Certificate, error) {
+	// by this point we have current signing cert/key pair.  We now need to make sure that the ca-bundle configmap has this cert and
+	// doesn't have any expired certs
+	originalCABundleConfigMap, err := c.Lister.ConfigMaps(c.Namespace).Get(c.Name)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+	caBundleConfigMap := originalCABundleConfigMap.DeepCopy()
+	if apierrors.IsNotFound(err) {
+		// create an empty one
+		caBundleConfigMap = &corev1.ConfigMap{ObjectMeta: NewTLSArtifactObjectMeta(
+			c.Name,
+			c.Namespace,
+			c.AdditionalAnnotations,
+		)}
+	}
+
+	needsMetadataUpdate := false
+	if c.Owner != nil {
+		needsMetadataUpdate = ensureOwnerReference(&caBundleConfigMap.ObjectMeta, c.Owner)
+	}
+	needsMetadataUpdate = c.AdditionalAnnotations.EnsureTLSMetadataUpdate(&caBundleConfigMap.ObjectMeta) || needsMetadataUpdate
+	if needsMetadataUpdate && len(caBundleConfigMap.ResourceVersion) > 0 {
+		_, _, err := resourceapply.ApplyConfigMap(ctx, c.Client, c.EventRecorder, caBundleConfigMap)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	updatedCerts, err := manageCABundleConfigMap(caBundleConfigMap, signingCertKeyPair.Config.Certs[0])
+	if err != nil {
+		return nil, err
+	}
+	if originalCABundleConfigMap == nil || originalCABundleConfigMap.Data == nil || !equality.Semantic.DeepEqual(originalCABundleConfigMap.Data, caBundleConfigMap.Data) {
+		c.EventRecorder.Eventf("CABundleUpdateRequired", "%q in %q requires a new cert", c.Name, c.Namespace)
+		LabelAsManagedConfigMap(caBundleConfigMap, CertificateTypeCABundle)
+
+		actualCABundleConfigMap, modified, err := resourceapply.ApplyConfigMap(ctx, c.Client, c.EventRecorder, caBundleConfigMap)
+		if err != nil {
+			return nil, err
+		}
+		if modified {
+			klog.V(2).Infof("Updated ca-bundle.crt configmap %s/%s with:\n%s", certs.CertificateBundleToString(updatedCerts), caBundleConfigMap.Namespace, caBundleConfigMap.Name)
+		}
+
+		caBundleConfigMap = actualCABundleConfigMap
+	}
+
+	caBundle := caBundleConfigMap.Data["ca-bundle.crt"]
+	if len(caBundle) == 0 {
+		return nil, fmt.Errorf("configmap/%s -n%s missing ca-bundle.crt", caBundleConfigMap.Name, caBundleConfigMap.Namespace)
+	}
+	certificates, err := cert.ParseCertsPEM([]byte(caBundle))
+	if err != nil {
+		return nil, err
+	}
+
+	return certificates, nil
+}
+
+// manageCABundleConfigMap adds the new certificate to the list of cabundles, eliminates duplicates, and prunes the list of expired
+// certs to trust as signers
+func manageCABundleConfigMap(caBundleConfigMap *corev1.ConfigMap, currentSigner *x509.Certificate) ([]*x509.Certificate, error) {
+	if caBundleConfigMap.Data == nil {
+		caBundleConfigMap.Data = map[string]string{}
+	}
+
+	certificates := []*x509.Certificate{}
+	caBundle := caBundleConfigMap.Data["ca-bundle.crt"]
+	if len(caBundle) > 0 {
+		var err error
+		certificates, err = cert.ParseCertsPEM([]byte(caBundle))
+		if err != nil {
+			return nil, err
+		}
+	}
+	certificates = append([]*x509.Certificate{currentSigner}, certificates...)
+	certificates = crypto.FilterExpiredCerts(certificates...)
+
+	finalCertificates := []*x509.Certificate{}
+	// now check for duplicates. n^2, but super simple
+	for i := range certificates {
+		found := false
+		for j := range finalCertificates {
+			if reflect.DeepEqual(certificates[i].Raw, finalCertificates[j].Raw) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			finalCertificates = append(finalCertificates, certificates[i])
+		}
+	}
+
+	// sorting ensures we don't continuously swap the certificates in the bundle, which might cause revision rollouts
+	sort.SliceStable(finalCertificates, func(i, j int) bool {
+		return bytes.Compare(finalCertificates[i].Raw, finalCertificates[j].Raw) < 0
+	})
+	caBytes, err := crypto.EncodeCertificates(finalCertificates...)
+	if err != nil {
+		return nil, err
+	}
+
+	caBundleConfigMap.Data["ca-bundle.crt"] = string(caBytes)
+
+	return finalCertificates, nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/client_cert_rotation_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/client_cert_rotation_controller.go
@@ -1,0 +1,162 @@
+package certrotation
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/condition"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+const (
+	// CertificateNotBeforeAnnotation contains the certificate expiration date in RFC3339 format.
+	CertificateNotBeforeAnnotation = "auth.openshift.io/certificate-not-before"
+	// CertificateNotAfterAnnotation contains the certificate expiration date in RFC3339 format.
+	CertificateNotAfterAnnotation = "auth.openshift.io/certificate-not-after"
+	// CertificateIssuer contains the common name of the certificate that signed another certificate.
+	CertificateIssuer = "auth.openshift.io/certificate-issuer"
+	// CertificateHostnames contains the hostnames used by a signer.
+	CertificateHostnames = "auth.openshift.io/certificate-hostnames"
+	// RunOnceContextKey is a context value key that can be used to call the controller Sync() and make it only run the syncWorker once and report error.
+	RunOnceContextKey = "cert-rotation-controller.openshift.io/run-once"
+)
+
+// StatusReporter knows how to report the status of cert rotation
+type StatusReporter interface {
+	Report(ctx context.Context, controllerName string, syncErr error) (updated bool, updateErr error)
+}
+
+var _ StatusReporter = (*StaticPodConditionStatusReporter)(nil)
+
+type StaticPodConditionStatusReporter struct {
+	// Plumbing:
+	OperatorClient v1helpers.StaticPodOperatorClient
+}
+
+func (s *StaticPodConditionStatusReporter) Report(ctx context.Context, controllerName string, syncErr error) (bool, error) {
+	newCondition := operatorv1.OperatorCondition{
+		Type:   fmt.Sprintf(condition.CertRotationDegradedConditionTypeFmt, controllerName),
+		Status: operatorv1.ConditionFalse,
+	}
+	if syncErr != nil {
+		newCondition.Status = operatorv1.ConditionTrue
+		newCondition.Reason = "RotationError"
+		newCondition.Message = syncErr.Error()
+	}
+	_, updated, updateErr := v1helpers.UpdateStaticPodStatus(ctx, s.OperatorClient, v1helpers.UpdateStaticPodConditionFn(newCondition))
+	return updated, updateErr
+}
+
+// CertRotationController does:
+//
+// 1) continuously create a self-signed signing CA (via RotatedSigningCASecret) and store it in a secret.
+// 2) maintain a CA bundle ConfigMap with all not yet expired CA certs.
+// 3) continuously create a target cert and key signed by the latest signing CA and store it in a secret.
+type CertRotationController struct {
+	// controller name
+	Name string
+	// RotatedSigningCASecret rotates a self-signed signing CA stored in a secret.
+	RotatedSigningCASecret RotatedSigningCASecret
+	// CABundleConfigMap maintains a CA bundle config map, by adding new CA certs coming from rotatedSigningCASecret, and by removing expired old ones.
+	CABundleConfigMap CABundleConfigMap
+	// RotatedSelfSignedCertKeySecret rotates a key and cert signed by a signing CA and stores it in a secret.
+	RotatedSelfSignedCertKeySecret RotatedSelfSignedCertKeySecret
+
+	// Plumbing:
+	StatusReporter StatusReporter
+}
+
+func NewCertRotationController(
+	name string,
+	rotatedSigningCASecret RotatedSigningCASecret,
+	caBundleConfigMap CABundleConfigMap,
+	rotatedSelfSignedCertKeySecret RotatedSelfSignedCertKeySecret,
+	recorder events.Recorder,
+	reporter StatusReporter,
+) factory.Controller {
+	c := &CertRotationController{
+		Name:                           name,
+		RotatedSigningCASecret:         rotatedSigningCASecret,
+		CABundleConfigMap:              caBundleConfigMap,
+		RotatedSelfSignedCertKeySecret: rotatedSelfSignedCertKeySecret,
+		StatusReporter:                 reporter,
+	}
+	return factory.New().
+		ResyncEvery(time.Minute).
+		WithSync(c.Sync).
+		WithInformers(
+			rotatedSigningCASecret.Informer.Informer(),
+			caBundleConfigMap.Informer.Informer(),
+			rotatedSelfSignedCertKeySecret.Informer.Informer(),
+		).
+		WithPostStartHooks(
+			c.targetCertRecheckerPostRunHook,
+		).
+		ToController("CertRotationController", recorder.WithComponentSuffix("cert-rotation-controller").WithComponentSuffix(name))
+}
+
+func (c CertRotationController) Sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	syncErr := c.SyncWorker(ctx)
+
+	// running this function with RunOnceContextKey value context will make this "run-once" without updating status.
+	isRunOnce, ok := ctx.Value(RunOnceContextKey).(bool)
+	if ok && isRunOnce {
+		return syncErr
+	}
+
+	updated, updateErr := c.StatusReporter.Report(ctx, c.Name, syncErr)
+	if updateErr != nil {
+		return updateErr
+	}
+	if updated && syncErr != nil {
+		syncCtx.Recorder().Warningf("RotationError", syncErr.Error())
+	}
+
+	return syncErr
+}
+
+func (c CertRotationController) SyncWorker(ctx context.Context) error {
+	signingCertKeyPair, _, err := c.RotatedSigningCASecret.EnsureSigningCertKeyPair(ctx)
+	if err != nil {
+		return err
+	}
+
+	cabundleCerts, err := c.CABundleConfigMap.EnsureConfigMapCABundle(ctx, signingCertKeyPair)
+	if err != nil {
+		return err
+	}
+
+	if _, err := c.RotatedSelfSignedCertKeySecret.EnsureTargetCertKeyPair(ctx, signingCertKeyPair, cabundleCerts); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c CertRotationController) targetCertRecheckerPostRunHook(ctx context.Context, syncCtx factory.SyncContext) error {
+	// If we have a need to force rechecking the cert, use this channel to do it.
+	refresher, ok := c.RotatedSelfSignedCertKeySecret.CertCreator.(TargetCertRechecker)
+	if !ok {
+		return nil
+	}
+	targetRefresh := refresher.RecheckChannel()
+	go wait.Until(func() {
+		for {
+			select {
+			case <-targetRefresh:
+				syncCtx.Queue().Add(factory.DefaultQueueKey)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}, time.Minute, ctx.Done())
+
+	<-ctx.Done()
+	return nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/config.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/config.go
@@ -1,0 +1,41 @@
+package certrotation
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+)
+
+// GetCertRotationScale  The normal scale is based on a day.  The value returned by this function
+// is used to scale rotation durations instead of a day, so you can set it shorter.
+func GetCertRotationScale(ctx context.Context, client kubernetes.Interface, namespace string) (time.Duration, error) {
+	certRotationScale := time.Duration(0)
+	err := wait.PollImmediate(time.Second, 1*time.Minute, func() (bool, error) {
+		certRotationConfig, err := client.CoreV1().ConfigMaps(namespace).Get(ctx, "unsupported-cert-rotation-config", metav1.GetOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+		if value, ok := certRotationConfig.Data["base"]; ok {
+			certRotationScale, err = time.ParseDuration(value)
+			if err != nil {
+				return false, err
+			}
+		}
+		return true, nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	if certRotationScale > 24*time.Hour {
+		return 0, fmt.Errorf("scale longer than 24h is not allowed: %v", certRotationScale)
+	}
+	return certRotationScale, nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/label.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/label.go
@@ -1,0 +1,61 @@
+package certrotation
+
+import (
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	// ManagedCertificateTypeLabelName marks config map or secret as object that contains managed certificates.
+	// This groups all objects that store certs and allow easy query to get them all.
+	// The value of this label should be set to "true".
+	ManagedCertificateTypeLabelName = "auth.openshift.io/managed-certificate-type"
+)
+
+type CertificateType string
+
+var (
+	CertificateTypeCABundle CertificateType = "ca-bundle"
+	CertificateTypeSigner   CertificateType = "signer"
+	CertificateTypeTarget   CertificateType = "target"
+	CertificateTypeUnknown  CertificateType = "unknown"
+)
+
+// LabelAsManagedConfigMap add label indicating the given config map contains certificates
+// that are managed.
+func LabelAsManagedConfigMap(config *v1.ConfigMap, certificateType CertificateType) {
+	if config.Labels == nil {
+		config.Labels = map[string]string{}
+	}
+	config.Labels[ManagedCertificateTypeLabelName] = string(certificateType)
+}
+
+// LabelAsManagedConfigMap add label indicating the given secret contains certificates
+// that are managed.
+func LabelAsManagedSecret(secret *v1.Secret, certificateType CertificateType) {
+	if secret.Labels == nil {
+		secret.Labels = map[string]string{}
+	}
+	secret.Labels[ManagedCertificateTypeLabelName] = string(certificateType)
+}
+
+// CertificateTypeFromObject returns the CertificateType based on the annotations of the object.
+func CertificateTypeFromObject(obj runtime.Object) (CertificateType, error) {
+	accesor, err := meta.Accessor(obj)
+	if err != nil {
+		return "", err
+	}
+	actualLabels := accesor.GetLabels()
+	if actualLabels == nil {
+		return CertificateTypeUnknown, nil
+	}
+
+	t := CertificateType(actualLabels[ManagedCertificateTypeLabelName])
+	switch t {
+	case CertificateTypeCABundle, CertificateTypeSigner, CertificateTypeTarget:
+		return t, nil
+	default:
+		return CertificateTypeUnknown, nil
+	}
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/metadata.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/metadata.go
@@ -1,0 +1,36 @@
+package certrotation
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ensureMetadataUpdate(secret *corev1.Secret, owner *metav1.OwnerReference, additionalAnnotations AdditionalAnnotations) bool {
+	needsMetadataUpdate := false
+	// no ownerReference set
+	if owner != nil {
+		needsMetadataUpdate = ensureOwnerReference(&secret.ObjectMeta, owner)
+	}
+	// ownership annotations not set
+	return additionalAnnotations.EnsureTLSMetadataUpdate(&secret.ObjectMeta) || needsMetadataUpdate
+}
+
+func ensureSecretTLSTypeSet(secret *corev1.Secret) bool {
+	// Existing secret not found - no need to update metadata (will be done by needNewSigningCertKeyPair / NeedNewTargetCertKeyPair)
+	if len(secret.ResourceVersion) == 0 {
+		return false
+	}
+
+	// convert outdated secret type (created by pre 4.7 installer)
+	if secret.Type != corev1.SecretTypeTLS {
+		secret.Type = corev1.SecretTypeTLS
+		// wipe secret contents if tls.crt and tls.key are missing
+		_, certExists := secret.Data[corev1.TLSCertKey]
+		_, keyExists := secret.Data[corev1.TLSPrivateKeyKey]
+		if !certExists || !keyExists {
+			secret.Data = map[string][]byte{}
+		}
+		return true
+	}
+	return false
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/signer.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/signer.go
@@ -1,0 +1,215 @@
+package certrotation
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/openshift/library-go/pkg/crypto"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+)
+
+// RotatedSigningCASecret rotates a self-signed signing CA stored in a secret. It creates a new one when
+// - refresh duration is over
+// - or 80% of validity is over (if RefreshOnlyWhenExpired is false)
+// - or the CA is expired.
+type RotatedSigningCASecret struct {
+	// Namespace is the namespace of the Secret.
+	Namespace string
+	// Name is the name of the Secret.
+	Name string
+	// Validity is the duration from time.Now() until the signing CA expires. If RefreshOnlyWhenExpired
+	// is false, the signing cert is rotated when 80% of validity is reached.
+	Validity time.Duration
+	// Refresh is the duration after signing CA creation when it is rotated at the latest. It is ignored
+	// if RefreshOnlyWhenExpired is true, or if Refresh > Validity.
+	Refresh time.Duration
+	// RefreshOnlyWhenExpired set to true means to ignore 80% of validity and the Refresh duration for rotation,
+	// but only rotate when the signing CA expires. This is useful for auto-recovery when we want to enforce
+	// rotation on expiration only, but not interfere with the ordinary rotation controller.
+	RefreshOnlyWhenExpired bool
+
+	// Owner is an optional reference to add to the secret that this rotator creates. Use this when downstream
+	// consumers of the signer CA need to be aware of changes to the object.
+	// WARNING: be careful when using this option, as deletion of the owning object will cascade into deletion
+	// of the signer. If the lifetime of the owning object is not a superset of the lifetime in which the signer
+	// is used, early deletion will be catastrophic.
+	Owner *metav1.OwnerReference
+
+	// AdditionalAnnotations is a collection of annotations set for the secret
+	AdditionalAnnotations AdditionalAnnotations
+
+	// Plumbing:
+	Informer      corev1informers.SecretInformer
+	Lister        corev1listers.SecretLister
+	Client        corev1client.SecretsGetter
+	EventRecorder events.Recorder
+
+	// Deprecated: DO NOT enable, it is intended as a short term hack for a very specific use case,
+	// and it works in tandem with a particular carry patch applied to the openshift kube-apiserver.
+	// we will remove this when we migrate all of the affected secret
+	// objects to their intended type: https://issues.redhat.com/browse/API-1800
+	UseSecretUpdateOnly bool
+}
+
+// EnsureSigningCertKeyPair manages the entire lifecycle of a signer cert as a secret, from creation to continued rotation.
+// It always returns the currently used CA pair, a bool indicating whether it was created/updated within this function call and an error.
+func (c RotatedSigningCASecret) EnsureSigningCertKeyPair(ctx context.Context) (*crypto.CA, bool, error) {
+	originalSigningCertKeyPairSecret, err := c.Lister.Secrets(c.Namespace).Get(c.Name)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, false, err
+	}
+	signingCertKeyPairSecret := originalSigningCertKeyPairSecret.DeepCopy()
+	if apierrors.IsNotFound(err) {
+		// create an empty one
+		signingCertKeyPairSecret = &corev1.Secret{
+			ObjectMeta: NewTLSArtifactObjectMeta(
+				c.Name,
+				c.Namespace,
+				c.AdditionalAnnotations,
+			),
+			Type: corev1.SecretTypeTLS,
+		}
+	}
+
+	applyFn := resourceapply.ApplySecret
+	if c.UseSecretUpdateOnly {
+		applyFn = resourceapply.ApplySecretDoNotUse
+	}
+
+	// apply necessary metadata (possibly via delete+recreate) if secret exists
+	// this is done before content update to prevent unexpected rollouts
+	if ensureMetadataUpdate(signingCertKeyPairSecret, c.Owner, c.AdditionalAnnotations) && ensureSecretTLSTypeSet(signingCertKeyPairSecret) {
+		actualSigningCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret)
+		if err != nil {
+			return nil, false, err
+		}
+		signingCertKeyPairSecret = actualSigningCertKeyPairSecret
+	}
+
+	signerUpdated := false
+	if needed, reason := needNewSigningCertKeyPair(signingCertKeyPairSecret.Annotations, c.Refresh, c.RefreshOnlyWhenExpired); needed {
+		c.EventRecorder.Eventf("SignerUpdateRequired", "%q in %q requires a new signing cert/key pair: %v", c.Name, c.Namespace, reason)
+		if err := setSigningCertKeyPairSecret(signingCertKeyPairSecret, c.Validity); err != nil {
+			return nil, false, err
+		}
+
+		LabelAsManagedSecret(signingCertKeyPairSecret, CertificateTypeSigner)
+
+		actualSigningCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret)
+		if err != nil {
+			return nil, false, err
+		}
+		signingCertKeyPairSecret = actualSigningCertKeyPairSecret
+		signerUpdated = true
+	}
+	// at this point, the secret has the correct signer, so we should read that signer to be able to sign
+	signingCertKeyPair, err := crypto.GetCAFromBytes(signingCertKeyPairSecret.Data["tls.crt"], signingCertKeyPairSecret.Data["tls.key"])
+	if err != nil {
+		return nil, signerUpdated, err
+	}
+
+	return signingCertKeyPair, signerUpdated, nil
+}
+
+// ensureOwnerReference adds the owner to the list of owner references in meta, if necessary
+func ensureOwnerReference(meta *metav1.ObjectMeta, owner *metav1.OwnerReference) bool {
+	var found bool
+	for _, ref := range meta.OwnerReferences {
+		if ref == *owner {
+			found = true
+			break
+		}
+	}
+	if !found {
+		meta.OwnerReferences = append(meta.OwnerReferences, *owner)
+		return true
+	}
+	return false
+}
+
+func needNewSigningCertKeyPair(annotations map[string]string, refresh time.Duration, refreshOnlyWhenExpired bool) (bool, string) {
+	notBefore, notAfter, reason := getValidityFromAnnotations(annotations)
+	if len(reason) > 0 {
+		return true, reason
+	}
+
+	if time.Now().After(notAfter) {
+		return true, "already expired"
+	}
+
+	if refreshOnlyWhenExpired {
+		return false, ""
+	}
+
+	validity := notAfter.Sub(notBefore)
+	at80Percent := notAfter.Add(-validity / 5)
+	if time.Now().After(at80Percent) {
+		return true, fmt.Sprintf("past its latest possible time %v", at80Percent)
+	}
+
+	developerSpecifiedRefresh := notBefore.Add(refresh)
+	if time.Now().After(developerSpecifiedRefresh) {
+		return true, fmt.Sprintf("past its refresh time %v", developerSpecifiedRefresh)
+	}
+
+	return false, ""
+}
+
+func getValidityFromAnnotations(annotations map[string]string) (notBefore time.Time, notAfter time.Time, reason string) {
+	notAfterString := annotations[CertificateNotAfterAnnotation]
+	if len(notAfterString) == 0 {
+		return notBefore, notAfter, "missing notAfter"
+	}
+	notAfter, err := time.Parse(time.RFC3339, notAfterString)
+	if err != nil {
+		return notBefore, notAfter, fmt.Sprintf("bad expiry: %q", notAfterString)
+	}
+	notBeforeString := annotations[CertificateNotBeforeAnnotation]
+	if len(notAfterString) == 0 {
+		return notBefore, notAfter, "missing notBefore"
+	}
+	notBefore, err = time.Parse(time.RFC3339, notBeforeString)
+	if err != nil {
+		return notBefore, notAfter, fmt.Sprintf("bad expiry: %q", notBeforeString)
+	}
+
+	return notBefore, notAfter, ""
+}
+
+// setSigningCertKeyPairSecret creates a new signing cert/key pair and sets them in the secret
+func setSigningCertKeyPairSecret(signingCertKeyPairSecret *corev1.Secret, validity time.Duration) error {
+	signerName := fmt.Sprintf("%s_%s@%d", signingCertKeyPairSecret.Namespace, signingCertKeyPairSecret.Name, time.Now().Unix())
+	ca, err := crypto.MakeSelfSignedCAConfigForDuration(signerName, validity)
+	if err != nil {
+		return err
+	}
+
+	certBytes := &bytes.Buffer{}
+	keyBytes := &bytes.Buffer{}
+	if err := ca.WriteCertConfig(certBytes, keyBytes); err != nil {
+		return err
+	}
+
+	if signingCertKeyPairSecret.Annotations == nil {
+		signingCertKeyPairSecret.Annotations = map[string]string{}
+	}
+	if signingCertKeyPairSecret.Data == nil {
+		signingCertKeyPairSecret.Data = map[string][]byte{}
+	}
+	signingCertKeyPairSecret.Data["tls.crt"] = certBytes.Bytes()
+	signingCertKeyPairSecret.Data["tls.key"] = keyBytes.Bytes()
+	signingCertKeyPairSecret.Annotations[CertificateNotAfterAnnotation] = ca.Certs[0].NotAfter.Format(time.RFC3339)
+	signingCertKeyPairSecret.Annotations[CertificateNotBeforeAnnotation] = ca.Certs[0].NotBefore.Format(time.RFC3339)
+	signingCertKeyPairSecret.Annotations[CertificateIssuer] = ca.Certs[0].Issuer.CommonName
+
+	return nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/target.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/target.go
@@ -1,0 +1,343 @@
+package certrotation
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/authentication/user"
+
+	"github.com/openshift/library-go/pkg/certs"
+	"github.com/openshift/library-go/pkg/crypto"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+)
+
+// RotatedSelfSignedCertKeySecret rotates a key and cert signed by a signing CA and stores it in a secret.
+//
+// It creates a new one when
+// - refresh duration is over
+// - or 80% of validity is over (if RefreshOnlyWhenExpired is false)
+// - or the cert is expired.
+// - or the signing CA changes.
+type RotatedSelfSignedCertKeySecret struct {
+	// Namespace is the namespace of the Secret.
+	Namespace string
+	// Name is the name of the Secret.
+	Name string
+	// Validity is the duration from time.Now() until the certificate expires. If RefreshOnlyWhenExpired
+	// is false, the key and certificate is rotated when 80% of validity is reached.
+	Validity time.Duration
+	// Refresh is the duration after certificate creation when it is rotated at the latest. It is ignored
+	// if RefreshOnlyWhenExpired is true, or if Refresh > Validity.
+	// Refresh is ignored until the signing CA at least 10% in its life-time to ensure it is deployed
+	// through-out the cluster.
+	Refresh time.Duration
+	// RefreshOnlyWhenExpired allows rotating only certs that are already expired. (for autorecovery)
+	// If false (regular flow) it rotates at the refresh interval but no later then 4/5 of the cert lifetime.
+
+	// RefreshOnlyWhenExpired set to true means to ignore 80% of validity and the Refresh duration for rotation,
+	// but only rotate when the certificate expires. This is useful for auto-recovery when we want to enforce
+	// rotation on expiration only, but not interfere with the ordinary rotation controller.
+	RefreshOnlyWhenExpired bool
+
+	// Owner is an optional reference to add to the secret that this rotator creates. Use this when downstream
+	// consumers of the certificate need to be aware of changes to the object.
+	// WARNING: be careful when using this option, as deletion of the owning object will cascade into deletion
+	// of the certificate. If the lifetime of the owning object is not a superset of the lifetime in which the
+	// certificate is used, early deletion will be catastrophic.
+	Owner *metav1.OwnerReference
+
+	// AdditionalAnnotations is a collection of annotations set for the secret
+	AdditionalAnnotations AdditionalAnnotations
+
+	// CertCreator does the actual cert generation.
+	CertCreator TargetCertCreator
+
+	// Plumbing:
+	Informer      corev1informers.SecretInformer
+	Lister        corev1listers.SecretLister
+	Client        corev1client.SecretsGetter
+	EventRecorder events.Recorder
+
+	// Deprecated: DO NOT eanble, it is intended as a short term hack for a very specific use case,
+	// and it works in tandem with a particular carry patch applied to the openshift kube-apiserver.
+	// we will remove this when we migrate all of the affected secret
+	// objects to their intended type: https://issues.redhat.com/browse/API-1800
+	UseSecretUpdateOnly bool
+}
+
+type TargetCertCreator interface {
+	// NewCertificate creates a new key-cert pair with the given signer.
+	NewCertificate(signer *crypto.CA, validity time.Duration) (*crypto.TLSCertificateConfig, error)
+	// NeedNewTargetCertKeyPair decides whether a new cert-key pair is needed. It returns a non-empty reason if it is the case.
+	NeedNewTargetCertKeyPair(currentCertSecret *corev1.Secret, signer *crypto.CA, caBundleCerts []*x509.Certificate, refresh time.Duration, refreshOnlyWhenExpired bool) string
+	// SetAnnotations gives an option to override or set additional annotations
+	SetAnnotations(cert *crypto.TLSCertificateConfig, annotations map[string]string) map[string]string
+}
+
+// TargetCertRechecker is an optional interface to be implemented by the TargetCertCreator to enforce
+// a controller run.
+type TargetCertRechecker interface {
+	RecheckChannel() <-chan struct{}
+}
+
+func (c RotatedSelfSignedCertKeySecret) EnsureTargetCertKeyPair(ctx context.Context, signingCertKeyPair *crypto.CA, caBundleCerts []*x509.Certificate) (*corev1.Secret, error) {
+	// at this point our trust bundle has been updated.  We don't know for sure that consumers have updated, but that's why we have a second
+	// validity percentage.  We always check to see if we need to sign.  Often we are signing with an old key or we have no target
+	// and need to mint one
+	// TODO do the cross signing thing, but this shows the API consumers want and a very simple impl.
+	originalTargetCertKeyPairSecret, err := c.Lister.Secrets(c.Namespace).Get(c.Name)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+	targetCertKeyPairSecret := originalTargetCertKeyPairSecret.DeepCopy()
+	if apierrors.IsNotFound(err) {
+		// create an empty one
+		targetCertKeyPairSecret = &corev1.Secret{
+			ObjectMeta: NewTLSArtifactObjectMeta(
+				c.Name,
+				c.Namespace,
+				c.AdditionalAnnotations,
+			),
+			Type: corev1.SecretTypeTLS,
+		}
+	}
+
+	applyFn := resourceapply.ApplySecret
+	if c.UseSecretUpdateOnly {
+		applyFn = resourceapply.ApplySecretDoNotUse
+	}
+
+	// apply necessary metadata (possibly via delete+recreate) if secret exists
+	// this is done before content update to prevent unexpected rollouts
+	if ensureMetadataUpdate(targetCertKeyPairSecret, c.Owner, c.AdditionalAnnotations) && ensureSecretTLSTypeSet(targetCertKeyPairSecret) {
+		actualTargetCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, targetCertKeyPairSecret)
+		if err != nil {
+			return nil, err
+		}
+		targetCertKeyPairSecret = actualTargetCertKeyPairSecret
+	}
+
+	if reason := c.CertCreator.NeedNewTargetCertKeyPair(targetCertKeyPairSecret, signingCertKeyPair, caBundleCerts, c.Refresh, c.RefreshOnlyWhenExpired); len(reason) > 0 {
+		c.EventRecorder.Eventf("TargetUpdateRequired", "%q in %q requires a new target cert/key pair: %v", c.Name, c.Namespace, reason)
+		if err := setTargetCertKeyPairSecret(targetCertKeyPairSecret, c.Validity, signingCertKeyPair, c.CertCreator, c.AdditionalAnnotations); err != nil {
+			return nil, err
+		}
+
+		LabelAsManagedSecret(targetCertKeyPairSecret, CertificateTypeTarget)
+
+		actualTargetCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, targetCertKeyPairSecret)
+		if err != nil {
+			return nil, err
+		}
+		targetCertKeyPairSecret = actualTargetCertKeyPairSecret
+	}
+
+	return targetCertKeyPairSecret, nil
+}
+
+func needNewTargetCertKeyPair(annotations map[string]string, signer *crypto.CA, caBundleCerts []*x509.Certificate, refresh time.Duration, refreshOnlyWhenExpired bool) string {
+	if reason := needNewTargetCertKeyPairForTime(annotations, signer, refresh, refreshOnlyWhenExpired); len(reason) > 0 {
+		return reason
+	}
+
+	// check the signer common name against all the common names in our ca bundle so we don't refresh early
+	signerCommonName := annotations[CertificateIssuer]
+	if len(signerCommonName) == 0 {
+		return "missing issuer name"
+	}
+	for _, caCert := range caBundleCerts {
+		if signerCommonName == caCert.Subject.CommonName {
+			return ""
+		}
+	}
+
+	return fmt.Sprintf("issuer %q, not in ca bundle:\n%s", signerCommonName, certs.CertificateBundleToString(caBundleCerts))
+}
+
+// needNewTargetCertKeyPairForTime returns true when
+//  1. when notAfter or notBefore is missing in the annotation
+//  2. when notAfter or notBefore is malformed
+//  3. when now is after the notAfter
+//  4. when now is after notAfter+refresh AND the signer has been valid
+//     for more than 5% of the "extra" time we renew the target
+//
+// in other words, we rotate if
+//
+// our old CA is gone from the bundle (then we are pretty late to the renewal party)
+// or the cert expired (then we are also pretty late)
+// or we are over the renewal percentage of the validity, but only if the new CA at least 10% into its age.
+// Maybe worth a go doc.
+//
+// So in general we need to see a signing CA at least aged 10% within 1-percentage of the cert validity.
+//
+// Hence, if the CAs are rotated too fast (like CA percentage around 10% or smaller), we will not hit the time to make use of the CA. Or if the cert renewal percentage is at 90%, there is not much time either.
+//
+// So with a cert percentage of 75% and equally long CA and cert validities at the worst case we start at 85% of the cert to renew, trying again every minute.
+func needNewTargetCertKeyPairForTime(annotations map[string]string, signer *crypto.CA, refresh time.Duration, refreshOnlyWhenExpired bool) string {
+	notBefore, notAfter, reason := getValidityFromAnnotations(annotations)
+	if len(reason) > 0 {
+		return reason
+	}
+
+	// Is cert expired?
+	if time.Now().After(notAfter) {
+		return "already expired"
+	}
+
+	if refreshOnlyWhenExpired {
+		return ""
+	}
+
+	// Are we at 80% of validity?
+	validity := notAfter.Sub(notBefore)
+	at80Percent := notAfter.Add(-validity / 5)
+	if time.Now().After(at80Percent) {
+		return fmt.Sprintf("past its latest possible time %v", at80Percent)
+	}
+
+	// If Certificate is past its refresh time, we may have action to take. We only do this if the signer is old enough.
+	refreshTime := notBefore.Add(refresh)
+	if time.Now().After(refreshTime) {
+		// make sure the signer has been valid for more than 10% of the target's refresh time.
+		timeToWaitForTrustRotation := refresh / 10
+		if time.Now().After(signer.Config.Certs[0].NotBefore.Add(time.Duration(timeToWaitForTrustRotation))) {
+			return fmt.Sprintf("past its refresh time %v", refreshTime)
+		}
+	}
+
+	return ""
+}
+
+// setTargetCertKeyPairSecret creates a new cert/key pair and sets them in the secret.  Only one of client, serving, or signer rotation may be specified.
+// TODO refactor with an interface for actually signing and move the one-of check higher in the stack.
+func setTargetCertKeyPairSecret(targetCertKeyPairSecret *corev1.Secret, validity time.Duration, signer *crypto.CA, certCreator TargetCertCreator, annotations AdditionalAnnotations) error {
+	if targetCertKeyPairSecret.Annotations == nil {
+		targetCertKeyPairSecret.Annotations = map[string]string{}
+	}
+	if targetCertKeyPairSecret.Data == nil {
+		targetCertKeyPairSecret.Data = map[string][]byte{}
+	}
+
+	// our annotation is based on our cert validity, so we want to make sure that we don't specify something past our signer
+	targetValidity := validity
+	remainingSignerValidity := signer.Config.Certs[0].NotAfter.Sub(time.Now())
+	if remainingSignerValidity < validity {
+		targetValidity = remainingSignerValidity
+	}
+
+	certKeyPair, err := certCreator.NewCertificate(signer, targetValidity)
+	if err != nil {
+		return err
+	}
+
+	targetCertKeyPairSecret.Data["tls.crt"], targetCertKeyPairSecret.Data["tls.key"], err = certKeyPair.GetPEMBytes()
+	if err != nil {
+		return err
+	}
+	targetCertKeyPairSecret.Annotations[CertificateNotAfterAnnotation] = certKeyPair.Certs[0].NotAfter.Format(time.RFC3339)
+	targetCertKeyPairSecret.Annotations[CertificateNotBeforeAnnotation] = certKeyPair.Certs[0].NotBefore.Format(time.RFC3339)
+	targetCertKeyPairSecret.Annotations[CertificateIssuer] = certKeyPair.Certs[0].Issuer.CommonName
+
+	_ = annotations.EnsureTLSMetadataUpdate(&targetCertKeyPairSecret.ObjectMeta)
+	certCreator.SetAnnotations(certKeyPair, targetCertKeyPairSecret.Annotations)
+
+	return nil
+}
+
+type ClientRotation struct {
+	UserInfo user.Info
+}
+
+func (r *ClientRotation) NewCertificate(signer *crypto.CA, validity time.Duration) (*crypto.TLSCertificateConfig, error) {
+	return signer.MakeClientCertificateForDuration(r.UserInfo, validity)
+}
+
+func (r *ClientRotation) NeedNewTargetCertKeyPair(currentCertSecret *corev1.Secret, signer *crypto.CA, caBundleCerts []*x509.Certificate, refresh time.Duration, refreshOnlyWhenExpired bool) string {
+	return needNewTargetCertKeyPair(currentCertSecret.Annotations, signer, caBundleCerts, refresh, refreshOnlyWhenExpired)
+}
+
+func (r *ClientRotation) SetAnnotations(cert *crypto.TLSCertificateConfig, annotations map[string]string) map[string]string {
+	return annotations
+}
+
+type ServingRotation struct {
+	Hostnames              ServingHostnameFunc
+	CertificateExtensionFn []crypto.CertificateExtensionFunc
+	HostnamesChanged       <-chan struct{}
+}
+
+func (r *ServingRotation) NewCertificate(signer *crypto.CA, validity time.Duration) (*crypto.TLSCertificateConfig, error) {
+	if len(r.Hostnames()) == 0 {
+		return nil, fmt.Errorf("no hostnames set")
+	}
+	return signer.MakeServerCertForDuration(sets.New(r.Hostnames()...), validity, r.CertificateExtensionFn...)
+}
+
+func (r *ServingRotation) RecheckChannel() <-chan struct{} {
+	return r.HostnamesChanged
+}
+
+func (r *ServingRotation) NeedNewTargetCertKeyPair(currentCertSecret *corev1.Secret, signer *crypto.CA, caBundleCerts []*x509.Certificate, refresh time.Duration, refreshOnlyWhenExpired bool) string {
+	reason := needNewTargetCertKeyPair(currentCertSecret.Annotations, signer, caBundleCerts, refresh, refreshOnlyWhenExpired)
+	if len(reason) > 0 {
+		return reason
+	}
+
+	return r.missingHostnames(currentCertSecret.Annotations)
+}
+
+func (r *ServingRotation) missingHostnames(annotations map[string]string) string {
+	existingHostnames := sets.New(strings.Split(annotations[CertificateHostnames], ",")...)
+	requiredHostnames := sets.New(r.Hostnames()...)
+	if !existingHostnames.Equal(requiredHostnames) {
+		existingNotRequired := existingHostnames.Difference(requiredHostnames)
+		requiredNotExisting := requiredHostnames.Difference(existingHostnames)
+		return fmt.Sprintf("%q are existing and not required, %q are required and not existing", strings.Join(sets.List(existingNotRequired), ","), strings.Join(sets.List(requiredNotExisting), ","))
+	}
+
+	return ""
+}
+
+func (r *ServingRotation) SetAnnotations(cert *crypto.TLSCertificateConfig, annotations map[string]string) map[string]string {
+	hostnames := sets.Set[string]{}
+	for _, ip := range cert.Certs[0].IPAddresses {
+		hostnames.Insert(ip.String())
+	}
+	for _, dnsName := range cert.Certs[0].DNSNames {
+		hostnames.Insert(dnsName)
+	}
+
+	// List does a sort so that we have a consistent representation
+	annotations[CertificateHostnames] = strings.Join(sets.List(hostnames), ",")
+	return annotations
+}
+
+type ServingHostnameFunc func() []string
+
+type SignerRotation struct {
+	SignerName string
+}
+
+func (r *SignerRotation) NewCertificate(signer *crypto.CA, validity time.Duration) (*crypto.TLSCertificateConfig, error) {
+	signerName := fmt.Sprintf("%s_@%d", r.SignerName, time.Now().Unix())
+	return crypto.MakeCAConfigForDuration(signerName, validity, signer)
+}
+
+func (r *SignerRotation) NeedNewTargetCertKeyPair(currentCertSecret *corev1.Secret, signer *crypto.CA, caBundleCerts []*x509.Certificate, refresh time.Duration, refreshOnlyWhenExpired bool) string {
+	return needNewTargetCertKeyPair(currentCertSecret.Annotations, signer, caBundleCerts, refresh, refreshOnlyWhenExpired)
+}
+
+func (r *SignerRotation) SetAnnotations(cert *crypto.TLSCertificateConfig, annotations map[string]string) map[string]string {
+	return annotations
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/condition/condition.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/condition/condition.go
@@ -1,0 +1,72 @@
+package condition
+
+const (
+	// ManagementStateDegradedConditionType is true when the operator ManagementState is not "Managed"..
+	// Possible reasons are Unmanaged, Removed or Unknown. Any of these cases means the operator is not actively managing the operand.
+	// This condition is set to false when the ManagementState is set to back to "Managed".
+	ManagementStateDegradedConditionType = "ManagementStateDegraded"
+
+	// UnsupportedConfigOverridesUpgradeableConditionType is true when operator unsupported config overrides is changed.
+	// When NoUnsupportedConfigOverrides reason is given it means there are no unsupported config overrides.
+	// When UnsupportedConfigOverridesSet reason is given it means the unsupported config overrides are set, which might impact the ability
+	// of operator to successfully upgrade its operand.
+	UnsupportedConfigOverridesUpgradeableConditionType = "UnsupportedConfigOverridesUpgradeable"
+
+	// MonitoringResourceControllerDegradedConditionType is true when the operator is unable to create or reconcile the ServiceMonitor
+	// CR resource, which is required by monitoring operator to collect Prometheus data from the operator. When this condition is true and the ServiceMonitor
+	// is already created, it won't have impact on collecting metrics. However, if the ServiceMonitor was not created, the metrics won't be available for
+	// collection until this condition is set to false.
+	// The condition is set to false automatically when the operator successfully synchronize the ServiceMonitor resource.
+	MonitoringResourceControllerDegradedConditionType = "MonitoringResourceControllerDegraded"
+
+	// BackingResourceControllerDegradedConditionType is true when the operator is unable to create or reconcile the resources needed
+	// to successfully run the installer pods (installer CRB and SA). If these were already created, this condition is not fatal, however if the resources
+	// were not created it means the installer pod creation will fail.
+	// This condition is set to false when the operator can successfully synchronize installer SA and CRB.
+	BackingResourceControllerDegradedConditionType = "BackingResourceControllerDegraded"
+
+	// StaticPodsDegradedConditionType is true when the operator observe errors when installing the new revision static pods.
+	// This condition report Error reason when the pods are terminated or not ready or waiting during which the operand quality of service is degraded.
+	// This condition is set to False when the pods change state to running and are observed ready.
+	StaticPodsDegradedConditionType = "StaticPodsDegraded"
+
+	// StaticPodsAvailableConditionType is true when the static pod is available on at least one node.
+	StaticPodsAvailableConditionType = "StaticPodsAvailable"
+
+	// ConfigObservationDegradedConditionType is true when the operator failed to observe or process configuration change.
+	// This is not transient condition and normally a correction or manual intervention is required on the config custom resource.
+	ConfigObservationDegradedConditionType = "ConfigObservationDegraded"
+
+	// ResourceSyncControllerDegradedConditionType is true when the operator failed to synchronize one or more secrets or config maps required
+	// to run the operand. Operand ability to provide service might be affected by this condition.
+	// This condition is set to false when the operator is able to create secrets and config maps.
+	ResourceSyncControllerDegradedConditionType = "ResourceSyncControllerDegraded"
+
+	// CertRotationDegradedConditionTypeFmt is true when the operator failed to properly rotate one or more certificates required by the operand.
+	// The RotationError reason is given with message describing details of this failure. This condition can be fatal when ignored as the existing certificate(s)
+	// validity can expire and without rotating/renewing them manual recovery might be required to fix the cluster.
+	CertRotationDegradedConditionTypeFmt = "CertRotation_%s_Degraded"
+
+	// InstallerControllerDegradedConditionType is true when the operator is not able to create new installer pods so the new revisions
+	// cannot be rolled out. This might happen when one or more required secrets or config maps does not exists.
+	// In case the missing secret or config map is available, this condition is automatically set to false.
+	InstallerControllerDegradedConditionType = "InstallerControllerDegraded"
+
+	// NodeInstallerDegradedConditionType is true when the operator is not able to create new installer pods because there are no schedulable nodes
+	// available to run the installer pods.
+	// The AllNodesAtLatestRevision reason is set when all master nodes are updated to the latest revision. It is false when some masters are pending revision.
+	// ZeroNodesActive reason is set to True when no active master nodes are observed. Is set to False when there is at least one active master node.
+	NodeInstallerDegradedConditionType = "NodeInstallerDegraded"
+
+	// NodeInstallerProgressingConditionType is true when the operator is moving nodes to a new revision.
+	NodeInstallerProgressingConditionType = "NodeInstallerProgressing"
+
+	// RevisionControllerDegradedConditionType is true when the operator is not able to create new desired revision because an error occurred when
+	// the operator attempted to created required resource(s) (secrets, configmaps, ...).
+	// This condition mean no new revision will be created.
+	RevisionControllerDegradedConditionType = "RevisionControllerDegraded"
+
+	// NodeControllerDegradedConditionType is true when the operator observed a master node that is not ready.
+	// Note that a node is not ready when its Condition.NodeReady wasn't set to true
+	NodeControllerDegradedConditionType = "NodeControllerDegraded"
+)

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/config_observer_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/config_observer_controller.go
@@ -1,0 +1,284 @@
+package configobserver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/imdario/mergo"
+	"k8s.io/klog/v2"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/tools/cache"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/condition"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/management"
+	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+// Listers is an interface which will be passed to the config observer funcs.  It is expected to be hard-cast to the "correct" type
+type Listers interface {
+	// ResourceSyncer can be used to copy content from one namespace to another
+	ResourceSyncer() resourcesynccontroller.ResourceSyncer
+	PreRunHasSynced() []cache.InformerSynced
+}
+
+// ObserveConfigFunc observes configuration and returns the observedConfig. This function should not return an
+// observedConfig that would cause the service being managed by the operator to crash. For example, if a required
+// configuration key cannot be observed, consider reusing the configuration key's previous value. Errors that occur
+// while attempting to generate the observedConfig should be returned in the errs slice.
+type ObserveConfigFunc func(listers Listers, recorder events.Recorder, existingConfig map[string]interface{}) (observedConfig map[string]interface{}, errs []error)
+
+type ConfigObserver struct {
+	// observers are called in an undefined order and their results are merged to
+	// determine the observed configuration.
+	observers []ObserveConfigFunc
+
+	operatorClient v1helpers.OperatorClient
+
+	// listers are used by config observers to retrieve necessary resources
+	listers Listers
+
+	nestedConfigPath      []string
+	degradedConditionType string
+}
+
+func NewConfigObserver(
+	operatorClient v1helpers.OperatorClient,
+	eventRecorder events.Recorder,
+	listers Listers,
+	informers []factory.Informer,
+	observers ...ObserveConfigFunc,
+) factory.Controller {
+	return NewNestedConfigObserver(
+		operatorClient,
+		eventRecorder,
+		listers,
+		informers,
+		nil,
+		"",
+		observers...,
+	)
+}
+
+// NewNestedConfigObserver creates a config observer that watches changes to a nested field (nestedConfigPath) in the config.
+// Useful when the config is shared across multiple controllers in the same process.
+//
+// Example:
+//
+// Given the following configuration, you could run two separate controllers and point each to its own section.
+// The first controller would be responsible for "oauthAPIServer" and the second for "oauthServer" section.
+//
+//	"observedConfig": {
+//	  "oauthAPIServer": {
+//	    "apiServerArguments": {"tls-min-version": "VersionTLS12"}
+//	  },
+//	  "oauthServer": {
+//	    "corsAllowedOrigins": [ "//127\\.0\\.0\\.1(:|$)","//localhost(:|$)"]
+//	  }
+//	}
+//
+// oauthAPIController    := NewNestedConfigObserver(..., []string{"oauthAPIServer"}
+// oauthServerController := NewNestedConfigObserver(..., []string{"oauthServer"}
+func NewNestedConfigObserver(
+	operatorClient v1helpers.OperatorClient,
+	eventRecorder events.Recorder,
+	listers Listers,
+	informers []factory.Informer,
+	nestedConfigPath []string,
+	degradedConditionPrefix string,
+	observers ...ObserveConfigFunc,
+) factory.Controller {
+	c := &ConfigObserver{
+		operatorClient:        operatorClient,
+		observers:             observers,
+		listers:               listers,
+		nestedConfigPath:      nestedConfigPath,
+		degradedConditionType: degradedConditionPrefix + condition.ConfigObservationDegradedConditionType,
+	}
+
+	return factory.New().ResyncEvery(time.Minute).WithSync(c.sync).WithInformers(append(informers, listersToInformer(listers)...)...).ToController("ConfigObserver", eventRecorder.WithComponentSuffix("config-observer"))
+}
+
+// sync reacts to a change in prereqs by finding information that is required to match another value in the cluster. This
+// must be information that is logically "owned" by another component.
+func (c ConfigObserver) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	originalSpec, _, _, err := c.operatorClient.GetOperatorState()
+	if management.IsOperatorRemovable() && apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	spec := originalSpec.DeepCopy()
+
+	// don't worry about errors.  If we can't decode, we'll simply stomp over the field.
+	existingConfig := map[string]interface{}{}
+	if err := json.NewDecoder(bytes.NewBuffer(spec.ObservedConfig.Raw)).Decode(&existingConfig); err != nil {
+		klog.V(4).Infof("decode of existing config failed with error: %v", err)
+	}
+
+	var errs []error
+	var observedConfigs []map[string]interface{}
+	for _, i := range rand.Perm(len(c.observers)) {
+		var currErrs []error
+		observedConfig, currErrs := c.observers[i](c.listers, syncCtx.Recorder(), existingConfig)
+		observedConfigs = append(observedConfigs, observedConfig)
+		errs = append(errs, currErrs...)
+	}
+
+	mergedObservedConfig := map[string]interface{}{}
+	for _, observedConfig := range observedConfigs {
+		if err := mergo.Merge(&mergedObservedConfig, observedConfig); err != nil {
+			klog.Warningf("merging observed config failed: %v", err)
+		}
+	}
+
+	reverseMergedObservedConfig := map[string]interface{}{}
+	for i := len(observedConfigs) - 1; i >= 0; i-- {
+		if err := mergo.Merge(&reverseMergedObservedConfig, observedConfigs[i]); err != nil {
+			klog.Warningf("merging observed config failed: %v", err)
+		}
+	}
+
+	if !equality.Semantic.DeepEqual(mergedObservedConfig, reverseMergedObservedConfig) {
+		errs = append(errs, errors.New("non-deterministic config observation detected"))
+	}
+
+	if err := c.updateObservedConfig(ctx, syncCtx, existingConfig, mergedObservedConfig); err != nil {
+		errs = []error{err}
+	}
+	configError := v1helpers.NewMultiLineAggregate(errs)
+
+	// update failing condition
+	cond := operatorv1.OperatorCondition{
+		Type:   c.degradedConditionType,
+		Status: operatorv1.ConditionFalse,
+	}
+	if configError != nil {
+		cond.Status = operatorv1.ConditionTrue
+		cond.Reason = "Error"
+		cond.Message = configError.Error()
+	}
+	if _, _, updateError := v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+		return updateError
+	}
+
+	return configError
+}
+
+func (c ConfigObserver) updateObservedConfig(ctx context.Context, syncCtx factory.SyncContext, existingConfig map[string]interface{}, mergedObservedConfig map[string]interface{}) error {
+	if len(c.nestedConfigPath) == 0 {
+		if !equality.Semantic.DeepEqual(existingConfig, mergedObservedConfig) {
+			syncCtx.Recorder().Eventf("ObservedConfigChanged", "Writing updated observed config: %v", diff.ObjectDiff(existingConfig, mergedObservedConfig))
+			return c.updateConfig(ctx, syncCtx, mergedObservedConfig, v1helpers.UpdateObservedConfigFn)
+		}
+		return nil
+	}
+
+	existingConfigNested, _, err := unstructured.NestedMap(existingConfig, c.nestedConfigPath...)
+	if err != nil {
+		return fmt.Errorf("unable to extract the config under %v key, err %v", c.nestedConfigPath, err)
+	}
+	mergedObservedConfigNested, _, err := unstructured.NestedMap(mergedObservedConfig, c.nestedConfigPath...)
+	if err != nil {
+		return fmt.Errorf("unable to extract the merged config under %v, err %v", c.nestedConfigPath, err)
+	}
+	if !equality.Semantic.DeepEqual(existingConfigNested, mergedObservedConfigNested) {
+		syncCtx.Recorder().Eventf("ObservedConfigChanged", "Writing updated section (%q) of observed config: %q", strings.Join(c.nestedConfigPath, "/"), diff.ObjectDiff(existingConfigNested, mergedObservedConfigNested))
+		return c.updateConfig(ctx, syncCtx, mergedObservedConfigNested, c.updateNestedConfigHelper)
+	}
+	return nil
+}
+
+type updateObservedConfigFn func(config map[string]interface{}) v1helpers.UpdateOperatorSpecFunc
+
+func (c ConfigObserver) updateConfig(ctx context.Context, syncCtx factory.SyncContext, updatedMaybeNestedConfig map[string]interface{}, updateConfigHelper updateObservedConfigFn) error {
+	if _, _, err := v1helpers.UpdateSpec(ctx, c.operatorClient, updateConfigHelper(updatedMaybeNestedConfig)); err != nil {
+		// At this point we failed to write the updated config. If we are permanently broken, do not pile the errors from observers
+		// but instead reset the errors and only report single error condition.
+		syncCtx.Recorder().Warningf("ObservedConfigWriteError", "Failed to write observed config: %v", err)
+		return fmt.Errorf("error writing updated observed config: %v", err)
+	}
+	return nil
+}
+
+// updateNestedConfigHelper returns a helper function for updating the nested config.
+func (c ConfigObserver) updateNestedConfigHelper(updatedNestedConfig map[string]interface{}) v1helpers.UpdateOperatorSpecFunc {
+	return func(currentSpec *operatorv1.OperatorSpec) error {
+		existingConfig := map[string]interface{}{}
+		if err := json.NewDecoder(bytes.NewBuffer(currentSpec.ObservedConfig.Raw)).Decode(&existingConfig); err != nil {
+			klog.V(4).Infof("decode of existing config failed with error: %v", err)
+		}
+		if err := unstructured.SetNestedField(existingConfig, updatedNestedConfig, c.nestedConfigPath...); err != nil {
+			return fmt.Errorf("unable to set the nested (%q) observed config: %v", strings.Join(c.nestedConfigPath, "/"), err)
+		}
+		currentSpec.ObservedConfig = runtime.RawExtension{Object: &unstructured.Unstructured{Object: existingConfig}}
+		return nil
+	}
+}
+
+// listersToInformer converts the Listers interface to informer with empty AddEventHandler as we only care about synced caches in the Run.
+func listersToInformer(l Listers) []factory.Informer {
+	result := make([]factory.Informer, len(l.PreRunHasSynced()))
+	for i := range l.PreRunHasSynced() {
+		result[i] = &listerInformer{cacheSynced: l.PreRunHasSynced()[i]}
+	}
+	return result
+}
+
+type listerInformer struct {
+	cacheSynced cache.InformerSynced
+}
+
+func (l *listerInformer) AddEventHandler(cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	return nil, nil
+}
+
+func (l *listerInformer) HasSynced() bool {
+	return l.cacheSynced()
+}
+
+// WithPrefix adds a prefix to the path the input observer would otherwise observe into
+func WithPrefix(observer ObserveConfigFunc, prefix ...string) ObserveConfigFunc {
+	if len(prefix) == 0 {
+		return observer
+	}
+
+	return func(listers Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
+		errs := []error{}
+
+		nestedExistingConfig, _, err := unstructured.NestedMap(existingConfig, prefix...)
+		if err != nil {
+			errs = append(errs, err)
+		}
+
+		orig, observerErrs := observer(listers, recorder, nestedExistingConfig)
+		errs = append(errs, observerErrs...)
+
+		if orig == nil {
+			return nil, errs
+		}
+
+		ret := map[string]interface{}{}
+		if err := unstructured.SetNestedField(ret, orig, prefix...); err != nil {
+			errs = append(errs, err)
+		}
+		return ret, errs
+
+	}
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/featuregate.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/featuregate.go
@@ -1,0 +1,48 @@
+package featuregates
+
+import (
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// FeatureGate indicates whether a given feature is enabled or not
+// This interface is heavily influenced by k8s.io/component-base, but not exactly compatible.
+type FeatureGate interface {
+	// Enabled returns true if the key is enabled.
+	Enabled(key configv1.FeatureGateName) bool
+	// KnownFeatures returns a slice of strings describing the FeatureGate's known features.
+	KnownFeatures() []configv1.FeatureGateName
+}
+
+type featureGate struct {
+	enabled  sets.Set[configv1.FeatureGateName]
+	disabled sets.Set[configv1.FeatureGateName]
+}
+
+func NewFeatureGate(enabled, disabled []configv1.FeatureGateName) FeatureGate {
+	return &featureGate{
+		enabled:  sets.New[configv1.FeatureGateName](enabled...),
+		disabled: sets.New[configv1.FeatureGateName](disabled...),
+	}
+}
+
+func (f *featureGate) Enabled(key configv1.FeatureGateName) bool {
+	if f.enabled.Has(key) {
+		return true
+	}
+	if f.disabled.Has(key) {
+		return false
+	}
+
+	panic(fmt.Errorf("feature %q is not registered in FeatureGates %v", key, f.KnownFeatures()))
+}
+
+func (f *featureGate) KnownFeatures() []configv1.FeatureGateName {
+	allKnown := sets.New[string]()
+	allKnown.Insert(FeatureGateNamesToStrings(f.enabled.UnsortedList())...)
+	allKnown.Insert(FeatureGateNamesToStrings(f.disabled.UnsortedList())...)
+
+	return StringsToFeatureGateNames(sets.List(allKnown))
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/hardcoded_featuregate_reader.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/hardcoded_featuregate_reader.go
@@ -1,0 +1,78 @@
+package featuregates
+
+import (
+	"context"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+type hardcodedFeatureGateAccess struct {
+	enabled  []configv1.FeatureGateName
+	disabled []configv1.FeatureGateName
+	readErr  error
+
+	initialFeatureGatesObserved chan struct{}
+}
+
+// NewHardcodedFeatureGateAccess returns a FeatureGateAccess that is always initialized and always
+// returns the provided feature gates.
+func NewHardcodedFeatureGateAccess(enabled, disabled []configv1.FeatureGateName) FeatureGateAccess {
+	initialFeatureGatesObserved := make(chan struct{})
+	close(initialFeatureGatesObserved)
+	c := &hardcodedFeatureGateAccess{
+		enabled:                     enabled,
+		disabled:                    disabled,
+		initialFeatureGatesObserved: initialFeatureGatesObserved,
+	}
+
+	return c
+}
+
+// NewHardcodedFeatureGateAccessForTesting returns a FeatureGateAccess that returns stub responses
+// using caller-supplied values.
+func NewHardcodedFeatureGateAccessForTesting(enabled, disabled []configv1.FeatureGateName, initialFeatureGatesObserved chan struct{}, readErr error) FeatureGateAccess {
+	return &hardcodedFeatureGateAccess{
+		enabled:                     enabled,
+		disabled:                    disabled,
+		initialFeatureGatesObserved: initialFeatureGatesObserved,
+		readErr:                     readErr,
+	}
+}
+
+func (c *hardcodedFeatureGateAccess) SetChangeHandler(featureGateChangeHandlerFn FeatureGateChangeHandlerFunc) {
+	// ignore
+}
+
+func (c *hardcodedFeatureGateAccess) Run(ctx context.Context) {
+	// ignore
+}
+
+func (c *hardcodedFeatureGateAccess) InitialFeatureGatesObserved() <-chan struct{} {
+	return c.initialFeatureGatesObserved
+}
+
+func (c *hardcodedFeatureGateAccess) AreInitialFeatureGatesObserved() bool {
+	select {
+	case <-c.InitialFeatureGatesObserved():
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *hardcodedFeatureGateAccess) CurrentFeatureGates() (FeatureGate, error) {
+	return NewFeatureGate(c.enabled, c.disabled), c.readErr
+}
+
+// NewHardcodedFeatureGateAccessFromFeatureGate returns a FeatureGateAccess that is static and initialised from
+// a populated FeatureGate status.
+// If the desired version is missing, this will return an error.
+func NewHardcodedFeatureGateAccessFromFeatureGate(featureGate *configv1.FeatureGate, desiredVersion string) (FeatureGateAccess, error) {
+	features, err := featuresFromFeatureGate(featureGate, desiredVersion)
+	if err != nil {
+		return nil, fmt.Errorf("unable to determine features: %w", err)
+	}
+
+	return NewHardcodedFeatureGateAccess(features.Enabled, features.Disabled), nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/observe_featuregates.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/observe_featuregates.go
@@ -1,0 +1,118 @@
+package featuregates
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+// NewObserveFeatureFlagsFunc produces a configobserver for feature gates.  If non-nil, the featureWhitelist filters
+// feature gates to a known subset (instead of everything).  The featureBlacklist will stop certain features from making
+// it through the list.  The featureBlacklist should be empty, but for a brief time, some featuregates may need to skipped.
+// @smarterclayton will live forever in shame for being the first to require this for "IPv6DualStack".
+func NewObserveFeatureFlagsFunc(featureWhitelist sets.Set[configv1.FeatureGateName], featureBlacklist sets.Set[configv1.FeatureGateName], configPath []string, featureGateAccess FeatureGateAccess) configobserver.ObserveConfigFunc {
+	return (&featureFlags{
+		allowAll:          len(featureWhitelist) == 0,
+		featureWhitelist:  featureWhitelist,
+		featureBlacklist:  featureBlacklist,
+		configPath:        configPath,
+		featureGateAccess: featureGateAccess,
+	}).ObserveFeatureFlags
+}
+
+type featureFlags struct {
+	allowAll         bool
+	featureWhitelist sets.Set[configv1.FeatureGateName]
+	// we add a forceDisableFeature list because we've now had bad featuregates break individual operators.  Awesome.
+	featureBlacklist  sets.Set[configv1.FeatureGateName]
+	configPath        []string
+	featureGateAccess FeatureGateAccess
+}
+
+// ObserveFeatureFlags fills in --feature-flags for the kube-apiserver
+func (f *featureFlags) ObserveFeatureFlags(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
+	prunedExistingConfig := configobserver.Pruned(existingConfig, f.configPath)
+
+	errs := []error{}
+
+	if !f.featureGateAccess.AreInitialFeatureGatesObserved() {
+		// if we haven't observed featuregates yet, return the existing
+		return prunedExistingConfig, nil
+	}
+
+	featureGates, err := f.featureGateAccess.CurrentFeatureGates()
+	if err != nil {
+		return prunedExistingConfig, append(errs, err)
+	}
+	observedConfig := map[string]interface{}{}
+	newConfigValue := f.getWhitelistedFeatureNames(featureGates)
+
+	currentConfigValue, _, err := unstructured.NestedStringSlice(existingConfig, f.configPath...)
+	if err != nil {
+		errs = append(errs, err)
+		// keep going on read error from existing config
+	}
+	if !reflect.DeepEqual(currentConfigValue, newConfigValue) {
+		recorder.Eventf("ObserveFeatureFlagsUpdated", "Updated %v to %s", strings.Join(f.configPath, "."), strings.Join(newConfigValue, ","))
+	}
+
+	if err := unstructured.SetNestedStringSlice(observedConfig, newConfigValue, f.configPath...); err != nil {
+		recorder.Warningf("ObserveFeatureFlags", "Failed setting %v: %v", strings.Join(f.configPath, "."), err)
+		return prunedExistingConfig, append(errs, err)
+	}
+
+	return configobserver.Pruned(observedConfig, f.configPath), errs
+}
+
+func (f *featureFlags) getWhitelistedFeatureNames(featureGates FeatureGate) []string {
+	newConfigValue := []string{}
+	formatEnabledFunc := func(fs configv1.FeatureGateName) string {
+		return fmt.Sprintf("%v=true", fs)
+	}
+	formatDisabledFunc := func(fs configv1.FeatureGateName) string {
+		return fmt.Sprintf("%v=false", fs)
+	}
+
+	for _, knownFeatureGate := range featureGates.KnownFeatures() {
+		if f.featureBlacklist.Has(knownFeatureGate) {
+			continue
+		}
+		// only add whitelisted feature flags
+		if !f.allowAll && !f.featureWhitelist.Has(knownFeatureGate) {
+			continue
+		}
+
+		if featureGates.Enabled(knownFeatureGate) {
+			newConfigValue = append(newConfigValue, formatEnabledFunc(knownFeatureGate))
+		} else {
+			newConfigValue = append(newConfigValue, formatDisabledFunc(knownFeatureGate))
+		}
+	}
+
+	return newConfigValue
+}
+
+func StringsToFeatureGateNames(in []string) []configv1.FeatureGateName {
+	out := []configv1.FeatureGateName{}
+	for _, curr := range in {
+		out = append(out, configv1.FeatureGateName(curr))
+	}
+
+	return out
+}
+
+func FeatureGateNamesToStrings(in []configv1.FeatureGateName) []string {
+	out := []string{}
+	for _, curr := range in {
+		out = append(out, string(curr))
+	}
+
+	return out
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/simple_featuregate_reader.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/simple_featuregate_reader.go
@@ -1,0 +1,318 @@
+package featuregates
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+	"sync"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	v1 "github.com/openshift/client-go/config/informers/externalversions/config/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/operator/events"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+)
+
+type FeatureGateChangeHandlerFunc func(featureChange FeatureChange)
+
+// FeatureGateAccess is used to get a list of enabled and disabled featuregates.
+// Create a new instance using NewFeatureGateAccess.
+// To create one for unit testing, use NewHardcodedFeatureGateAccess.
+type FeatureGateAccess interface {
+	// SetChangeHandler can only be called before Run.
+	// The default change handler will exit 0 when the set of featuregates changes.
+	// That is usually the easiest and simplest thing for an *operator* to do.
+	// This also discourages direct operand reading since all operands restarting simultaneously is bad.
+	// This function allows changing that default behavior to something else (perhaps a channel notification for
+	// all impacted controllers in an operator.
+	// I doubt this will be worth the effort in the majority of cases.
+	SetChangeHandler(featureGateChangeHandlerFn FeatureGateChangeHandlerFunc)
+
+	// Run starts a go func that continously watches the set of featuregates enabled in the cluster.
+	Run(ctx context.Context)
+	// InitialFeatureGatesObserved returns a channel that is closed once the featuregates have
+	// been observed. Once closed, the CurrentFeatureGates method will return the current set of
+	// featuregates and will never return a non-nil error.
+	InitialFeatureGatesObserved() <-chan struct{}
+	// CurrentFeatureGates returns the list of enabled and disabled featuregates.
+	// It returns an error if the current set of featuregates is not known.
+	CurrentFeatureGates() (FeatureGate, error)
+	// AreInitialFeatureGatesObserved returns true if the initial featuregates have been observed.
+	AreInitialFeatureGatesObserved() bool
+}
+
+type Features struct {
+	Enabled  []configv1.FeatureGateName
+	Disabled []configv1.FeatureGateName
+}
+
+type FeatureChange struct {
+	Previous *Features
+	New      Features
+}
+
+type defaultFeatureGateAccess struct {
+	desiredVersion              string
+	missingVersionMarker        string
+	clusterVersionLister        configlistersv1.ClusterVersionLister
+	featureGateLister           configlistersv1.FeatureGateLister
+	initialFeatureGatesObserved chan struct{}
+
+	featureGateChangeHandlerFn FeatureGateChangeHandlerFunc
+
+	lock            sync.Mutex
+	started         bool
+	initialFeatures Features
+	currentFeatures Features
+
+	queue         workqueue.RateLimitingInterface
+	eventRecorder events.Recorder
+}
+
+// NewFeatureGateAccess returns a controller that keeps the list of enabled/disabled featuregates up to date.
+// desiredVersion is the version of this operator that would be set on the clusteroperator.status.versions.
+// missingVersionMarker is the stub version provided by the operator.  If that is also the desired version,
+// then the most either the desired clusterVersion or most recent version will be used.
+// clusterVersionInformer is used when desiredVersion and missingVersionMarker are the same to derive the "best" version
+// of featuregates to use.
+// featureGateInformer is used to track changes to the featureGates once they are initially set.
+// By default, when the enabled/disabled list  of featuregates changes, os.Exit is called.  This behavior can be
+// overridden by calling SetChangeHandler to whatever you wish the behavior to be.
+// A common construct is:
+/* go
+featureGateAccessor := NewFeatureGateAccess(args)
+go featureGateAccessor.Run(ctx)
+
+select{
+case <- featureGateAccessor.InitialFeatureGatesObserved():
+	featureGates, _ := featureGateAccessor.CurrentFeatureGates()
+	klog.Infof("FeatureGates initialized: knownFeatureGates=%v", featureGates.KnownFeatures())
+case <- time.After(1*time.Minute):
+	klog.Errorf("timed out waiting for FeatureGate detection")
+	return fmt.Errorf("timed out waiting for FeatureGate detection")
+}
+
+// whatever other initialization you have to do, at this point you have FeatureGates to drive your behavior.
+*/
+// That construct is easy.  It is better to use the .spec.observedConfiguration construct common in library-go operators
+// to avoid gating your general startup on FeatureGate determination, but if you haven't already got that mechanism
+// this construct is easy.
+func NewFeatureGateAccess(
+	desiredVersion, missingVersionMarker string,
+	clusterVersionInformer v1.ClusterVersionInformer,
+	featureGateInformer v1.FeatureGateInformer,
+	eventRecorder events.Recorder) FeatureGateAccess {
+	c := &defaultFeatureGateAccess{
+		desiredVersion:              desiredVersion,
+		missingVersionMarker:        missingVersionMarker,
+		clusterVersionLister:        clusterVersionInformer.Lister(),
+		featureGateLister:           featureGateInformer.Lister(),
+		initialFeatureGatesObserved: make(chan struct{}),
+		queue:                       workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "feature-gate-detector"),
+		eventRecorder:               eventRecorder,
+	}
+	c.SetChangeHandler(ForceExit)
+
+	// we aren't expecting many
+	clusterVersionInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			c.queue.Add("cluster")
+		},
+		UpdateFunc: func(old, cur interface{}) {
+			c.queue.Add("cluster")
+		},
+		DeleteFunc: func(uncast interface{}) {
+			c.queue.Add("cluster")
+		},
+	})
+	featureGateInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			c.queue.Add("cluster")
+		},
+		UpdateFunc: func(old, cur interface{}) {
+			c.queue.Add("cluster")
+		},
+		DeleteFunc: func(uncast interface{}) {
+			c.queue.Add("cluster")
+		},
+	})
+
+	return c
+}
+
+func ForceExit(featureChange FeatureChange) {
+	if featureChange.Previous != nil {
+		os.Exit(0)
+	}
+}
+
+func (c *defaultFeatureGateAccess) SetChangeHandler(featureGateChangeHandlerFn FeatureGateChangeHandlerFunc) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.started {
+		panic("programmer error, cannot update the change handler after starting")
+	}
+	c.featureGateChangeHandlerFn = featureGateChangeHandlerFn
+}
+
+func (c *defaultFeatureGateAccess) Run(ctx context.Context) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	klog.Infof("Starting feature-gate-detector")
+	defer klog.Infof("Shutting down feature-gate-detector")
+
+	go wait.UntilWithContext(ctx, c.runWorker, time.Second)
+
+	<-ctx.Done()
+}
+
+func (c *defaultFeatureGateAccess) syncHandler(ctx context.Context) error {
+	desiredVersion := c.desiredVersion
+	if c.missingVersionMarker == c.desiredVersion {
+		clusterVersion, err := c.clusterVersionLister.Get("version")
+		if apierrors.IsNotFound(err) {
+			return nil // we will be re-triggered when it is created
+		}
+		if err != nil {
+			return err
+		}
+
+		desiredVersion = clusterVersion.Status.Desired.Version
+		if len(desiredVersion) == 0 && len(clusterVersion.Status.History) > 0 {
+			desiredVersion = clusterVersion.Status.History[0].Version
+		}
+	}
+
+	featureGate, err := c.featureGateLister.Get("cluster")
+	if apierrors.IsNotFound(err) {
+		return nil // we will be re-triggered when it is created
+	}
+	if err != nil {
+		return err
+	}
+
+	features, err := featuresFromFeatureGate(featureGate, desiredVersion)
+	if err != nil {
+		return fmt.Errorf("unable to determine features: %w", err)
+	}
+
+	c.setFeatureGates(features)
+
+	return nil
+}
+
+func (c *defaultFeatureGateAccess) setFeatureGates(features Features) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	var previousFeatures *Features
+	if c.AreInitialFeatureGatesObserved() {
+		t := c.currentFeatures
+		previousFeatures = &t
+	}
+
+	c.currentFeatures = features
+
+	if !c.AreInitialFeatureGatesObserved() {
+		c.initialFeatures = features
+		close(c.initialFeatureGatesObserved)
+		c.eventRecorder.Eventf("FeatureGatesInitialized", "FeatureGates updated to %#v", c.currentFeatures)
+	}
+
+	if previousFeatures == nil || !reflect.DeepEqual(*previousFeatures, c.currentFeatures) {
+		if previousFeatures != nil {
+			c.eventRecorder.Eventf("FeatureGatesModified", "FeatureGates updated to %#v", c.currentFeatures)
+		}
+
+		c.featureGateChangeHandlerFn(FeatureChange{
+			Previous: previousFeatures,
+			New:      c.currentFeatures,
+		})
+	}
+}
+
+func (c *defaultFeatureGateAccess) InitialFeatureGatesObserved() <-chan struct{} {
+	return c.initialFeatureGatesObserved
+}
+
+func (c *defaultFeatureGateAccess) AreInitialFeatureGatesObserved() bool {
+	select {
+	case <-c.InitialFeatureGatesObserved():
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *defaultFeatureGateAccess) CurrentFeatureGates() (FeatureGate, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if !c.AreInitialFeatureGatesObserved() {
+		return nil, fmt.Errorf("featureGates not yet observed")
+	}
+	retEnabled := make([]configv1.FeatureGateName, len(c.currentFeatures.Enabled))
+	retDisabled := make([]configv1.FeatureGateName, len(c.currentFeatures.Disabled))
+	copy(retEnabled, c.currentFeatures.Enabled)
+	copy(retDisabled, c.currentFeatures.Disabled)
+
+	return NewFeatureGate(retEnabled, retDisabled), nil
+}
+
+func (c *defaultFeatureGateAccess) runWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *defaultFeatureGateAccess) processNextWorkItem(ctx context.Context) bool {
+	dsKey, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(dsKey)
+
+	err := c.syncHandler(ctx)
+	if err == nil {
+		c.queue.Forget(dsKey)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
+	c.queue.AddRateLimited(dsKey)
+
+	return true
+}
+
+func featuresFromFeatureGate(featureGate *configv1.FeatureGate, desiredVersion string) (Features, error) {
+	found := false
+	features := Features{}
+	for _, featureGateValues := range featureGate.Status.FeatureGates {
+		if featureGateValues.Version != desiredVersion {
+			continue
+		}
+		found = true
+		for _, enabled := range featureGateValues.Enabled {
+			features.Enabled = append(features.Enabled, enabled.Name)
+		}
+		for _, disabled := range featureGateValues.Disabled {
+			features.Disabled = append(features.Disabled, disabled.Name)
+		}
+		break
+	}
+
+	if !found {
+		return Features{}, fmt.Errorf("missing desired version %q in featuregates.config.openshift.io/cluster", desiredVersion)
+	}
+
+	return features, nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/unstructured.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/unstructured.go
@@ -1,0 +1,45 @@
+package configobserver
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// Pruned returns the unstructured filtered by the given paths, i.e. everything
+// outside of them will be dropped. The returned data structure might overlap
+// with the input, but the input is not mutated. In case of error for a path,
+// that path is dropped.
+func Pruned(obj map[string]interface{}, pths ...[]string) map[string]interface{} {
+	if obj == nil || len(pths) == 0 {
+		return obj
+	}
+
+	ret := map[string]interface{}{}
+	if len(pths) == 1 {
+		x, found, err := unstructured.NestedFieldCopy(obj, pths[0]...)
+		if err != nil || !found {
+			return ret
+		}
+		unstructured.SetNestedField(ret, x, pths[0]...)
+		return ret
+	}
+
+	for i, p := range pths {
+		x, found, err := unstructured.NestedFieldCopy(obj, p...)
+		if err != nil {
+			continue
+		}
+		if !found {
+			continue
+		}
+		if i < len(pths)-1 {
+			// this might be overwritten by a later path
+			x = runtime.DeepCopyJSONValue(x)
+		}
+		if err := unstructured.SetNestedField(ret, x, p...); err != nil {
+			continue
+		}
+	}
+
+	return ret
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/core.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/core.go
@@ -1,0 +1,72 @@
+package resourcesynccontroller
+
+import (
+	"crypto/x509"
+	"fmt"
+	"reflect"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/util/cert"
+
+	"github.com/openshift/library-go/pkg/crypto"
+	"github.com/openshift/library-go/pkg/operator/certrotation"
+)
+
+func CombineCABundleConfigMaps(destinationConfigMap ResourceLocation, lister corev1listers.ConfigMapLister, additionalAnnotations certrotation.AdditionalAnnotations, inputConfigMaps ...ResourceLocation) (*corev1.ConfigMap, error) {
+	certificates := []*x509.Certificate{}
+	for _, input := range inputConfigMaps {
+		inputConfigMap, err := lister.ConfigMaps(input.Namespace).Get(input.Name)
+		if apierrors.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		// configmaps must conform to this
+		inputContent := inputConfigMap.Data["ca-bundle.crt"]
+		if len(inputContent) == 0 {
+			continue
+		}
+		inputCerts, err := cert.ParseCertsPEM([]byte(inputContent))
+		if err != nil {
+			return nil, fmt.Errorf("configmap/%s in %q is malformed: %v", input.Name, input.Namespace, err)
+		}
+		certificates = append(certificates, inputCerts...)
+	}
+
+	certificates = crypto.FilterExpiredCerts(certificates...)
+	finalCertificates := []*x509.Certificate{}
+	// now check for duplicates. n^2, but super simple
+	for i := range certificates {
+		found := false
+		for j := range finalCertificates {
+			if reflect.DeepEqual(certificates[i].Raw, finalCertificates[j].Raw) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			finalCertificates = append(finalCertificates, certificates[i])
+		}
+	}
+
+	caBytes, err := crypto.EncodeCertificates(finalCertificates...)
+	if err != nil {
+		return nil, err
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: certrotation.NewTLSArtifactObjectMeta(
+			destinationConfigMap.Name,
+			destinationConfigMap.Namespace,
+			additionalAnnotations,
+		),
+		Data: map[string]string{
+			"ca-bundle.crt": string(caBytes),
+		},
+	}
+	return cm, nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/interfaces.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/interfaces.go
@@ -1,0 +1,41 @@
+package resourcesynccontroller
+
+import "k8s.io/apimachinery/pkg/util/sets"
+
+// ResourceLocation describes coordinates for a resource to be synced
+type ResourceLocation struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+
+	// Provider if set for the source location enhance the error message to point to the component which
+	// provide this resource.
+	Provider string `json:"provider,omitempty"`
+}
+
+// PreconditionsFulfilled is a function that indicates whether all prerequisites
+// are met and a resource can be synced.
+type preconditionsFulfilled func() (bool, error)
+
+func alwaysFulfilledPreconditions() (bool, error) { return true, nil }
+
+type syncRuleSource struct {
+	ResourceLocation
+	syncedKeys               sets.Set[string]       // defines the set of keys to sync from source to dest
+	preconditionsFulfilledFn preconditionsFulfilled // preconditions to fulfill before syncing the resource
+}
+
+type syncRules map[ResourceLocation]syncRuleSource
+
+var (
+	emptyResourceLocation = ResourceLocation{}
+)
+
+// ResourceSyncer allows changes to syncing rules by this controller
+type ResourceSyncer interface {
+	// SyncConfigMap indicates that a configmap should be copied from the source to the destination.  It will also
+	// mirror a deletion from the source.  If the source is a zero object the destination will be deleted.
+	SyncConfigMap(destination, source ResourceLocation) error
+	// SyncSecret indicates that a secret should be copied from the source to the destination.  It will also
+	// mirror a deletion from the source.  If the source is a zero object the destination will be deleted.
+	SyncSecret(destination, source ResourceLocation) error
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/resourcesync_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/resourcesync_controller.go
@@ -1,0 +1,340 @@
+package resourcesynccontroller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/condition"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/management"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+// ResourceSyncController is a controller that will copy source configmaps and secrets to their destinations.
+// It will also mirror deletions by deleting destinations.
+type ResourceSyncController struct {
+	name string
+	// syncRuleLock is used to ensure we avoid races on changes to syncing rules
+	syncRuleLock sync.RWMutex
+	// configMapSyncRules is a map from destination location to source location
+	configMapSyncRules syncRules
+	// secretSyncRules is a map from destination location to source location
+	secretSyncRules syncRules
+
+	// knownNamespaces is the list of namespaces we are watching.
+	knownNamespaces sets.Set[string]
+
+	configMapGetter            corev1client.ConfigMapsGetter
+	secretGetter               corev1client.SecretsGetter
+	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces
+	operatorConfigClient       v1helpers.OperatorClient
+
+	runFn   func(ctx context.Context, workers int)
+	syncCtx factory.SyncContext
+}
+
+var _ ResourceSyncer = &ResourceSyncController{}
+var _ factory.Controller = &ResourceSyncController{}
+
+// NewResourceSyncController creates ResourceSyncController.
+func NewResourceSyncController(
+	operatorConfigClient v1helpers.OperatorClient,
+	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
+	secretsGetter corev1client.SecretsGetter,
+	configMapsGetter corev1client.ConfigMapsGetter,
+	eventRecorder events.Recorder,
+) *ResourceSyncController {
+	c := &ResourceSyncController{
+		name:                 "ResourceSyncController",
+		operatorConfigClient: operatorConfigClient,
+
+		configMapSyncRules:         syncRules{},
+		secretSyncRules:            syncRules{},
+		kubeInformersForNamespaces: kubeInformersForNamespaces,
+		knownNamespaces:            kubeInformersForNamespaces.Namespaces(),
+
+		configMapGetter: v1helpers.CachedConfigMapGetter(configMapsGetter, kubeInformersForNamespaces),
+		secretGetter:    v1helpers.CachedSecretGetter(secretsGetter, kubeInformersForNamespaces),
+		syncCtx:         factory.NewSyncContext("ResourceSyncController", eventRecorder.WithComponentSuffix("resource-sync-controller")),
+	}
+
+	informers := []factory.Informer{
+		operatorConfigClient.Informer(),
+	}
+	for namespace := range kubeInformersForNamespaces.Namespaces() {
+		if len(namespace) == 0 {
+			continue
+		}
+		informer := kubeInformersForNamespaces.InformersFor(namespace)
+		informers = append(informers, informer.Core().V1().ConfigMaps().Informer())
+		informers = append(informers, informer.Core().V1().Secrets().Informer())
+	}
+
+	f := factory.New().WithSync(c.Sync).WithSyncContext(c.syncCtx).WithInformers(informers...).ResyncEvery(time.Minute).ToController(c.name, eventRecorder.WithComponentSuffix("resource-sync-controller"))
+	c.runFn = f.Run
+
+	return c
+}
+
+func (c *ResourceSyncController) Run(ctx context.Context, workers int) {
+	c.runFn(ctx, workers)
+}
+
+func (c *ResourceSyncController) Name() string {
+	return c.name
+}
+
+func (c *ResourceSyncController) SyncConfigMap(destination, source ResourceLocation) error {
+	return c.syncConfigMap(destination, source, alwaysFulfilledPreconditions)
+}
+
+func (c *ResourceSyncController) SyncPartialConfigMap(destination ResourceLocation, source ResourceLocation, keys ...string) error {
+	return c.syncConfigMap(destination, source, alwaysFulfilledPreconditions, keys...)
+}
+
+// SyncConfigMapConditionally adds a new configmap that the resource sync
+// controller will synchronise if the given precondition is fulfilled.
+func (c *ResourceSyncController) SyncConfigMapConditionally(destination, source ResourceLocation, preconditionsFulfilledFn preconditionsFulfilled) error {
+	return c.syncConfigMap(destination, source, preconditionsFulfilledFn)
+}
+
+func (c *ResourceSyncController) syncConfigMap(destination ResourceLocation, source ResourceLocation, preconditionsFulfilledFn preconditionsFulfilled, keys ...string) error {
+	if !c.knownNamespaces.Has(destination.Namespace) {
+		return fmt.Errorf("not watching namespace %q", destination.Namespace)
+	}
+	if source != emptyResourceLocation && !c.knownNamespaces.Has(source.Namespace) {
+		return fmt.Errorf("not watching namespace %q", source.Namespace)
+	}
+
+	c.syncRuleLock.Lock()
+	defer c.syncRuleLock.Unlock()
+	c.configMapSyncRules[destination] = syncRuleSource{
+		ResourceLocation:         source,
+		syncedKeys:               sets.New(keys...),
+		preconditionsFulfilledFn: preconditionsFulfilledFn,
+	}
+
+	// make sure the new rule is picked up
+	c.syncCtx.Queue().Add(c.syncCtx.QueueKey())
+	return nil
+}
+
+func (c *ResourceSyncController) SyncSecret(destination, source ResourceLocation) error {
+	return c.syncSecret(destination, source, alwaysFulfilledPreconditions)
+}
+
+func (c *ResourceSyncController) SyncPartialSecret(destination, source ResourceLocation, keys ...string) error {
+	return c.syncSecret(destination, source, alwaysFulfilledPreconditions, keys...)
+}
+
+// SyncSecretConditionally adds a new secret that the resource sync controller
+// will synchronise if the given precondition is fulfilled.
+func (c *ResourceSyncController) SyncSecretConditionally(destination, source ResourceLocation, preconditionsFulfilledFn preconditionsFulfilled) error {
+	return c.syncSecret(destination, source, preconditionsFulfilledFn)
+}
+
+func (c *ResourceSyncController) syncSecret(destination, source ResourceLocation, preconditionsFulfilledFn preconditionsFulfilled, keys ...string) error {
+	if !c.knownNamespaces.Has(destination.Namespace) {
+		return fmt.Errorf("not watching namespace %q", destination.Namespace)
+	}
+	if source != emptyResourceLocation && !c.knownNamespaces.Has(source.Namespace) {
+		return fmt.Errorf("not watching namespace %q", source.Namespace)
+	}
+
+	c.syncRuleLock.Lock()
+	defer c.syncRuleLock.Unlock()
+	c.secretSyncRules[destination] = syncRuleSource{
+		ResourceLocation:         source,
+		syncedKeys:               sets.New(keys...),
+		preconditionsFulfilledFn: preconditionsFulfilledFn,
+	}
+
+	// make sure the new rule is picked up
+	c.syncCtx.Queue().Add(c.syncCtx.QueueKey())
+	return nil
+}
+
+// errorWithProvider provides a finger of blame in case a source resource cannot be retrieved.
+func errorWithProvider(provider string, err error) error {
+	if len(provider) > 0 {
+		return fmt.Errorf("%w (check the %q that is supposed to provide this resource)", err, provider)
+	}
+	return err
+}
+
+func (c *ResourceSyncController) Sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	operatorSpec, _, _, err := c.operatorConfigClient.GetOperatorState()
+	if err != nil {
+		return err
+	}
+
+	if !management.IsOperatorManaged(operatorSpec.ManagementState) {
+		return nil
+	}
+
+	c.syncRuleLock.RLock()
+	defer c.syncRuleLock.RUnlock()
+
+	errors := []error{}
+
+	for destination, source := range c.configMapSyncRules {
+		// skip the sync if the preconditions aren't fulfilled
+		if fulfilled, err := source.preconditionsFulfilledFn(); !fulfilled || err != nil {
+			if err != nil {
+				errors = append(errors, err)
+			}
+			continue
+		}
+
+		if source.ResourceLocation == emptyResourceLocation {
+			// use the cache to check whether the configmap exists in target namespace, if not skip the extra delete call.
+			if _, err := c.configMapGetter.ConfigMaps(destination.Namespace).Get(ctx, destination.Name, metav1.GetOptions{}); err != nil {
+				if !apierrors.IsNotFound(err) {
+					errors = append(errors, err)
+				}
+				continue
+			}
+			if err := c.configMapGetter.ConfigMaps(destination.Namespace).Delete(ctx, destination.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				errors = append(errors, err)
+			}
+			continue
+		}
+
+		_, _, err := resourceapply.SyncPartialConfigMap(ctx, c.configMapGetter, syncCtx.Recorder(), source.Namespace, source.Name, destination.Namespace, destination.Name, source.syncedKeys, []metav1.OwnerReference{})
+		if err != nil {
+			errors = append(errors, errorWithProvider(source.Provider, err))
+		}
+	}
+	for destination, source := range c.secretSyncRules {
+		// skip the sync if the preconditions aren't fulfilled
+		if fulfilled, err := source.preconditionsFulfilledFn(); !fulfilled || err != nil {
+			if err != nil {
+				errors = append(errors, err)
+			}
+			continue
+		}
+
+		if source.ResourceLocation == emptyResourceLocation {
+			// use the cache to check whether the secret exists in target namespace, if not skip the extra delete call.
+			if _, err := c.secretGetter.Secrets(destination.Namespace).Get(ctx, destination.Name, metav1.GetOptions{}); err != nil {
+				if !apierrors.IsNotFound(err) {
+					errors = append(errors, err)
+				}
+				continue
+			}
+			if err := c.secretGetter.Secrets(destination.Namespace).Delete(ctx, destination.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				errors = append(errors, err)
+			}
+			continue
+		}
+
+		_, _, err := resourceapply.SyncPartialSecret(ctx, c.secretGetter, syncCtx.Recorder(), source.Namespace, source.Name, destination.Namespace, destination.Name, source.syncedKeys, []metav1.OwnerReference{})
+		if err != nil {
+			errors = append(errors, errorWithProvider(source.Provider, err))
+		}
+	}
+
+	if len(errors) > 0 {
+		cond := operatorv1.OperatorCondition{
+			Type:    condition.ResourceSyncControllerDegradedConditionType,
+			Status:  operatorv1.ConditionTrue,
+			Reason:  "Error",
+			Message: v1helpers.NewMultiLineAggregate(errors).Error(),
+		}
+		if _, _, updateError := v1helpers.UpdateStatus(ctx, c.operatorConfigClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+			return updateError
+		}
+		return nil
+	}
+
+	cond := operatorv1.OperatorCondition{
+		Type:   condition.ResourceSyncControllerDegradedConditionType,
+		Status: operatorv1.ConditionFalse,
+	}
+	if _, _, updateError := v1helpers.UpdateStatus(ctx, c.operatorConfigClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+		return updateError
+	}
+	return nil
+}
+
+func NewDebugHandler(controller *ResourceSyncController) http.Handler {
+	return &debugHTTPHandler{controller: controller}
+}
+
+type debugHTTPHandler struct {
+	controller *ResourceSyncController
+}
+
+type ResourceSyncRule struct {
+	Destination ResourceLocation `json:"destination"`
+	Source      syncRuleSource   `json:"source"`
+}
+
+type ResourceSyncRuleList []ResourceSyncRule
+
+func (l ResourceSyncRuleList) Len() int      { return len(l) }
+func (l ResourceSyncRuleList) Swap(i, j int) { l[i], l[j] = l[j], l[i] }
+func (l ResourceSyncRuleList) Less(i, j int) bool {
+	if strings.Compare(l[i].Source.Namespace, l[j].Source.Namespace) < 0 {
+		return true
+	}
+	if strings.Compare(l[i].Source.Namespace, l[j].Source.Namespace) > 0 {
+		return false
+	}
+	if strings.Compare(l[i].Source.Name, l[j].Source.Name) < 0 {
+		return true
+	}
+	return false
+}
+
+type ControllerSyncRules struct {
+	Secrets ResourceSyncRuleList `json:"secrets"`
+	Configs ResourceSyncRuleList `json:"configs"`
+}
+
+// ServeSyncRules provides a handler function to return the sync rules of the controller
+func (h *debugHTTPHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	syncRules := ControllerSyncRules{ResourceSyncRuleList{}, ResourceSyncRuleList{}}
+
+	h.controller.syncRuleLock.RLock()
+	defer h.controller.syncRuleLock.RUnlock()
+	syncRules.Secrets = append(syncRules.Secrets, resourceSyncRuleList(h.controller.secretSyncRules)...)
+	syncRules.Configs = append(syncRules.Configs, resourceSyncRuleList(h.controller.configMapSyncRules)...)
+
+	data, err := json.Marshal(syncRules)
+	if err != nil {
+		w.Write([]byte(err.Error()))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.Write(data)
+	w.WriteHeader(http.StatusOK)
+}
+
+func resourceSyncRuleList(syncRules syncRules) ResourceSyncRuleList {
+	rules := make(ResourceSyncRuleList, 0, len(syncRules))
+	for dest, src := range syncRules {
+		rule := ResourceSyncRule{
+			Source:      src,
+			Destination: dest,
+		}
+		rules = append(rules, rule)
+	}
+	sort.Sort(rules)
+	return rules
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/status/condition.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/status/condition.go
@@ -1,0 +1,169 @@
+package status
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+)
+
+// UnionCondition returns a single operator condition that is the union of multiple operator conditions.
+//
+// defaultConditionStatus indicates whether you want to merge all Falses or merge all Trues.  For instance, Failures merge
+// on true, but Available merges on false.  Thing of it like an anti-default.
+//
+// If inertia is non-nil, then resist returning a condition with a status opposite the defaultConditionStatus.
+func UnionCondition(conditionType string, defaultConditionStatus operatorv1.ConditionStatus, inertia Inertia, allConditions ...operatorv1.OperatorCondition) operatorv1.OperatorCondition {
+	var oppositeConditionStatus operatorv1.ConditionStatus
+	if defaultConditionStatus == operatorv1.ConditionTrue {
+		oppositeConditionStatus = operatorv1.ConditionFalse
+	} else {
+		oppositeConditionStatus = operatorv1.ConditionTrue
+	}
+
+	interestingConditions := []operatorv1.OperatorCondition{}
+	badConditions := []operatorv1.OperatorCondition{}
+	badConditionStatus := operatorv1.ConditionUnknown
+	for _, condition := range allConditions {
+		if strings.HasSuffix(condition.Type, conditionType) {
+			interestingConditions = append(interestingConditions, condition)
+
+			if condition.Status != defaultConditionStatus {
+				badConditions = append(badConditions, condition)
+				if condition.Status == oppositeConditionStatus {
+					badConditionStatus = oppositeConditionStatus
+				}
+			}
+		}
+	}
+	sort.Sort(byConditionType(badConditions))
+
+	unionedCondition := operatorv1.OperatorCondition{Type: conditionType, Status: operatorv1.ConditionUnknown}
+	if len(interestingConditions) == 0 {
+		unionedCondition.Status = operatorv1.ConditionUnknown
+		unionedCondition.Reason = "NoData"
+		return unionedCondition
+	}
+
+	var elderBadConditions []operatorv1.OperatorCondition
+	if inertia == nil {
+		elderBadConditions = badConditions
+	} else {
+		now := time.Now()
+		for _, condition := range badConditions {
+			if condition.LastTransitionTime.Time.Before(now.Add(-inertia(condition))) {
+				elderBadConditions = append(elderBadConditions, condition)
+			}
+		}
+	}
+
+	if len(elderBadConditions) == 0 {
+		unionedCondition.Status = defaultConditionStatus
+		unionedCondition.Message = unionMessage(interestingConditions)
+		if unionedCondition.Message == "" {
+			unionedCondition.Message = "All is well"
+		}
+		unionedCondition.Reason = "AsExpected"
+		unionedCondition.LastTransitionTime = latestTransitionTime(interestingConditions)
+
+		return unionedCondition
+	}
+
+	// at this point we have bad conditions
+	unionedCondition.Status = badConditionStatus
+	unionedCondition.Message = unionMessage(badConditions)
+	unionedCondition.Reason = unionReason(conditionType, badConditions)
+	unionedCondition.LastTransitionTime = latestTransitionTime(badConditions)
+
+	return unionedCondition
+}
+
+// UnionClusterCondition returns a single cluster operator condition that is the union of multiple operator conditions.
+//
+// defaultConditionStatus indicates whether you want to merge all Falses or merge all Trues.  For instance, Failures merge
+// on true, but Available merges on false.  Thing of it like an anti-default.
+//
+// If inertia is non-nil, then resist returning a condition with a status opposite the defaultConditionStatus.
+func UnionClusterCondition(conditionType configv1.ClusterStatusConditionType, defaultConditionStatus operatorv1.ConditionStatus, inertia Inertia, allConditions ...operatorv1.OperatorCondition) configv1.ClusterOperatorStatusCondition {
+	cnd := UnionCondition(string(conditionType), defaultConditionStatus, inertia, allConditions...)
+	return OperatorConditionToClusterOperatorCondition(cnd)
+}
+
+func OperatorConditionToClusterOperatorCondition(condition operatorv1.OperatorCondition) configv1.ClusterOperatorStatusCondition {
+	return configv1.ClusterOperatorStatusCondition{
+		Type:               configv1.ClusterStatusConditionType(condition.Type),
+		Status:             configv1.ConditionStatus(condition.Status),
+		LastTransitionTime: condition.LastTransitionTime,
+		Reason:             condition.Reason,
+		Message:            condition.Message,
+	}
+}
+func latestTransitionTime(conditions []operatorv1.OperatorCondition) metav1.Time {
+	latestTransitionTime := metav1.Time{}
+	for _, condition := range conditions {
+		if latestTransitionTime.Before(&condition.LastTransitionTime) {
+			latestTransitionTime = condition.LastTransitionTime
+		}
+	}
+	return latestTransitionTime
+}
+
+func uniq(s []string) []string {
+	seen := make(map[string]struct{}, len(s))
+	j := 0
+	for _, v := range s {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		s[j] = v
+		j++
+	}
+	return s[:j]
+}
+
+func unionMessage(conditions []operatorv1.OperatorCondition) string {
+	messages := []string{}
+	for _, condition := range conditions {
+		if len(condition.Message) == 0 {
+			continue
+		}
+		for _, message := range uniq(strings.Split(condition.Message, "\n")) {
+			messages = append(messages, fmt.Sprintf("%s: %s", condition.Type, message))
+		}
+	}
+	return strings.Join(messages, "\n")
+}
+
+func unionReason(unionConditionType string, conditions []operatorv1.OperatorCondition) string {
+	typeReasons := []string{}
+	for _, curr := range conditions {
+		currType := curr.Type[:len(curr.Type)-len(unionConditionType)]
+		if len(curr.Reason) > 0 {
+			typeReasons = append(typeReasons, currType+"_"+curr.Reason)
+		} else {
+			typeReasons = append(typeReasons, currType)
+		}
+	}
+	sort.Strings(typeReasons)
+	return strings.Join(typeReasons, "::")
+}
+
+type byConditionType []operatorv1.OperatorCondition
+
+var _ sort.Interface = byConditionType{}
+
+func (s byConditionType) Len() int {
+	return len(s)
+}
+func (s byConditionType) Less(i, j int) bool {
+	return s[i].Type < s[j].Type
+}
+func (s byConditionType) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/status/inertia.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/status/inertia.go
@@ -1,0 +1,66 @@
+package status
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+)
+
+// Inertia returns the inertial duration for the given condition.
+type Inertia func(condition operatorv1.OperatorCondition) time.Duration
+
+// InertiaCondition configures an inertia duration for a given set of
+// condition types.
+type InertiaCondition struct {
+	// ConditionTypeMatcher is a regular expression selecting condition types
+	// with which this InertiaCondition is associated.
+	ConditionTypeMatcher *regexp.Regexp
+
+	// Duration is the inertial duration for associated conditions.
+	Duration time.Duration
+}
+
+// InertiaConfig holds configuration for an Inertia implementation.
+type InertiaConfig struct {
+	defaultDuration time.Duration
+	conditions      []InertiaCondition
+}
+
+// NewInertia creates a new InertiaConfig object.  Conditions are
+// applied in the given order, so a condition type matching multiple
+// regular expressions will have the duration associated with the first
+// matching entry.
+func NewInertia(defaultDuration time.Duration, conditions ...InertiaCondition) (*InertiaConfig, error) {
+	for i, condition := range conditions {
+		if condition.ConditionTypeMatcher == nil {
+			return nil, fmt.Errorf("condition %d has a nil ConditionTypeMatcher", i)
+		}
+	}
+
+	return &InertiaConfig{
+		defaultDuration: defaultDuration,
+		conditions:      conditions,
+	}, nil
+}
+
+// MustNewInertia is like NewInertia but panics on error.
+func MustNewInertia(defaultDuration time.Duration, conditions ...InertiaCondition) *InertiaConfig {
+	inertia, err := NewInertia(defaultDuration, conditions...)
+	if err != nil {
+		panic(err)
+	}
+
+	return inertia
+}
+
+// Inertia returns the configured inertia for the given condition type.
+func (c *InertiaConfig) Inertia(condition operatorv1.OperatorCondition) time.Duration {
+	for _, matcher := range c.conditions {
+		if matcher.ConditionTypeMatcher.MatchString(condition.Type) {
+			return matcher.Duration
+		}
+	}
+	return c.defaultDuration
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/status/status_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/status/status_controller.go
@@ -1,0 +1,281 @@
+package status
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
+	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	configv1helpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/management"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+type VersionGetter interface {
+	// SetVersion is a way to set the version for an operand.  It must be thread-safe
+	SetVersion(operandName, version string)
+	// GetVersion is way to get the versions for all operands.  It must be thread-safe and return an object that doesn't mutate
+	GetVersions() map[string]string
+	// VersionChangedChannel is a channel that will get an item whenever SetVersion has been called
+	VersionChangedChannel() <-chan struct{}
+}
+
+type RelatedObjectsFunc func() (isset bool, objs []configv1.ObjectReference)
+
+type StatusSyncer struct {
+	clusterOperatorName string
+	relatedObjects      []configv1.ObjectReference
+	relatedObjectsFunc  RelatedObjectsFunc
+
+	versionGetter         VersionGetter
+	operatorClient        operatorv1helpers.OperatorClient
+	clusterOperatorClient configv1client.ClusterOperatorsGetter
+	clusterOperatorLister configv1listers.ClusterOperatorLister
+
+	controllerFactory *factory.Factory
+	recorder          events.Recorder
+	degradedInertia   Inertia
+
+	removeUnusedVersions bool
+}
+
+var _ factory.Controller = &StatusSyncer{}
+
+func (c *StatusSyncer) Name() string {
+	return c.clusterOperatorName
+}
+
+func NewClusterOperatorStatusController(
+	name string,
+	relatedObjects []configv1.ObjectReference,
+	clusterOperatorClient configv1client.ClusterOperatorsGetter,
+	clusterOperatorInformer configv1informers.ClusterOperatorInformer,
+	operatorClient operatorv1helpers.OperatorClient,
+	versionGetter VersionGetter,
+	recorder events.Recorder,
+) *StatusSyncer {
+	return &StatusSyncer{
+		clusterOperatorName:   name,
+		relatedObjects:        relatedObjects,
+		versionGetter:         versionGetter,
+		clusterOperatorClient: clusterOperatorClient,
+		clusterOperatorLister: clusterOperatorInformer.Lister(),
+		operatorClient:        operatorClient,
+		degradedInertia:       MustNewInertia(2 * time.Minute).Inertia,
+		controllerFactory: factory.New().ResyncEvery(time.Minute).WithInformers(
+			operatorClient.Informer(),
+			clusterOperatorInformer.Informer(),
+		),
+		recorder: recorder.WithComponentSuffix("status-controller"),
+	}
+}
+
+// WithRelatedObjectsFunc allows the set of related objects to be dynamically
+// determined.
+//
+// The function returns (isset, objects)
+//
+// If isset is false, then the set of related objects is copied over from the
+// existing ClusterOperator object. This is useful in cases where an operator
+// has just restarted, and hasn't yet reconciled.
+//
+// Any statically-defined related objects (in NewClusterOperatorStatusController)
+// will always be included in the result.
+func (c *StatusSyncer) WithRelatedObjectsFunc(f RelatedObjectsFunc) {
+	c.relatedObjectsFunc = f
+}
+
+func (c *StatusSyncer) Run(ctx context.Context, workers int) {
+	c.controllerFactory.WithPostStartHooks(c.watchVersionGetterPostRunHook).WithSync(c.Sync).ToController("StatusSyncer_"+c.Name(), c.recorder).Run(ctx, workers)
+}
+
+// WithDegradedInertia returns a copy of the StatusSyncer with the
+// requested inertia function for degraded conditions.
+func (c *StatusSyncer) WithDegradedInertia(inertia Inertia) *StatusSyncer {
+	output := *c
+	output.degradedInertia = inertia
+	return &output
+}
+
+// WithVersionRemoval returns a copy of the StatusSyncer that will
+// remove versions that are missing in VersionGetter from the status.
+func (c *StatusSyncer) WithVersionRemoval() *StatusSyncer {
+	output := *c
+	output.removeUnusedVersions = true
+	return &output
+}
+
+// sync reacts to a change in prereqs by finding information that is required to match another value in the cluster. This
+// must be information that is logically "owned" by another component.
+func (c StatusSyncer) Sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	detailedSpec, currentDetailedStatus, _, err := c.operatorClient.GetOperatorState()
+	if apierrors.IsNotFound(err) {
+		syncCtx.Recorder().Warningf("StatusNotFound", "Unable to determine current operator status for clusteroperator/%s", c.clusterOperatorName)
+		if err := c.clusterOperatorClient.ClusterOperators().Delete(ctx, c.clusterOperatorName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	originalClusterOperatorObj, err := c.clusterOperatorLister.Get(c.clusterOperatorName)
+	if err != nil && !apierrors.IsNotFound(err) {
+		syncCtx.Recorder().Warningf("StatusFailed", "Unable to get current operator status for clusteroperator/%s: %v", c.clusterOperatorName, err)
+		return err
+	}
+
+	// ensure that we have a clusteroperator resource
+	if originalClusterOperatorObj == nil || apierrors.IsNotFound(err) {
+		klog.Infof("clusteroperator/%s not found", c.clusterOperatorName)
+		var createErr error
+		originalClusterOperatorObj, createErr = c.clusterOperatorClient.ClusterOperators().Create(ctx, &configv1.ClusterOperator{
+			ObjectMeta: metav1.ObjectMeta{Name: c.clusterOperatorName},
+		}, metav1.CreateOptions{})
+		if apierrors.IsNotFound(createErr) {
+			// this means that the API isn't present.  We did not fail.  Try again later
+			klog.Infof("ClusterOperator API not created")
+			syncCtx.Queue().AddRateLimited(factory.DefaultQueueKey)
+			return nil
+		}
+		if createErr != nil {
+			syncCtx.Recorder().Warningf("StatusCreateFailed", "Failed to create operator status: %v", createErr)
+			return createErr
+		}
+	}
+	clusterOperatorObj := originalClusterOperatorObj.DeepCopy()
+
+	if detailedSpec.ManagementState == operatorv1.Unmanaged && !management.IsOperatorAlwaysManaged() {
+		configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorAvailable, Status: configv1.ConditionUnknown, Reason: "Unmanaged"})
+		configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorProgressing, Status: configv1.ConditionUnknown, Reason: "Unmanaged"})
+		configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorDegraded, Status: configv1.ConditionUnknown, Reason: "Unmanaged"})
+		configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorUpgradeable, Status: configv1.ConditionUnknown, Reason: "Unmanaged"})
+		configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.EvaluationConditionsDetected, Status: configv1.ConditionUnknown, Reason: "Unmanaged"})
+
+		if equality.Semantic.DeepEqual(clusterOperatorObj, originalClusterOperatorObj) {
+			return nil
+		}
+		if _, err := c.clusterOperatorClient.ClusterOperators().UpdateStatus(ctx, clusterOperatorObj, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+		if !skipOperatorStatusChangedEvent(originalClusterOperatorObj.Status, clusterOperatorObj.Status) {
+			syncCtx.Recorder().Eventf("OperatorStatusChanged", "Status for operator %s changed: %s", c.clusterOperatorName, configv1helpers.GetStatusDiff(originalClusterOperatorObj.Status, clusterOperatorObj.Status))
+		}
+		return nil
+	}
+
+	if c.relatedObjectsFunc != nil {
+		isSet, ro := c.relatedObjectsFunc()
+		if !isSet { // temporarily unknown - copy over from existing object
+			ro = clusterOperatorObj.Status.RelatedObjects
+		}
+
+		// merge in any static objects
+		for _, obj := range c.relatedObjects {
+			found := false
+			for _, existingObj := range ro {
+				if obj == existingObj {
+					found = true
+					break
+				}
+			}
+			if !found {
+				ro = append(ro, obj)
+			}
+		}
+		clusterOperatorObj.Status.RelatedObjects = ro
+	} else {
+		clusterOperatorObj.Status.RelatedObjects = c.relatedObjects
+	}
+
+	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, UnionClusterCondition(configv1.OperatorDegraded, operatorv1.ConditionFalse, c.degradedInertia, currentDetailedStatus.Conditions...))
+	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, UnionClusterCondition(configv1.OperatorProgressing, operatorv1.ConditionFalse, nil, currentDetailedStatus.Conditions...))
+	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, UnionClusterCondition(configv1.OperatorAvailable, operatorv1.ConditionTrue, nil, currentDetailedStatus.Conditions...))
+	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, UnionClusterCondition(configv1.OperatorUpgradeable, operatorv1.ConditionTrue, nil, currentDetailedStatus.Conditions...))
+	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, UnionClusterCondition(configv1.EvaluationConditionsDetected, operatorv1.ConditionFalse, nil, currentDetailedStatus.Conditions...))
+
+	c.syncStatusVersions(clusterOperatorObj, syncCtx)
+
+	// if we have no diff, just return
+	if equality.Semantic.DeepEqual(clusterOperatorObj, originalClusterOperatorObj) {
+		return nil
+	}
+	klog.V(2).Infof("clusteroperator/%s diff %v", c.clusterOperatorName, resourceapply.JSONPatchNoError(originalClusterOperatorObj, clusterOperatorObj))
+
+	if _, updateErr := c.clusterOperatorClient.ClusterOperators().UpdateStatus(ctx, clusterOperatorObj, metav1.UpdateOptions{}); updateErr != nil {
+		return updateErr
+	}
+	if !skipOperatorStatusChangedEvent(originalClusterOperatorObj.Status, clusterOperatorObj.Status) {
+		syncCtx.Recorder().Eventf("OperatorStatusChanged", "Status for clusteroperator/%s changed: %s", c.clusterOperatorName, configv1helpers.GetStatusDiff(originalClusterOperatorObj.Status, clusterOperatorObj.Status))
+	}
+	return nil
+}
+
+func skipOperatorStatusChangedEvent(originalStatus, newStatus configv1.ClusterOperatorStatus) bool {
+	originalCopy := *originalStatus.DeepCopy()
+	for i, condition := range originalCopy.Conditions {
+		switch condition.Type {
+		case configv1.OperatorAvailable, configv1.OperatorDegraded, configv1.OperatorProgressing, configv1.OperatorUpgradeable:
+			originalCopy.Conditions[i].Message = strings.TrimPrefix(condition.Message, "\ufeff")
+		}
+	}
+	return len(configv1helpers.GetStatusDiff(originalCopy, newStatus)) == 0
+}
+
+func (c *StatusSyncer) syncStatusVersions(clusterOperatorObj *configv1.ClusterOperator, syncCtx factory.SyncContext) {
+	versions := c.versionGetter.GetVersions()
+	// Add new versions from versionGetter to status
+	for operand, version := range versions {
+		previousVersion := operatorv1helpers.SetOperandVersion(&clusterOperatorObj.Status.Versions, configv1.OperandVersion{Name: operand, Version: version})
+		if previousVersion != version {
+			// having this message will give us a marker in events when the operator updated compared to when the operand is updated
+			syncCtx.Recorder().Eventf("OperatorVersionChanged", "clusteroperator/%s version %q changed from %q to %q", c.clusterOperatorName, operand, previousVersion, version)
+		}
+	}
+
+	if !c.removeUnusedVersions {
+		return
+	}
+
+	// Filter out all versions from status that are not in versionGetter
+	filteredVersions := make([]configv1.OperandVersion, 0, len(clusterOperatorObj.Status.Versions))
+	for _, version := range clusterOperatorObj.Status.Versions {
+		if _, found := versions[version.Name]; found {
+			filteredVersions = append(filteredVersions, version)
+		}
+	}
+
+	clusterOperatorObj.Status.Versions = filteredVersions
+}
+
+func (c *StatusSyncer) watchVersionGetterPostRunHook(ctx context.Context, syncCtx factory.SyncContext) error {
+	defer utilruntime.HandleCrash()
+
+	versionCh := c.versionGetter.VersionChangedChannel()
+	// always kick at least once
+	syncCtx.Queue().Add(factory.DefaultQueueKey)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-versionCh:
+			syncCtx.Queue().Add(factory.DefaultQueueKey)
+		}
+	}
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/status/version.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/status/version.go
@@ -1,0 +1,96 @@
+package status
+
+import (
+	"context"
+	"os"
+	"sync"
+
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type versionGetter struct {
+	lock                 sync.Mutex
+	versions             map[string]string
+	notificationChannels []chan struct{}
+}
+
+const (
+	operandImageEnvVarName         = "IMAGE"
+	operandImageVersionEnvVarName  = "OPERAND_IMAGE_VERSION"
+	operatorImageVersionEnvVarName = "OPERATOR_IMAGE_VERSION"
+)
+
+func NewVersionGetter() VersionGetter {
+	return &versionGetter{
+		versions: map[string]string{},
+	}
+}
+
+func (v *versionGetter) SetVersion(operandName, version string) {
+	v.lock.Lock()
+	defer v.lock.Unlock()
+
+	v.versions[operandName] = version
+
+	for i := range v.notificationChannels {
+		ch := v.notificationChannels[i]
+		// don't let a slow consumer block the rest
+		go func() {
+			ch <- struct{}{}
+		}()
+	}
+}
+
+func (v *versionGetter) GetVersions() map[string]string {
+	v.lock.Lock()
+	defer v.lock.Unlock()
+
+	ret := map[string]string{}
+	for k, v := range v.versions {
+		ret[k] = v
+	}
+	return ret
+}
+
+func (v *versionGetter) VersionChangedChannel() <-chan struct{} {
+	v.lock.Lock()
+	defer v.lock.Unlock()
+
+	channel := make(chan struct{}, 50)
+	v.notificationChannels = append(v.notificationChannels, channel)
+	return channel
+}
+
+func ImageForOperandFromEnv() string {
+	return os.Getenv(operandImageEnvVarName)
+}
+
+func VersionForOperandFromEnv() string {
+	return os.Getenv(operandImageVersionEnvVarName)
+}
+
+func VersionForOperatorFromEnv() string {
+	return os.Getenv(operatorImageVersionEnvVarName)
+}
+
+func VersionForOperand(namespace, imagePullSpec string, configMapGetter corev1client.ConfigMapsGetter, eventRecorder events.Recorder) string {
+	versionMap := map[string]string{}
+	versionMapping, err := configMapGetter.ConfigMaps(namespace).Get(context.TODO(), "version-mapping", metav1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		eventRecorder.Warningf("VersionMappingFailure", "unable to get version mapping: %v", err)
+		return ""
+	}
+	if versionMapping != nil {
+		for version, image := range versionMapping.Data {
+			versionMap[image] = version
+		}
+	}
+
+	// we have the actual daemonset and we need the pull spec
+	operandVersion := versionMap[imagePullSpec]
+	return operandVersion
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -543,6 +543,7 @@ github.com/oklog/ulid
 # github.com/openshift/api v0.0.0-20240508125607-95e22923d553
 ## explicit; go 1.21
 github.com/openshift/api
+github.com/openshift/api/annotations
 github.com/openshift/api/apiserver
 github.com/openshift/api/apiserver/v1
 github.com/openshift/api/apps
@@ -686,6 +687,7 @@ github.com/openshift/client-go/route/listers/route/v1
 # github.com/openshift/library-go v0.0.0-20240508091607-5fface69be35
 ## explicit; go 1.21
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer
+github.com/openshift/library-go/pkg/certs
 github.com/openshift/library-go/pkg/config/client
 github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers
 github.com/openshift/library-go/pkg/config/clusterstatus
@@ -697,6 +699,10 @@ github.com/openshift/library-go/pkg/controller/factory
 github.com/openshift/library-go/pkg/controller/fileobserver
 github.com/openshift/library-go/pkg/crypto
 github.com/openshift/library-go/pkg/network
+github.com/openshift/library-go/pkg/operator/certrotation
+github.com/openshift/library-go/pkg/operator/condition
+github.com/openshift/library-go/pkg/operator/configobserver
+github.com/openshift/library-go/pkg/operator/configobserver/featuregates
 github.com/openshift/library-go/pkg/operator/events
 github.com/openshift/library-go/pkg/operator/loglevel
 github.com/openshift/library-go/pkg/operator/management
@@ -704,6 +710,8 @@ github.com/openshift/library-go/pkg/operator/resource/resourceapply
 github.com/openshift/library-go/pkg/operator/resource/resourcehelper
 github.com/openshift/library-go/pkg/operator/resource/resourcemerge
 github.com/openshift/library-go/pkg/operator/resource/resourceread
+github.com/openshift/library-go/pkg/operator/resourcesynccontroller
+github.com/openshift/library-go/pkg/operator/status
 github.com/openshift/library-go/pkg/operator/v1helpers
 github.com/openshift/library-go/pkg/serviceability
 # github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b


### PR DESCRIPTION
Trying to work around a bug for r2 integration with s3 bucket, exposing chunksize variable by utilizing the docker registry S3 driver configuration option: https://docker-docs.uclv.cu/registry/storage-drivers/s3/ 

/hold for https://github.com/openshift/api/pull/1864 to merge

https://issues.redhat.com//browse/IR-471 

/cc @flavianmissi 