### PR TITLE
OCPBUGS-33453: add SAR capability to image-registry

### DIFF
--- a/manifests/02-rbac.yaml
+++ b/manifests/02-rbac.yaml
@@ -223,6 +223,12 @@ rules:
   - imagecontentsourcepolicies
   verbs:
   - list
+- apiGroups:
+  - "authorization.k8s.io"
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/resource/clusterrole.go
+++ b/pkg/resource/clusterrole.go
@@ -103,6 +103,13 @@ func (gcr *generatorClusterRole) expected() (runtime.Object, error) {
 					"imagetagmirrorsets",
 				},
 			},
+			{
+				Verbs:     []string{"create"},
+				APIGroups: []string{"authorization.k8s.io"},
+				Resources: []string{
+					"subjectaccessreviews",
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
## What

Add `subjectaccessreviews` capability to operator and registry.

## Why

SSAR doesn't work anymore with [AUTH-509](https://issues.redhat.com/browse/AUTH-509), but we can do a SAR instead and specifying the user / group as anonymous.
In order for the image-registry to be able to create a SAR, we need this change.