### PR TITLE
TRT-1576: Ensure affinity rules are applied for >=2 replicas

### DIFF
--- a/pkg/resource/podtemplatespec.go
+++ b/pkg/resource/podtemplatespec.go
@@ -440,9 +440,9 @@ func makePodTemplateSpec(coreClient coreset.CoreV1Interface, proxyLister configl
 
 	// if user has provided an affinity through config spec we use it here, if not
 	// then we fallback to a preferred affinity configuration. we only require a
-	// certain affinity during schedule if the number of replicas is defined to two.
+	// certain affinity during schedule if the number of replicas is 2 or more.
 	affinity := cr.Spec.Affinity
-	if affinity == nil && cr.Spec.Replicas == 2 {
+	if affinity == nil && cr.Spec.Replicas >= 2 {
 		affinity = &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{


### PR DESCRIPTION
In [this PR in release repo](https://github.com/openshift/release/pull/52731/commits/caaa8089880f747e6775ac086ca96f7083928afe), we tried to set image-registry replicas to 3 but the anti-affinity rules did not get applied so we hard coded them there.  The [passing rehearse job](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/52731/rehearse-52731-pull-ci-openshift-origin-release-4.17-e2e-gcp-ovn-techpreview-serial/1798677279266574336) on that release PR shows that the [image-registry deployment](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/52731/rehearse-52731-pull-ci-openshift-origin-release-4.17-e2e-gcp-ovn-techpreview-serial/1798677279266574336/artifacts/e2e-gcp-ovn-techpreview-serial/gather-extra/artifacts/deployments.json) (search for `"uid": "df518b63-2a03-4b12-9614-39c40646dc2b"`) has the anti-affinity rules applied.

The operator seems like the right place to apply those rules so that it can support any number of replicas beyond 1.