### PR TITLE
[release-4.15] OCPBUGS-36325: Set required-scc for openshift workloads

### DIFF
--- a/bindata/nodecadaemon.yaml
+++ b/bindata/nodecadaemon.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
       labels:
         name: node-ca
     spec:

--- a/manifests/07-operator-ibm-cloud-managed.yaml
+++ b/manifests/07-operator-ibm-cloud-managed.yaml
@@ -18,6 +18,7 @@ spec:
   template:
     metadata:
       annotations:
+        openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: cluster-image-registry-operator

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: restricted-v2
       labels:
         name: cluster-image-registry-operator
     spec:

--- a/pkg/resource/azurepathfixjob.go
+++ b/pkg/resource/azurepathfixjob.go
@@ -21,6 +21,7 @@ import (
 
 	configapiv1 "github.com/openshift/api/config/v1"
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+	securityv1 "github.com/openshift/api/security/v1"
 	configlisters "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/openshift/cluster-image-registry-operator/pkg/defaults"
 	"github.com/openshift/cluster-image-registry-operator/pkg/storage/azure"
@@ -225,6 +226,11 @@ func (gapfj *generatorAzurePathFixJob) expected() (runtime.Object, error) {
 		Spec: batchv1.JobSpec{
 			BackoffLimit: &backoffLimit,
 			Template: kcorev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						securityv1.RequiredSCCAnnotation: "restricted-v2",
+					},
+				},
 				Spec: kcorev1.PodSpec{
 					RestartPolicy:      kcorev1.RestartPolicyNever,
 					ServiceAccountName: defaults.ServiceAccountName,

--- a/pkg/resource/deployment.go
+++ b/pkg/resource/deployment.go
@@ -18,6 +18,7 @@ import (
 
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
+	securityv1 "github.com/openshift/api/security/v1"
 	configlisters "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
@@ -94,6 +95,7 @@ func (gd *generatorDeployment) expected() (runtime.Object, error) {
 		podTemplateSpec.Annotations = map[string]string{}
 	}
 	podTemplateSpec.Annotations[defaults.ChecksumOperatorDepsAnnotation] = depsChecksum
+	podTemplateSpec.Annotations[securityv1.RequiredSCCAnnotation] = "restricted-v2"
 
 	// Strategy defaults to RollingUpdate
 	deployStrategy := appsapi.DeploymentStrategyType(gd.cr.Spec.RolloutStrategy)

--- a/pkg/resource/prunercronjob.go
+++ b/pkg/resource/prunercronjob.go
@@ -15,6 +15,7 @@ import (
 	batchlisters "k8s.io/client-go/listers/batch/v1"
 
 	imageregistryapiv1 "github.com/openshift/api/imageregistry/v1"
+	securityv1 "github.com/openshift/api/security/v1"
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
 	imageregistryv1listers "github.com/openshift/client-go/imageregistry/listers/imageregistry/v1"
 	"github.com/openshift/library-go/pkg/operator/loglevel"
@@ -174,6 +175,7 @@ done
 		},
 	}
 	cj.Spec.JobTemplate.Labels = map[string]string{"created-by": gcj.GetName()}
+	cj.Spec.JobTemplate.Annotations = map[string]string{securityv1.RequiredSCCAnnotation: "restricted-v2"}
 	return cj, nil
 }
 


### PR DESCRIPTION
[OCPBUGS-36325](https://issues.redhat.com/browse/OCPBUGS-36325)

Manual cherry-pick of [#1008](https://github.com/openshift/cluster-image-registry-operator/pull/1008)