### PR TITLE
WIP: DO NOT MERGE: force operator verbose logs

### DIFF
--- a/cmd/cluster-image-registry-operator/main.go
+++ b/cmd/cluster-image-registry-operator/main.go
@@ -39,6 +39,11 @@ func main() {
 		_ = logstderr.Value.Set("true")
 	}
 
+	if err := klogFlags.Set("v", "5"); err != nil {
+		klog.Errorf("%v", err)
+		os.Exit(1)
+	}
+
 	watchedFileChanged := make(chan struct{})
 	ctx, cancel := context.WithCancel(context.Background())
 	stopCh := signals.SetupSignalHandler()


### PR DESCRIPTION
this commit will never merge.

the operatorLogLevel configuration has not worked for a while, so to help troubleshoot OCPBUGS-37505 we're forcing it to 5 on startup.