### PR TITLE
OCPBUGS-37543: pkg/storage/azure: do not retry remove storage operation

### DIFF
--- a/manifests/01-registry-credentials-request-azure.yaml
+++ b/manifests/01-registry-credentials-request-azure.yaml
@@ -25,7 +25,9 @@ spec:
       - Microsoft.Storage/storageAccounts/blobServices/read
       - Microsoft.Storage/storageAccounts/blobServices/containers/read
       - Microsoft.Storage/storageAccounts/blobServices/containers/write
-      - Microsoft.Storage/storageAccounts/blobServices/containers/delete
+      # this permission is not strictily required because deleting the storage
+      # account also deletes the container.
+      # - Microsoft.Storage/storageAccounts/blobServices/containers/delete
       - Microsoft.Storage/storageAccounts/blobServices/generateUserDelegationKey/action
       - Microsoft.Storage/storageAccounts/read
       - Microsoft.Storage/storageAccounts/write


### PR DESCRIPTION
Previous to commit 472515d, `RemoveStorage` never triggered a retry. After removing storage account key usage for workload identity enabled clusters (OCPBUGS-37543), a failed container deletion (caused by a 404) would trigger a retry (which is not a full reconcile in this case, since the operator CR does not get updated), and would cause a permanent `AccountNotFound` error.

/assign @rajdeepc2792 

Holding until QE has verified this fix works.
/hold
