### PR TITLE
OCPBUGS-38842: pkg/resource: invoke update-ca-trust extract with --output

### DIFF
--- a/pkg/resource/podtemplatespec.go
+++ b/pkg/resource/podtemplatespec.go
@@ -486,7 +486,7 @@ func makePodTemplateSpec(coreClient coreset.CoreV1Interface, proxyLister configl
 					Command: []string{
 						"/bin/sh",
 						"-c",
-						"mkdir -p /etc/pki/ca-trust/extracted/edk2 /etc/pki/ca-trust/extracted/java /etc/pki/ca-trust/extracted/openssl /etc/pki/ca-trust/extracted/pem && update-ca-trust extract && exec /usr/bin/dockerregistry",
+						"mkdir -p /etc/pki/ca-trust/extracted/edk2 /etc/pki/ca-trust/extracted/java /etc/pki/ca-trust/extracted/openssl /etc/pki/ca-trust/extracted/pem && update-ca-trust extract --output /etc/pki/ca-trust/extracted/ && exec /usr/bin/dockerregistry",
 					},
 					Ports: []corev1.ContainerPort{
 						{


### PR DESCRIPTION
using this might help keep write permissions on
/etc/pki/ca-trust/extracted/pem/directory-hash.