### PR TITLE
[release-4.15] OCPBUGS-38895: pkg/resource: invoke update-ca-trust extract with --output

### DIFF
--- a/pkg/resource/azurepathfixjob.go
+++ b/pkg/resource/azurepathfixjob.go
@@ -255,7 +255,7 @@ func (gapfj *generatorAzurePathFixJob) expected() (runtime.Object, error) {
 							Command: []string{"/bin/sh"},
 							Args: []string{
 								"-c",
-								"mkdir -p /etc/pki/ca-trust/extracted/edk2 /etc/pki/ca-trust/extracted/java /etc/pki/ca-trust/extracted/openssl /etc/pki/ca-trust/extracted/pem && update-ca-trust extract && /usr/bin/move-blobs",
+								"mkdir -p /etc/pki/ca-trust/extracted/edk2 /etc/pki/ca-trust/extracted/java /etc/pki/ca-trust/extracted/openssl /etc/pki/ca-trust/extracted/pem && update-ca-trust extract --output /etc/pki/ca-trust/extracted/ && /usr/bin/move-blobs",
 							},
 						},
 					},

--- a/pkg/resource/podtemplatespec.go
+++ b/pkg/resource/podtemplatespec.go
@@ -486,7 +486,7 @@ func makePodTemplateSpec(coreClient coreset.CoreV1Interface, proxyLister configl
 					Command: []string{
 						"/bin/sh",
 						"-c",
-						"mkdir -p /etc/pki/ca-trust/extracted/edk2 /etc/pki/ca-trust/extracted/java /etc/pki/ca-trust/extracted/openssl /etc/pki/ca-trust/extracted/pem && update-ca-trust extract && exec /usr/bin/dockerregistry",
+						"mkdir -p /etc/pki/ca-trust/extracted/edk2 /etc/pki/ca-trust/extracted/java /etc/pki/ca-trust/extracted/openssl /etc/pki/ca-trust/extracted/pem && update-ca-trust extract --output /etc/pki/ca-trust/extracted/ && exec /usr/bin/dockerregistry",
 					},
 					Ports: []corev1.ContainerPort{
 						{


### PR DESCRIPTION
manual cherry pick to include both required commits.

overrides https://github.com/openshift/cluster-image-registry-operator/pull/1099