### PR TITLE
[release-4.16]  OCPBUGS-41903: pkg/operator/azurepathfixcontroller: do not sync on non-azure storage

### DIFF
--- a/pkg/operator/azurepathfixcontroller.go
+++ b/pkg/operator/azurepathfixcontroller.go
@@ -178,6 +178,12 @@ func (c *AzurePathFixController) sync() error {
 		return err
 	}
 
+	// skip this controller entirely if in Azure but storage is configured to anything other
+	// Azure storage, or if the operator is removed
+	if imageRegistryConfig.Spec.ManagementState == operatorv1.Removed || imageRegistryConfig.Status.Storage.PVC != nil || imageRegistryConfig.Status.Storage.EmptyDir != nil || imageRegistryConfig.Status.Storage.S3 != nil || imageRegistryConfig.Status.Storage.GCS != nil || imageRegistryConfig.Status.Storage.Swift != nil || imageRegistryConfig.Status.Storage.IBMCOS != nil || imageRegistryConfig.Status.Storage.OSS != nil {
+		return nil
+	}
+
 	azureStorage := imageRegistryConfig.Status.Storage.Azure
 	if azureStorage == nil || len(azureStorage.AccountName) == 0 {
 		return fmt.Errorf("storage account not yet provisioned")


### PR DESCRIPTION
or when the operator is removed.

This will also stop the azure-path-fix controller from running when users have configured storage other than azure.