### PR TITLE
OCPBUGS-42004: Set the Managed Identity client ID

### DIFF
--- a/pkg/storage/azure/azure.go
+++ b/pkg/storage/azure/azure.go
@@ -370,13 +370,14 @@ func (d *driver) storageAccountsClient(cfg *Azure, environment autorestazure.Env
 		cred azcore.TokenCredential
 		err  error
 	)
-	// MSI Override for ARO HCP
-	msi := os.Getenv("AZURE_MSI_AUTHENTICATION")
-	if msi == "true" {
+	// Managed Identity Override for ARO HCP
+	managedIdentityClientID := os.Getenv("ARO_HCP_MI_CLIENT_ID")
+	if managedIdentityClientID != "" {
 		options := azidentity.ManagedIdentityCredentialOptions{
 			ClientOptions: azcore.ClientOptions{
 				Cloud: cloudConfig,
 			},
+			ID: azidentity.ClientID(managedIdentityClientID),
 		}
 
 		var err error

--- a/pkg/storage/azure/azureclient/azureclient.go
+++ b/pkg/storage/azure/azureclient/azureclient.go
@@ -84,13 +84,14 @@ func New(opts *Options) (*Client, error) {
 	if creds == nil {
 		var err error
 
-		// MSI Override for ARO HCP
-		msi := os.Getenv("AZURE_MSI_AUTHENTICATION")
-		if msi == "true" {
+		// Managed Identity Override for ARO HCP
+		managedIdentityClientID := os.Getenv("ARO_HCP_MI_CLIENT_ID")
+		if managedIdentityClientID != "" {
 			options := azidentity.ManagedIdentityCredentialOptions{
 				ClientOptions: azcore.ClientOptions{
 					Cloud: cloudConfig,
 				},
+				ID: azidentity.ClientID(managedIdentityClientID),
 			}
 			creds, err = azidentity.NewManagedIdentityCredential(&options)
 			if err != nil {


### PR DESCRIPTION
HyperShift will pass a client ID through an environment variable, ARO_HCP_MI_CLIENT_ID, when it deploys the cluster-image-registry operator on a hosted control plane. This client ID will be used to create a new managed identity to authenticate with Azure on the hosted control plane.