### PR TITLE
OCPBUGS-42196: pkg/storage/azure: use cluster-api tag key to discover vnet

### DIFF
--- a/pkg/storage/azure/azure.go
+++ b/pkg/storage/azure/azure.go
@@ -675,8 +675,13 @@ func (d *driver) assurePrivateAccount(cfg *Azure, infra *configv1.Infrastructure
 	}
 
 	if internalConfig.VNetName == "" {
+		upstreamTagKey := fmt.Sprintf("sigs.k8s.io_cluster-api-provider-azure_cluster_%s", infra.Status.InfrastructureName)
 		tagKey := fmt.Sprintf("kubernetes.io_cluster.%s", infra.Status.InfrastructureName)
-		vnet, err := azclient.GetVNetByTag(d.Context, networkResourceGroup, tagKey, "owned", "shared")
+		tagFilter := map[string][]string{
+			upstreamTagKey: {"owned", "shared"},
+			tagKey:         {"owned", "shared"},
+		}
+		vnet, err := azclient.GetVNetByTags(d.Context, networkResourceGroup, tagFilter)
 		if err != nil {
 			return "", fmt.Errorf("failed to discover vnet name, please provide network details manually: %q", err)
 		}

--- a/pkg/storage/azure/azureclient/azureclient.go
+++ b/pkg/storage/azure/azureclient/azureclient.go
@@ -149,7 +149,22 @@ func (c *Client) getStorageAccount(ctx context.Context, resourceGroupName, accou
 	return resp.Account, nil
 }
 
-func (c *Client) GetVNetByTag(ctx context.Context, resourceGroupName, tagKey string, tagValues ...string) (armnetwork.VirtualNetwork, error) {
+func (c *Client) vnetHasAnyTag(vnet armnetwork.VirtualNetwork, tagFilter map[string][]string) bool {
+	for tagKey, tagValues := range tagFilter {
+		tag, ok := vnet.Tags[tagKey]
+		if !ok {
+			continue
+		}
+		for _, tagValue := range tagValues {
+			if *tag == tagValue {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (c *Client) GetVNetByTags(ctx context.Context, resourceGroupName string, tagFilter map[string][]string) (armnetwork.VirtualNetwork, error) {
 	client, err := armnetwork.NewVirtualNetworksClient(c.subscriptionID, c.creds, &arm.ClientOptions{
 		ClientOptions: *c.clientOpts,
 	})
@@ -164,19 +179,13 @@ func (c *Client) GetVNetByTag(ctx context.Context, resourceGroupName, tagKey str
 			return armnetwork.VirtualNetwork{}, err
 		}
 		for _, vnet := range page.Value {
-			tag, ok := vnet.Tags[tagKey]
-			if !ok {
-				continue
-			}
-			for _, tagValue := range tagValues {
-				if *tag == tagValue {
-					return *vnet, nil
-				}
+			if c.vnetHasAnyTag(*vnet, tagFilter) {
+				return *vnet, nil
 			}
 		}
 	}
 
-	return armnetwork.VirtualNetwork{}, fmt.Errorf("vnet with tag '%s: %v' not found", tagKey, tagValues)
+	return armnetwork.VirtualNetwork{}, fmt.Errorf("vnet with tags '%+v' not found", tagFilter)
 }
 
 func (c *Client) GetSubnetsByVNet(ctx context.Context, resourceGroupName, vnetName string) (armnetwork.Subnet, error) {


### PR DESCRIPTION
the previous tag key seems to no longer be added to clusters created using the cluster-api since 4.17.

---

Making it WIP because we're not sure if this is the right way to go, or if the installer should be backwards compatible and continue tagging the vnet using the previous format.