### PR TITLE
OCPBUGS-42732: pkg/storage/azure: also check for auth failure error code on deletion

### DIFF
--- a/pkg/storage/azure/azure.go
+++ b/pkg/storage/azure/azure.go
@@ -1142,7 +1142,7 @@ func (d *driver) removeStorageContainerViaTrack2SDK(cr *imageregistryv1.Config, 
 	}
 	err = blobClient.DeleteStorageContainer(d.Context, d.Config.Container)
 	if err != nil {
-		if bloberror.HasCode(err, bloberror.AuthorizationPermissionMismatch) {
+		if bloberror.HasCode(err, bloberror.AuthorizationPermissionMismatch) || bloberror.HasCode(err, bloberror.AuthorizationFailure) {
 			util.UpdateCondition(cr, defaults.StorageExists, operatorapiv1.ConditionUnknown, storageExistsReasonAzureError, fmt.Sprintf("Unable to delete storage container due to delete container permission missing, trying account deletion: %s", err))
 			return false, nil
 		} else if bloberror.HasCode(err, "AccountNotFound") {


### PR DESCRIPTION
I cannot explain the behavior, but after `networkAccess` to `Internal` in the operator config, if the operator tries to delete the container (which happens setting `managementState` to `Removed` in the config), the call to `DeleteStorageContainer` fails with a
`bloberror.AuthorizationFailure`, despite the operator having the `containers/delete` permission in its `CredentialsRequest`.

Note that setting `networkAccess` to `Internal` triggers the operator to create a private endpoint in Azure, then disable public access to the storage account in question. This could be related to the issue.