### PR TITLE
[release-4.16] OCPBUGS-42933: azureclient: stop validating credentials when creating the client

### DIFF
--- a/pkg/storage/azure/azureclient/azureclient_test.go
+++ b/pkg/storage/azure/azureclient/azureclient_test.go
@@ -35,7 +35,7 @@ func TestNew(t *testing.T) {
 		if err == nil {
 			t.Fatal("new with no options should fail, but error was nil")
 		}
-		msg := "client misconfigured, missing 'Environment.ResourceManagerEndpoint', 'Environment.ActiveDirectoryEndpoint', 'Environment.TokenAudience', 'TenantID', 'ClientID', 'ClientSecret', 'FederatedTokenFile', 'Creds', 'SubscriptionID' option(s)"
+		msg := "client misconfigured, missing 'Environment.ResourceManagerEndpoint', 'Environment.ActiveDirectoryEndpoint', 'Environment.TokenAudience' option(s)"
 		if err.Error() != msg {
 			t.Error("client failed with wrong error")
 			t.Logf("want %q", msg)


### PR DESCRIPTION
Manually cherry-picking https://github.com/openshift/cluster-image-registry-operator/pull/1130 due to merge conflicts.

---

different operations in Azure require different sets of credentials. some operations for example only need a storage account key to authenticate with Azure API.

since we cannot predict which operation the caller will need, we cannot validate auth related options on client instantiation time.

this didn't use to be an issue because the client was only used for private endpoint configuration, which did not use account key for auth, so validation was more predictable.