### PR TITLE
[release-4.15] OCPBUGS-42930: Continuous pull-secret updates / slow initialization on build01 (test platform infrastructure)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/prometheus/common v0.44.0
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.9.0
+	golang.org/x/exp v0.0.0-20220827204233-334a2380cb91
 	golang.org/x/net v0.27.0
 	golang.org/x/oauth2 v0.8.0
 	golang.org/x/time v0.3.0
@@ -152,7 +153,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.19.0 // indirect
 	golang.org/x/crypto v0.25.0 // indirect
-	golang.org/x/exp v0.0.0-20220827204233-334a2380cb91 // indirect
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.22.0 // indirect
 	golang.org/x/term v0.22.0 // indirect

--- a/pkg/operator/imageconfig.go
+++ b/pkg/operator/imageconfig.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/exp/slices"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -253,6 +255,9 @@ func (icc *ImageConfigController) getRouteHostnames() ([]string, error) {
 	// ensure a stable order for these values so we don't cause flapping in the
 	// downstream controllers that watch this array
 	sort.Strings(routeNames)
+
+	// remove duplicates
+	routeNames = slices.Compact(routeNames)
 
 	// make sure the default route hostname comes first in the list because the
 	// first entry will be used as the public repository hostname by the cluster


### PR DESCRIPTION
This is a cherry-pick of #1126