### PR TITLE
OCPBUGS-38667: pkg/operator: wait for image registry config object cache sync

### DIFF
--- a/pkg/operator/azurestackcloud.go
+++ b/pkg/operator/azurestackcloud.go
@@ -41,6 +41,8 @@ func NewAzureStackCloudController(
 		queue:                 workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "AzureStackCloudController"),
 	}
 
+	c.cachesToSync = append(c.cachesToSync, operatorClient.Informer().HasSynced)
+
 	if _, err := openshiftConfigInformer.Informer().AddEventHandler(c.eventHandler()); err != nil {
 		return nil, err
 	}

--- a/pkg/operator/imageconfig.go
+++ b/pkg/operator/imageconfig.go
@@ -64,6 +64,8 @@ func NewImageConfigController(
 		imageStreamImportModeEnabled: imageStreamImportModeEnabled,
 	}
 
+	icc.cachesToSync = append(icc.cachesToSync, operatorClient.Informer().HasSynced)
+
 	if _, err := serviceInformer.Informer().AddEventHandler(icc.eventHandler()); err != nil {
 		return nil, err
 	}

--- a/pkg/operator/nodecadaemon.go
+++ b/pkg/operator/nodecadaemon.go
@@ -54,6 +54,8 @@ func NewNodeCADaemonController(
 		queue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "NodeCADaemonController"),
 	}
 
+	c.cachesToSync = append(c.cachesToSync, operatorClient.Informer().HasSynced)
+
 	if _, err := daemonSetInformer.Informer().AddEventHandler(c.eventHandler()); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
without this wait, the nodeca daemon controller would sometimes make the operator become Degraded.

the azure stack cloud and image config controllers were showing errors when the operator pod started after an upgrade, so this also adds sync waits to those.