### PR TITLE
OCPBUGS-43508: fix proxy config and leader election test flakes

### DIFF
--- a/test/e2e/configuration_test.go
+++ b/test/e2e/configuration_test.go
@@ -265,7 +265,10 @@ func TestRouteConfiguration(t *testing.T) {
 
 func TestOperatorProxyConfiguration(t *testing.T) {
 	te := framework.SetupAvailableImageRegistry(t, nil)
-	defer framework.TeardownImageRegistry(te)
+	// this test sometimes fails during tear down because some components
+	// (unrelated to the image registry) do not recover within the default
+	// timeout.
+	defer framework.TeardownImageRegistryWithTimeoutIncrement(te, 5*time.Minute)
 	defer framework.ResetClusterProxyConfig(te)
 
 	// Get the service network to set as NO_PROXY so that the

--- a/test/framework/imageregistry.go
+++ b/test/framework/imageregistry.go
@@ -580,8 +580,8 @@ func SetupAvailableImageRegistry(t *testing.T, spec *imageregistryapiv1.ImageReg
 	return te
 }
 
-func TeardownImageRegistry(te TestEnv) {
-	defer WaitUntilClusterOperatorsAreHealthy(te, 30*time.Second, AsyncOperationTimeout)
+func TeardownImageRegistryWithTimeoutIncrement(te TestEnv, timeoutIncrement time.Duration) {
+	defer WaitUntilClusterOperatorsAreHealthy(te, 30*time.Second, AsyncOperationTimeout+timeoutIncrement)
 	defer CheckAbsenceOfOperatorPods(te)
 	defer RemoveImageRegistry(te)
 	defer CheckPodsAreNotRestarted(te, labels.Everything())
@@ -590,4 +590,8 @@ func TeardownImageRegistry(te TestEnv) {
 		DumpOperatorDeployment(te)
 		DumpOperatorLogs(context.Background(), te)
 	}
+}
+
+func TeardownImageRegistry(te TestEnv) {
+	TeardownImageRegistryWithTimeoutIncrement(te, 0)
 }


### PR DESCRIPTION
the TestOperandProxyConfiguration job has been flakying more and more lately. analysis show that the cause is not the test itself, but cluster recovery after the test teardown runs. it seems some components need longer to recover after a change in proxy configuration.

this commit increases the timeout from 5 to 10 minutes in hopes to stabilize this test.

Also changes TestLeaderElection to assert on leader lease acquiring instead of waiting on lease message as this would at times flake.