### PR TITLE
WIP: [release-4.16] stabilize azurepathfixcontroller 4.16

### DIFF
--- a/pkg/operator/azurepathfixcontroller.go
+++ b/pkg/operator/azurepathfixcontroller.go
@@ -220,10 +220,10 @@ func (c *AzurePathFixController) sync() error {
 
 	azureStorage := imageRegistryConfig.Status.Storage.Azure
 	if azureStorage == nil || len(azureStorage.AccountName) == 0 {
-		return fmt.Errorf("storage account not yet provisioned")
+		return nil
 	}
 	if azureStorage == nil || len(azureStorage.Container) == 0 {
-		return fmt.Errorf("storage container not yet provisioned")
+		return nil
 	}
 
 	// the move-blobs cmd does not work on Azure Stack Hub. Users on ASH


### PR DESCRIPTION
this PR is not against master because the code looks very different there - we'll need a different version on both master (currently 4.18) and 4.17, which I'll work on later. Right now I just want the e2e-azure-operator job to run.