### PR TITLE
OCPBUGS-41903: operator/status: clear azure path fix job conditions on operator removal

### DIFF
--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -174,6 +174,17 @@ func NewController(
 			c.listers.Infrastructures = informer.Lister()
 			return informer.Informer()
 		},
+		func() cache.SharedIndexInformer {
+			// here we don't need the lister but we do want to be informed
+			// when jobs change because of the azure-path-fix job.
+			// this isn't so important in OCP >= 4.17 (because the job
+			// is not deployed starting on 4.17), but in OCP 4.14 through
+			// OCP 4.16 it is vital that this controller gets triggered
+			// when the job status changes, speacially in situations where
+			// the operator is set to Removed before the job is finished.
+			informer := kubeInformerFactory.Batch().V1().Jobs()
+			return informer.Informer()
+		},
 	} {
 		informer := ctor()
 		if _, err := informer.AddEventHandler(c.handler()); err != nil {


### PR DESCRIPTION
there is sometimes a race condition when setting .spec.managementState back and forth between Removed and Managed where the azure path fix controller will kick off the job, but the resources needed for the job to run will get removed (as expected) before the job can finish and its controller update the operator's progressing condition to reflect that.

this has been happening often in the TestLeaderElection e2e test. this test does not wait for the image registry operator to become available before removing it, and this is what triggers the race. a customer has reported a similar issue, although their error was slightly different and proved harder to reproduce. this commit should fix both problems.

clearing the status is most important when users upgrade from a version of the azure path fix controller that deploys the job. OCP versions that do not deploy the job should not have the problem, and including this code in them should be harmless.
in OCP >= 4.17 this job is no longer deployed, though the controller is kept it can probably be safely removed in OCP >= 4.18.

---

## Testing

We need upgrade tests as well as regression tests for this one. Testing operator removal (`.spec.managementState: Removed`) would also be great.