### PR TITLE
IR-490: manifests: add pvc related alerts to prometheus rules

### DIFF
--- a/manifests/09-prometheus-rules.yaml
+++ b/manifests/09-prometheus-rules.yaml
@@ -5,8 +5,31 @@ metadata:
   namespace: openshift-image-registry
   annotations:
     capability.openshift.io/name: ImageRegistry
-    release.openshift.io/delete: "true"
     include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+spec:
+  groups:
+    - name: pvc-problem-detector.rules
+      rules:
+      - alert: ImageRegistryStorageReadOnly
+        for: 10m
+        expr: sum without(instance, pod, operation) (rate(imageregistry_storage_errors_total{code="READ_ONLY_FILESYSTEM"}[5m])) > 0
+        labels:
+           kubernetes_operator_part_of: image-registry
+           severity: warning
+        annotations:
+           summary: The image registry storage is read-only and no images will be committed to storage.
+           description: The image registry storage is read-only. Read-only storage affects direct pushes to the image registry, and pull-through proxy caching. In the case of pull-through proxy caching, read-only storage is particularly important because without it the image registry won't be actually caching anything. Please verify your backing storage solution and make sure the volume mounted on the image-registry pods is writable to avoid potential outages.
+           message: The image registry storage is read-only and no images will be committed to storage.
+      - alert: ImageRegistryStorageFull
+        for: 10m
+        expr: sum without(instance, pod, operation) (rate(imageregistry_storage_errors_total{code="DEVICE_OUT_OF_SPACE"}[5m])) > 0
+        labels:
+           kubernetes_operator_part_of: image-registry
+           severity: warning
+        annotations:
+           summary: The image registry storage disk is full and no images will be committed to storage.
+           description: The image registry storage disk is full. A full disk affects direct pushes to the image registry, and pull-through proxy caching. In the case of pull-through proxy caching, disk space is particularly important because without it the image registry won't be actually caching anything. Please verify your backing storage solution and make sure the volume mounted on the image-registry pods have enough free disk space to avoid potential outages.
+           message: The image registry storage disk is full and no images will be committed to storage.


### PR DESCRIPTION
alerts when detecting metrics for read-only filesystem and device out of space errors.

the alerts in this commit follow the conventions specified by https://github.com/openshift/enhancements/blob/master/enhancements/monitoring/alerting-consistency.md.

---

Please see the description of https://github.com/openshift/image-registry/pull/412 for steps on configuring the image registry with a read-only pvc.