### PR TITLE
[release-4.15] OCPBUGS-43918: fix proxy config and leader election test flakes

### DIFF
--- a/test/e2e/configuration_test.go
+++ b/test/e2e/configuration_test.go
@@ -265,7 +265,10 @@ func TestRouteConfiguration(t *testing.T) {
 
 func TestOperatorProxyConfiguration(t *testing.T) {
 	te := framework.SetupAvailableImageRegistry(t, nil)
-	defer framework.TeardownImageRegistry(te)
+	// this test sometimes fails during tear down because some components
+	// (unrelated to the image registry) do not recover within the default
+	// timeout.
+	defer framework.TeardownImageRegistryWithTimeoutIncrement(te, 5*time.Minute)
 	defer framework.ResetClusterProxyConfig(te)
 
 	// Get the service network to set as NO_PROXY so that the

--- a/test/framework/imageregistry.go
+++ b/test/framework/imageregistry.go
@@ -580,8 +580,8 @@ func SetupAvailableImageRegistry(t *testing.T, spec *imageregistryapiv1.ImageReg
 	return te
 }
 
-func TeardownImageRegistry(te TestEnv) {
-	defer WaitUntilClusterOperatorsAreHealthy(te, 10*time.Second, AsyncOperationTimeout)
+func TeardownImageRegistryWithTimeoutIncrement(te TestEnv, timeoutIncrement time.Duration) {
+	defer WaitUntilClusterOperatorsAreHealthy(te, 10*time.Second, AsyncOperationTimeout+timeoutIncrement)
 	defer CheckAbsenceOfOperatorPods(te)
 	defer RemoveImageRegistry(te)
 	defer CheckPodsAreNotRestarted(te, labels.Everything())
@@ -590,4 +590,8 @@ func TeardownImageRegistry(te TestEnv) {
 		DumpOperatorDeployment(te)
 		DumpOperatorLogs(context.Background(), te)
 	}
+}
+
+func TeardownImageRegistry(te TestEnv) {
+	TeardownImageRegistryWithTimeoutIncrement(te, 0)
 }


### PR DESCRIPTION
Due to git conflict, this manually backports https://github.com/openshift/cluster-image-registry-operator/pull/1148.