### PR TITLE
[release-4.16] OCPBUGS-45041: operator/status clear azure path fix job conditions on operator removal

### DIFF
--- a/pkg/operator/azurepathfixcontroller.go
+++ b/pkg/operator/azurepathfixcontroller.go
@@ -178,17 +178,10 @@ func (c *AzurePathFixController) sync() error {
 		return err
 	}
 
-	azureStorage := imageRegistryConfig.Status.Storage.Azure
-	if azureStorage == nil || len(azureStorage.AccountName) == 0 {
-		return fmt.Errorf("storage account not yet provisioned")
-	}
-	if azureStorage == nil || len(azureStorage.Container) == 0 {
-		return fmt.Errorf("storage container not yet provisioned")
-	}
-
 	// the move-blobs cmd does not work on Azure Stack Hub. Users on ASH
 	// will have to copy the blobs on their own using something like az copy.
-	if strings.EqualFold(azureStorage.CloudName, "AZURESTACKCLOUD") {
+	azureStorage := imageRegistryConfig.Status.Storage.Azure
+	if azureStorage != nil && strings.EqualFold(azureStorage.CloudName, "AZURESTACKCLOUD") {
 		return nil
 	}
 


### PR DESCRIPTION
DO NOT MERGE! 

This PR is a reinterpretation of the changes originally made on https://github.com/openshift/cluster-image-registry-operator/pull/1142. The `AzurePathFixController` source code looks very different between the main branch and 4.14-4.16 branches. 
I'm opening this PR to ensure the approach taken on #1142 works similarly here as well.

---

The original bug (see #1142 for bug link) was quite often caught by `TestLeaderElection`. This test would often fail in a situation where the operator condition would get stuck on `AzurePathFixProgressing: Azure path fix job is progressing: 1 pods active; 0 pods failed`, while other controllers would have successfully progressed into `Removed` state. 
Running `TestLeaderElection` a few times in a row reliably reproduces this issue on 4.14-4.16 branches.
With the changes in this PR, I can no longer see this failure in my local environment. I have run `TestLeaderElection` 20 times and it passed every time.

/hold