### PR TITLE
OCPBUGS-47503: Power VS: Revert #1076 to match new API validation

### DIFF
--- a/pkg/storage/ibmcos/ibmcos.go
+++ b/pkg/storage/ibmcos/ibmcos.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"path/filepath"
 	"reflect"
-	"strings"
 	"time"
 
 	"golang.org/x/net/http/httpproxy"
@@ -501,19 +500,19 @@ func (d *driver) setServiceEndpointOverrides(infra *configapiv1.Infrastructure) 
 			if infra.Status.PlatformStatus.PowerVS != nil && len(infra.Status.PlatformStatus.PowerVS.ServiceEndpoints) > 0 {
 				for _, endpoint := range infra.Status.PlatformStatus.PowerVS.ServiceEndpoints {
 					switch endpoint.Name {
-					case strings.ToLower(string(configapiv1.IBMCloudServiceCOS)):
+					case string(configapiv1.IBMCloudServiceCOS):
 						klog.Infof("found override for ibmcloud cos endpoint: %s", endpoint.URL)
 						d.cosServiceEndpoint = endpoint.URL
-					case strings.ToLower(string(configapiv1.IBMCloudServiceIAM)):
+					case string(configapiv1.IBMCloudServiceIAM):
 						klog.Infof("found override for ibmcloud iam endpoint: %s", endpoint.URL)
 						d.iamServiceEndpoint = endpoint.URL
-					case strings.ToLower(string(configapiv1.IBMCloudServiceResourceController)):
+					case string(configapiv1.IBMCloudServiceResourceController):
 						klog.Infof("found override for ibmcloud resource controller endpoint: %s", endpoint.URL)
 						d.rcServiceEndpoint = endpoint.URL
-					case strings.ToLower(string(configapiv1.IBMCloudServiceResourceManager)):
+					case string(configapiv1.IBMCloudServiceResourceManager):
 						klog.Infof("found override for ibmcloud resource manager endpoint: %s", endpoint.URL)
 						d.rmServiceEndpoint = endpoint.URL
-					case strings.ToLower(string(configapiv1.IBMCloudServiceCIS)), strings.ToLower(string(configapiv1.IBMCloudServiceDNSServices)), strings.ToLower(string(configapiv1.IBMCloudServiceGlobalSearch)), strings.ToLower(string(configapiv1.IBMCloudServiceGlobalTagging)), strings.ToLower(string(configapiv1.IBMCloudServiceHyperProtect)), strings.ToLower(string(configapiv1.IBMCloudServiceKeyProtect)), strings.ToLower(string(configapiv1.IBMCloudServiceVPC)), strings.ToLower(string(configapiv1.IBMCloudServiceCOSConfig)), strings.ToLower(string(configapiv1.IBMCloudServiceGlobalCatalog)):
+					case "Power", string(configapiv1.IBMCloudServiceCIS), string(configapiv1.IBMCloudServiceDNSServices), string(configapiv1.IBMCloudServiceGlobalSearch), string(configapiv1.IBMCloudServiceGlobalTagging), string(configapiv1.IBMCloudServiceHyperProtect), string(configapiv1.IBMCloudServiceKeyProtect), string(configapiv1.IBMCloudServiceVPC), string(configapiv1.IBMCloudServiceCOSConfig), string(configapiv1.IBMCloudServiceGlobalCatalog):
 						klog.Infof("ignoring unused service endpoint: %s", endpoint.Name)
 					default:
 						klog.Infof("ignoring unknown service: %s", endpoint.Name)


### PR DESCRIPTION
After https://github.com/openshift/api/pull/2076, the validation in the image registry operator for the Power VS platform does not match the API's expectations.  This PR reverts #1076 which intended to work around the API's initial validation issues.

