### PR TITLE
OCPBUGS-50950: ensure that storage names don't end in dashes

### DIFF
--- a/pkg/storage/util/util.go
+++ b/pkg/storage/util/util.go
@@ -119,6 +119,9 @@ func GenerateStorageName(listers *regopclient.StorageListers, additionalInfo ...
 
 	// Check the length and pad or truncate as needed
 	switch {
+	case len(name) == 61:
+		// if the name is 61 chars, we don't have room for a dash before the padding
+		name = name + string(byte(97+rand.Intn(25)))
 	case len(name) < 62:
 		padding := 62 - len(name) - 1
 		bytes := make([]byte, padding)
@@ -126,10 +129,10 @@ func GenerateStorageName(listers *regopclient.StorageListers, additionalInfo ...
 			bytes[i] = byte(97 + rand.Intn(25)) // a=97 and z=97+25
 		}
 		name = fmt.Sprintf("%s-%s", name, string(bytes))
-	case len(name) > 62:
+	case len(name) >= 62:
 		name = name[0:62]
-		if strings.HasSuffix(name, "-") {
-			name = name[0:61] + string(byte(97+rand.Intn(25)))
+		if before, hasDash := strings.CutSuffix(name, "-"); hasDash {
+			name = before + string(byte(97+rand.Intn(25)))
 		}
 	}
 

--- a/pkg/storage/util/util_test.go
+++ b/pkg/storage/util/util_test.go
@@ -88,6 +88,11 @@ func TestGenerateStorageName(t *testing.T) {
 			infraName:      "MY-INFRA",
 			additionalInfo: []string{"test1", "test2"},
 		},
+		{
+			name:           "govcloud region name",
+			infraName:      "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			additionalInfo: []string{"us-gov-west-1"},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			l := regopclient.StorageListers{Infrastructures: MockInfrastructureLister{
@@ -122,6 +127,10 @@ func TestGenerateStorageName(t *testing.T) {
 
 			if n != strings.ToLower(n) {
 				t.Errorf("name should not contain upper case: %s", n)
+			}
+
+			if strings.HasSuffix(n, "-") {
+				t.Errorf("name should not end in a dash: %s", n)
 			}
 		})
 	}


### PR DESCRIPTION
to ensure compatibility with all cloud region names, specifically the longer region names used in AWS GovCloud.