### PR TITLE
WIP TEST: Reproduce OCPBUGS-23514 for CVO

### DIFF
--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -58,7 +58,7 @@ spec:
               memory: 50Mi
           env:
             - name: RELEASE_VERSION
-              value: "0.0.1-snapshot"
+              value: 4.19.0-ec.2
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -78,7 +78,7 @@ spec:
             - name: AZURE_ENVIRONMENT_FILEPATH
               value: /tmp/azurestackcloud.json
             - name: OPERATOR_IMAGE_VERSION
-              value: 0.0.1-snapshot
+              value: 4.19.0-ec.2
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - name: trusted-ca


### PR DESCRIPTION
(sorry for the noise)

Attempt to make OCPBUGS-23514 reproducible by creating an ephemeral payload that will not respect CVO's update assumptions/contract. I try to make the following work:

1. Install 4.19 EC2
2. Build a 4.19 ephemeral payload with this patch, containing an image-registry CO with hardcoded `4.19.0-ec.2` OPERATOR_IMAGE_VERSION (=instead of actual payload image version)
3. Update the cluster to this ephemeral payload
4. Image registry operator should set the CO version to 4.19.0-ec.2 and therefore CVO will never consider the CO as updated, and the update should get stuck on it (reproducing OCPBUGS-23514)