### PR TITLE
AUTH-482: Move required-scc annotation from pruner job to pod

### DIFF
--- a/pkg/resource/prunercronjob.go
+++ b/pkg/resource/prunercronjob.go
@@ -175,7 +175,7 @@ done
 		},
 	}
 	cj.Spec.JobTemplate.Labels = map[string]string{"created-by": gcj.GetName()}
-	cj.Spec.JobTemplate.Annotations = map[string]string{securityv1.RequiredSCCAnnotation: "restricted-v2"}
+	cj.Spec.JobTemplate.Spec.Template.Annotations = map[string]string{securityv1.RequiredSCCAnnotation: "restricted-v2"}
 	return cj, nil
 }
 


### PR DESCRIPTION
The `required-scc` annotation should be on the template that gets applied to the pod itself, not the template for the job resource.