### PR TITLE
OCPBUGS-58424: Revert readonlyRootFilesystem changes

### DIFF
--- a/bindata/nodecadaemon.yaml
+++ b/bindata/nodecadaemon.yaml
@@ -29,7 +29,6 @@ spec:
       containers:
       - name: node-ca
         securityContext:
-          readOnlyRootFilesystem: true
           privileged: true
           runAsUser: 1001
           runAsGroup: 0

--- a/manifests/07-operator-ibm-cloud-managed.yaml
+++ b/manifests/07-operator-ibm-cloud-managed.yaml
@@ -62,8 +62,6 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
-        securityContext:
-          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/configmaps/trusted-ca/
@@ -73,8 +71,6 @@ spec:
         - mountPath: /var/run/secrets/openshift/serviceaccount
           name: bound-sa-token
           readOnly: true
-        - mountPath: /tmp
-          name: tmp
       priorityClassName: system-cluster-critical
       serviceAccountName: cluster-image-registry-operator
       shareProcessNamespace: false
@@ -91,8 +87,6 @@ spec:
         operator: Exists
         tolerationSeconds: 120
       volumes:
-      - emptyDir: {}
-        name: tmp
       - name: image-registry-operator-tls
         secret:
           secretName: image-registry-operator-tls

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -79,8 +79,6 @@ spec:
               value: /tmp/azurestackcloud.json
             - name: OPERATOR_IMAGE_VERSION
               value: 0.0.1-snapshot
-          securityContext:
-            readOnlyRootFilesystem: true
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - name: trusted-ca
@@ -90,11 +88,7 @@ spec:
             - name: bound-sa-token
               mountPath: /var/run/secrets/openshift/serviceaccount
               readOnly: true
-            - name: tmp
-              mountPath: /tmp
       volumes:
-        - name: tmp
-          emptyDir: {}
         - name: image-registry-operator-tls
           secret:
             secretName: image-registry-operator-tls

--- a/pkg/resource/podtemplatespec.go
+++ b/pkg/resource/podtemplatespec.go
@@ -13,7 +13,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	coreset "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/utils/ptr"
 
 	configapiv1 "github.com/openshift/api/config/v1"
 	v1 "github.com/openshift/api/imageregistry/v1"
@@ -512,9 +511,6 @@ func makePodTemplateSpec(coreClient coreset.CoreV1Interface, proxyLister configl
 						},
 					},
 					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
-					SecurityContext: &corev1.SecurityContext{
-						ReadOnlyRootFilesystem: ptr.To(true),
-					},
 				},
 			},
 			Volumes:                       volumes,

--- a/pkg/resource/prunercronjob.go
+++ b/pkg/resource/prunercronjob.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	batchset "k8s.io/client-go/kubernetes/typed/batch/v1"
 	batchlisters "k8s.io/client-go/listers/batch/v1"
-	"k8s.io/utils/ptr"
 
 	imageregistryapiv1 "github.com/openshift/api/imageregistry/v1"
 	securityv1 "github.com/openshift/api/security/v1"
@@ -166,9 +165,6 @@ done
 											MountPath: "/var/run/configmaps/serviceca",
 											ReadOnly:  true,
 										},
-									},
-									SecurityContext: &kcorev1.SecurityContext{
-										ReadOnlyRootFilesystem: ptr.To(true),
 									},
 								},
 							},


### PR DESCRIPTION
This reverts commit 723cdc479e5092830af1c5fd3715a8560d284d16. Do not merge this as we are checking if this is indeed what is causing the problem reported on the referred bug.