### PR TITLE
OCPBUGS-59734: fix(azure): resolve credential caching issues around UAMI support

### DIFF
--- a/pkg/storage/azure/azure.go
+++ b/pkg/storage/azure/azure.go
@@ -384,7 +384,7 @@ func (d *driver) storageAccountsClient(cfg *Azure, environment autorestazure.Env
 		var ok bool
 
 		// We need to only store the Azure credentials once and reuse them after that.
-		storedCreds, found := d.azureCredentials.Load(userAssignedIdentityCredentialsFilePath)
+		storedCreds, found := d.azureCredentials.Load(azureCredentialsKey)
 		if !found {
 			klog.V(2).Info("Using UserAssignedIdentityCredentials for Azure authentication for managed Azure HCP")
 			clientOptions := azcore.ClientOptions{

--- a/pkg/storage/azure/azureclient/azureclient.go
+++ b/pkg/storage/azure/azureclient/azureclient.go
@@ -111,7 +111,7 @@ func (c *Client) getCreds(ctx context.Context) (azcore.TokenCredential, error) {
 		var ok bool
 
 		// We need to only store the Azure credentials once and reuse them after that.
-		storedCreds, found := c.azureCredentials.Load(userAssignedIdentityCredentialsFilePath)
+		storedCreds, found := c.azureCredentials.Load(azureCredentialsKey)
 		if !found {
 			klog.V(2).Info("Using UserAssignedIdentityCredentials for Azure authentication for managed Azure HCP")
 			clientOptions := azcore.ClientOptions{


### PR DESCRIPTION
## Summary
This PR fixes credential caching issues in Azure storage operations and adds caching support for User Assigned Managed Identity (UAMI) credentials.

Caching at the driver level was not enough so a global cache was introduced so that we are not getting new credentials over and over from Azure.

## Changes
- **fix(azure): fix credential caching key mismatch in driver storageAccountsClient** 
  Resolves credential caching key inconsistencies in the storage accounts client
  
- **fix(azure): fix credential caching key mismatch in azureclient**
  Fixes credential caching key mismatches in the Azure client implementation
  
- **feat(azure): add ensureUAMICredentials function with comprehensive tests**
  - Adds new `ensureUAMICredentials` function to obtain and cache Azure TokenCredential using User Assigned Managed Identity (UAMI)
  - Function loads credentials from global cache or creates new ones with proper environment configuration
  - Comprehensive unit tests covering environment variable handling, cache behavior, and error scenarios
  - Tests follow table-driven pattern and use `t.Setenv` for proper environment handling
  - Updates Azure client instantiation to use UAMI credentials when available

## Testing
- Added comprehensive unit tests for the new `ensureUAMICredentials` function
- Tests follow established codebase patterns and conventions

## Impact
- Improves credential management reliability in Azure storage operations
- Enables proper UAMI support for managed Azure environments
- No breaking changes to existing functionality