### PR TITLE
MON-4483: chore: add permissions on endpointslice to Prometheus Role nd use serviceDiscoveryRole: EndpointSlice in ServiceMonitors

### DIFF
--- a/manifests/0000_90_cluster-image-registry-operator_00_servicemonitor-rbac.yaml
+++ b/manifests/0000_90_cluster-image-registry-operator_00_servicemonitor-rbac.yaml
@@ -59,6 +59,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/manifests/0000_90_cluster-image-registry-operator_01_operand-servicemonitor.yaml
+++ b/manifests/0000_90_cluster-image-registry-operator_01_operand-servicemonitor.yaml
@@ -25,3 +25,4 @@ spec:
     matchNames:
     - openshift-image-registry
   selector: {}
+  serviceDiscoveryRole: EndpointSlice

--- a/manifests/0000_90_cluster-image-registry-operator_02_operator-servicemonitor.yaml
+++ b/manifests/0000_90_cluster-image-registry-operator_02_operator-servicemonitor.yaml
@@ -22,3 +22,4 @@ spec:
   selector:
     matchLabels:
       name: image-registry-operator
+  serviceDiscoveryRole: EndpointSlice


### PR DESCRIPTION
This PR migrates Prometheus service discovery from the deprecated Endpoints API to the EndpointSlices API, by:

- Setting `serviceDiscoveryRole: EndpointSlice` on ServiceMonitors.
- Granting Prometheus `endpointslices` permissions.

We're taking a conservative approach by keeping the existing `endpoints` permissions alongside the new `endpointslices` ones. This provides a safety net in case any ServiceMonitors, whether deployed from this repo or from another source, still rely on the same Role and were missed during the migration.

That said, since both resources provide essentially the same data, keeping both isn't meaningfully more permissive from a security standpoint.

**These changes target OpenShift 4.22+ and should not be backported to earlier releases.**
