### PR TITLE
OCPBUGS-66225: bump deployment ProgressDeadlineSeconds to 120s

### DIFF
--- a/pkg/resource/deployment.go
+++ b/pkg/resource/deployment.go
@@ -145,7 +145,7 @@ func (gd *generatorDeployment) expected() (runtime.Object, error) {
 			},
 		},
 		Spec: appsapi.DeploymentSpec{
-			ProgressDeadlineSeconds: ptr.To[int32](60),
+			ProgressDeadlineSeconds: ptr.To[int32](120),
 			Replicas:                &gd.cr.Spec.Replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: defaults.DeploymentLabels,


### PR DESCRIPTION
This bumps the deadline seconds of the operand deployment, in many failures we're just scratching the timeout and cause a degraded blip.

Also required for https://github.com/openshift/origin/pull/30755