### PR TITLE
OCPBUGS-66225: migrate to go 1.25

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.24-openshift-4.22
+  tag: rhel-9-release-golang-1.25-openshift-4.22

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,13 +1,39 @@
+version: "2"
 linters:
+  settings:
+    staticcheck:
+      checks:
+        - all
+        # below list makes the verify target pass
+        - '-QF1001' # could apply De Morgan's law
+        - '-QF1004' # could use strings.ReplaceAll instead
+        - '-QF1008' # could remove embedded field
+        - '-ST1003' # should not use underscores in Go names
+        - '-ST1005' # error strings should not be capitalized
+        - '-ST1012' # error should have name of the form ErrFoo
+        - '-ST1016' # methods on the same type should have the same receiver name
+        - '-ST1019' # package is being imported more than once
   enable:
-  - contextcheck
-  - errcheck
-  - exhaustive
-  - gofumpt
-  - gosimple
-  - govet
-  - ineffassign
-  - misspell
-  - staticcheck
-  - typecheck
-  - unused
+    - contextcheck
+    - exhaustive
+    - misspell
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofumpt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-image-registry-operator
 COPY . .
 RUN make build \

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ PROG  := cluster-image-registry-operator
 
 GOLANGCI_LINT = _output/tools/golangci-lint
 GOLANGCI_LINT_CACHE = $(PWD)/_output/golangci-lint-cache
-GOLANGCI_LINT_VERSION = v1.64.8
+GOLANGCI_LINT_VERSION = v2.11.3
 
-GO_REQUIRED_MIN_VERSION = 1.16
+GO_REQUIRED_MIN_VERSION = 1.25
 
 include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
     targets/help.mk \

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/openshift/cluster-image-registry-operator
 
-go 1.24.0
-
-toolchain go1.24.6
+go 1.25.0
 
 require (
 	cloud.google.com/go/resourcemanager v1.9.6


### PR DESCRIPTION
Prep work for the next rebased library-go update, separated out from #1304 

