### PR TITLE
OCPBUGS-79878: Bump google.golang.org/grpc to v1.79.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -160,7 +160,7 @@ require (
 	google.golang.org/genproto v0.0.0-20230530153820-e85fd2cbaebc // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20230530153820-e85fd2cbaebc // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230530153820-e85fd2cbaebc // indirect
-	google.golang.org/grpc v1.55.0 // indirect
+	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.62.0 // indirect

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1021,7 +1021,7 @@ google.golang.org/genproto/googleapis/api/httpbody
 google.golang.org/genproto/googleapis/rpc/code
 google.golang.org/genproto/googleapis/rpc/errdetails
 google.golang.org/genproto/googleapis/rpc/status
-# google.golang.org/grpc v1.55.0 => google.golang.org/grpc v1.55.0
+# google.golang.org/grpc v1.79.3 => google.golang.org/grpc v1.55.0
 ## explicit; go 1.17
 google.golang.org/grpc
 google.golang.org/grpc/attributes


### PR DESCRIPTION
This PR is part of an automated process.

The commands used to generate this PR were:

```
go get google.golang.org/grpc@v1.79.3 toolchain@none
go mod tidy
go mod vendor
```

A member of the Red Hat Openshift Sustaining Team will review the PR and take appropriate action.