### PR TITLE
OCPBUGS-79782: Bump google.golang.org/grpc to v1.79.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -150,7 +150,7 @@ require (
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20220502173005-c8bf987b8c21 // indirect
-	google.golang.org/grpc v1.49.0 // indirect
+	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.31.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -902,7 +902,7 @@ google.golang.org/genproto/googleapis/rpc/errdetails
 google.golang.org/genproto/googleapis/rpc/status
 google.golang.org/genproto/googleapis/type/expr
 google.golang.org/genproto/protobuf/field_mask
-# google.golang.org/grpc v1.49.0 => google.golang.org/grpc v1.40.0
+# google.golang.org/grpc v1.79.3 => google.golang.org/grpc v1.40.0
 ## explicit; go 1.11
 google.golang.org/grpc
 google.golang.org/grpc/attributes


### PR DESCRIPTION
This PR is part of an automated process.

The commands used to generate this PR were:

```
go get google.golang.org/grpc@v1.79.3 toolchain@none
go mod tidy
go mod vendor
```

A member of the Red Hat Openshift Sustaining Team will review the PR and take appropriate action.