### PR TITLE
OCPBUGS-66225: ImageConfigController: wait for ClusterVersion informe…

### DIFF
--- a/pkg/operator/imageconfig.go
+++ b/pkg/operator/imageconfig.go
@@ -86,6 +86,7 @@ func NewImageConfigController(
 			return nil, err
 		}
 		icc.cachesToSync = append(icc.cachesToSync, imageConfigInformer.Informer().HasSynced)
+		icc.cachesToSync = append(icc.cachesToSync, clusterVersionInformer.Informer().HasSynced)
 	}
 	return icc, nil
 }


### PR DESCRIPTION
…r when import mode gate is on

When ImageStreamImportMode is enabled, syncImageStatus reads clusterversion.config.openshift.io/version from the lister before the ClusterVersion informer had finished its initial sync, Get returned NotFound and ImageConfigControllerDegraded was set briefly. Append the ClusterVersion informer HasSynced to cachesToSync in that configuration so workers start only after the version object is in cache.

Made-with: Cursor