### PR TITLE
OCPBUGS-83282: Allow longer window before going Degraded

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -349,7 +349,7 @@ func (c *Controller) syncStatus(
 		operatorDegraded.Reason = "Removed"
 	} else if operatorAvailable.Status != operatorapiv1.ConditionTrue {
 		updatedAvailableCondition := v1helpers.FindOperatorCondition(cr.Status.Conditions, operatorapiv1.OperatorStatusTypeAvailable)
-		if updatedAvailableCondition != nil && time.Since(updatedAvailableCondition.LastTransitionTime.Time) > time.Minute {
+		if updatedAvailableCondition != nil && time.Since(updatedAvailableCondition.LastTransitionTime.Time) > 2*time.Minute {
 			operatorDegraded.Status = operatorapiv1.ConditionTrue
 			operatorDegraded.Message = updatedAvailableCondition.Message
 			operatorDegraded.Reason = "Unavailable"

--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -371,7 +371,7 @@ func Test_syncStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "Deployment without replicas for more than one minute",
+			name: "Deployment without replicas for more than two minutes",
 			cfg: &imageregistryv1.Config{
 				Spec: imageregistryv1.ImageRegistrySpec{
 					OperatorSpec: operatorv1.OperatorSpec{
@@ -384,7 +384,7 @@ func Test_syncStatus(t *testing.T) {
 							{
 								Type:               "Available",
 								Status:             "False",
-								LastTransitionTime: metav1.NewTime(time.Now().Add(-1 * time.Minute)),
+								LastTransitionTime: metav1.NewTime(time.Now().Add(-2*time.Minute - time.Second)),
 							},
 						},
 					},
@@ -590,7 +590,7 @@ func Test_syncStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "Deployment not in place after one minute",
+			name: "Deployment not in place after two minutes",
 			cfg: &imageregistryv1.Config{
 				Spec: imageregistryv1.ImageRegistrySpec{
 					OperatorSpec: operatorv1.OperatorSpec{
@@ -603,7 +603,7 @@ func Test_syncStatus(t *testing.T) {
 							{
 								Type:               "Available",
 								Status:             "False",
-								LastTransitionTime: metav1.NewTime(time.Now().Add(-1 * time.Minute)),
+								LastTransitionTime: metav1.NewTime(time.Now().Add(-2*time.Minute - time.Second)),
 							},
 						},
 					},


### PR DESCRIPTION
…istry

Raise the grace period from 1m to 2m before mirroring a false Available condition into Degraded with reason Unavailable. This reduces flakes when the deployment temporarily has no available replicas (e.g. Recreate strategy with slow volume attach on some platforms).

Update syncStatus tests to use LastTransitionTime beyond the new threshold.

Made-with: Cursor