### PR TITLE
IR-486: use AlwaysAllow UnhealthyPodEvictionPolicy option in PDBs

### DIFF
--- a/pkg/resource/poddisruptionbudget.go
+++ b/pkg/resource/poddisruptionbudget.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	policyclient "k8s.io/client-go/kubernetes/typed/policy/v1"
 	policylisters "k8s.io/client-go/listers/policy/v1"
+	"k8s.io/utils/ptr"
 )
 
 var _ Mutator = &generatorPodDisruptionBudget{}
@@ -57,6 +58,7 @@ func (gpdb *generatorPodDisruptionBudget) expected() (runtime.Object, error) {
 			Selector: &metav1.LabelSelector{
 				MatchLabels: defaults.DeploymentLabels,
 			},
+			UnhealthyPodEvictionPolicy: ptr.To(policyv1.AlwaysAllow),
 		},
 	}
 


### PR DESCRIPTION
Allow eviction of unhealthy (not ready) pods even if there are no disruptions
allowed on a PodDisruptionBudget. This can help to drain/maintain a node and
recover without a manual intervention when multiple instances of nodes or pods
are misbehaving.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pod Disruption Budget resources now properly configure the unhealthy pod eviction policy, ensuring consistent handling of pod evictions when health checks fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->