### PR TITLE
NO-JIRA: fix flaky TestGlobalTLSCopy unit test

### DIFF
--- a/pkg/operator/controller_test.go
+++ b/pkg/operator/controller_test.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"context"
+	"encoding/json"
 	"strconv"
 	"testing"
 	"time"
@@ -64,6 +65,24 @@ func registryConfigResourceVersionBumper(t *testing.T, regcli *imageregistryfake
 	return func(action clientgotesting.Action) (bool, runtime.Object, error) {
 		update := action.(clientgotesting.UpdateAction)
 		newcfg := update.GetObject().(*imageregistryv1.Config).DeepCopy()
+
+		// during a real apiserver communication objects are marshaled
+		// and umarshaled when crossing through the wire. when the
+		// unmarshal happen on the server side the RawExtension.Object
+		// isn't unmarshaled (its data remain on the RawExtension.Raw
+		// property). as we are not a real apiserver and this operator
+		// needs the RawExtension.Raw property of the config we have to
+		// marshal and unmarshal. this operation attempts to simulate
+		// the object passing through the wire before hiting the
+		// storage.
+		data, err := json.Marshal(newcfg)
+		if err != nil {
+			t.Fatalf("failed to marshal config: %v", err)
+		}
+		newcfg = &imageregistryv1.Config{}
+		if err := json.Unmarshal(data, newcfg); err != nil {
+			t.Fatalf("failed to unmarshal config: %v", err)
+		}
 
 		gvr := schema.GroupVersionResource{
 			Group:    "imageregistry.operator.openshift.io",


### PR DESCRIPTION
the fake client stored objects in-memory without json round-tripping, leaving RawExtension.Object set instead of converting to .Raw like the real api server does. ConfigObserver's UpdateOperatorSpec sets .Object, then ApplyOperatorStatus converts it to .Raw via server-side apply's json marshaling. The test raced on whether the registry controller read before or after the conversion. Add marshal/unmarshal in the reactor to match production behavior. if it read before we have a failure, if it read after a success.

to better understand the problem, the snippet below prints:
```
true false
false true
```

```go
package main

import (
        "encoding/json"
        "fmt"

        imageregistryv1 "github.com/openshift/api/imageregistry/v1"
        corev1 "k8s.io/api/core/v1"
        "k8s.io/apimachinery/pkg/runtime"
)

func main() {
        var config imageregistryv1.Config

        config.Spec.ObservedConfig = runtime.RawExtension{Object: &corev1.Namespace{}}
        fmt.Println(config.Spec.ObservedConfig.Raw == nil, config.Spec.ObservedConfig.Object == nil)

        data, err := json.Marshal(config)
        if err != nil {
                panic(err)
        }

        config = imageregistryv1.Config{}
        if err := json.Unmarshal(data, &config); err != nil {
                panic(err)
        }
        fmt.Println(config.Spec.ObservedConfig.Raw == nil, config.Spec.ObservedConfig.Object == nil)

}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced tests to better simulate Kubernetes API server normalization, fail fast on serialization issues, and more accurately exercise the tracker/resource-version update path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->