### PR TITLE
OCPBUGS-83863: Strip debug symbols from Go binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 RUN make build \
     && gzip tmp/_output/bin/cluster-image-registry-operator-tests-ext 
 WORKDIR /go/src/github.com/openshift/cluster-image-registry-operator/cmd/move-blobs
-RUN go build -o ../../tmp/_output/bin/move-blobs
+RUN go build -ldflags '-s -w' -o ../../tmp/_output/bin/move-blobs
 
 FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
 COPY images/bin/entrypoint.sh /usr/bin/

--- a/hack/build/build.sh
+++ b/hack/build/build.sh
@@ -13,7 +13,7 @@ BIN_DIR="$(pwd)/tmp/_output/bin"
 mkdir -p ${BIN_DIR}
 REPO_PATH="github.com/openshift/cluster-image-registry-operator"
 VERSION="$(git describe --tags --always --dirty)"
-GO_LDFLAGS="-X ${REPO_PATH}/pkg/version.Version=${VERSION}"
+GO_LDFLAGS="-s -w -X ${REPO_PATH}/pkg/version.Version=${VERSION}"
 
 # Build cluster-image-registry-operator
 PROJECT_NAME="cluster-image-registry-operator"


### PR DESCRIPTION
## Summary
- Add `-s -w` to ldflags in `hack/build/build.sh` and `Dockerfile` (move-blobs) to strip DWARF debug info and symbol tables

## Impact
The cluster-image-registry-operator image (465 MB) contains two unstripped Go binaries:
- `cluster-image-registry-operator` (139.6 MB)
- `move-blobs` (12.9 MB)

Stripping typically reduces Go binary size by 20-30%, reducing container image pull time during node scale-up.

## Test plan
- [ ] Verify image builds successfully
- [ ] Verify binaries are stripped
- [ ] Verify operator functions correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configurations to generate optimized binary distributions with reduced size while maintaining full functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->