### PR TITLE
OCPBUGS-85107: fix required-scc annotation on image-pruner pods

### DIFF
--- a/pkg/resource/prunercronjob.go
+++ b/pkg/resource/prunercronjob.go
@@ -180,7 +180,7 @@ done
 	}
 	cj.Spec.JobTemplate.Labels = map[string]string{"created-by": gcj.GetName()}
 	cj.Spec.JobTemplate.Spec.Template.Labels = defaults.PrunerPodLabels
-	cj.Spec.JobTemplate.Annotations = map[string]string{securityv1.RequiredSCCAnnotation: "restricted-v2"}
+	cj.Spec.JobTemplate.Spec.Template.Annotations = map[string]string{securityv1.RequiredSCCAnnotation: "restricted-v2"}
 	return cj, nil
 }
 


### PR DESCRIPTION
The annotation was set on the Job metadata instead of the Pod template, so it was not propagated to the pruner pods.

Failing sippy tests: https://sippy.dptools.openshift.org/sippy-ng/tests/5.0/analysis?test=%5BMonitor%3Arequired-scc-annotation-checker%5D%5Bsig-auth%5D%20all%20workloads%20in%20ns%2Fopenshift-image-registry%20must%20set%20the%20%27openshift.io%2Frequired-scc%27%20annotation

Fixing this will allow us to drop the [exception](https://github.com/openshift/origin/blob/main/pkg/monitortests/authentication/requiredsccmonitortests/monitortest.go#L43) from the `required-scc-annotation-checker` monitor test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed security context configuration to apply at the correct level in scheduled job pods, ensuring proper security compliance enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->