### PR TITLE
CNTRLPLANE-3658: Add AGENTS.md, ARCHITECTURE.md, CLAUDE.md, update CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,83 @@
+# AI Agent Instructions for cluster-image-registry-operator
+
+Before making changes, check the `docs/` directory for additional context — it contains documentation on credentials flow, development builds, operator lifecycle, and metrics.
+
+## What This Repo Is
+
+This is an OpenShift operator that manages the singleton internal container image registry. It handles registry deployment, storage provisioning across cloud providers (AWS S3, Azure Blob, GCS, IBM COS, OpenStack Swift, PVC, EmptyDir), routes, and image pruning.
+
+The operator runs in the `openshift-image-registry` namespace and is managed by the ClusterVersionOperator (CVO).
+
+## Critical Rules
+
+1. **Do not edit vendored files.** The `vendor/` directory is managed by `go mod tidy && go mod vendor`. Never hand-edit anything under `vendor/`.
+2. **Do not edit generated files.** Files matching `zz_generated.*` and CRD manifests under `vendor/github.com/openshift/api/` are generated in the `openshift/api` repo.
+3. **Use `make build`, not `go build`.** The Makefile injects version info via ldflags and places binaries in `tmp/_output/bin/`.
+4. **Run `make verify` before considering any change complete.** This runs gofmt, golangci-lint, and dependency checks.
+
+## Repository Structure
+
+```
+cmd/
+├── cluster-image-registry-operator/         # Main operator binary
+├── cluster-image-registry-operator-tests-ext/ # OTE e2e test harness
+└── move-blobs/                              # Azure blob migration utility
+
+pkg/
+├── operator/           # Controllers (11+ running concurrently)
+│   ├── controller.go   # Main reconciliation controller
+│   ├── starter.go      # Wires and starts all controllers
+│   ├── bootstrap.go    # Creates default Config CR with platform defaults
+│   └── ...             # ClusterOperator status, pruner, certs, metrics, etc.
+├── resource/           # Kubernetes resource generators (Deployment, Service, Route, RBAC, etc.)
+├── storage/            # Cloud storage drivers (s3/, azure/, gcs/, ibmcos/, swift/, pvc/, emptydir/)
+├── client/             # Custom client/lister wrappers
+├── defaults/           # Constants (namespace names, resource names)
+└── metrics/            # Prometheus metrics
+
+test/
+├── e2e/                # End-to-end tests (require real OpenShift cluster)
+└── framework/          # Shared test helpers
+```
+
+## Key Patterns to Follow
+
+- **Storage Driver interface**: All cloud backends implement the `Driver` interface in `pkg/storage/`. New storage backends must implement the full interface — no partial implementations.
+- **Single workqueue**: All events coalesce to a single workqueue key (`"changes"`). The main controller's `sync()` handles all reconciliation in one pass.
+- **Config CR is source of truth**: All reconciliation state comes from the `configs.imageregistry.operator.openshift.io/cluster` CR. Do not derive state from Deployment status alone.
+- **Retry on conflict**: Use `retry.RetryOnConflict` when updating the Config CR status — multiple controllers may update it concurrently.
+
+## Important Constraints
+
+- **Storage config is immutable after bootstrap.** S3 bucket names, Azure container names, etc. are set once during initial Config CR creation and are not changed afterward. Changing storage type requires CR deletion and recreation.
+- **Config CR is read directly from the API server**, not from the informer cache, to avoid staleness issues during rapid updates.
+- **PVC storage forces `Recreate` deployment strategy** because `RollingUpdate` causes new pods to block waiting for exclusive volume access. Cloud storage backends use `RollingUpdate`.
+- **Platform detection** reads `config.openshift.io/infrastructures/cluster`. Unknown platforms default to EmptyDir (ephemeral) storage.
+- **Credential override**: Users can supply custom cloud credentials via the `image-registry-private-configuration-user` secret. The operator merges these into `image-registry-private-configuration` for the storage drivers.
+
+## Build and Test
+
+```bash
+make build       # Compile operator + test binaries
+make test-unit   # Unit tests
+make test-e2e    # E2E tests (requires real OpenShift cluster)
+make verify      # Linters, gofmt, dependency checks
+```
+
+### OTE (OpenShift Tests Extension)
+
+E2E tests run via the OTE framework. The test harness binary is at `cmd/cluster-image-registry-operator-tests-ext/` and registers two suites:
+
+- **Serial suite** (`openshift/cluster-image-registry-operator/operator/serial`): Parallelism=1. Runs tests tagged `[Serial]` or `[Disruptive]` — these modify shared cluster state (e.g., ImageRegistry config, storage).
+- **Parallel suite** (`openshift/cluster-image-registry-operator/operator/parallel`): Parallelism=4. Runs all other tests concurrently.
+
+Tests live in `test/e2e/` and use the shared `test/framework/` helpers. They require a real OpenShift cluster — do not run on Kind or Minikube. When adding new e2e tests, tag with `[Serial]` if the test modifies cluster-wide resources; otherwise it runs in the parallel suite by default.
+
+## What NOT to Do
+
+- Do not modify CRD definitions here — they live in the `openshift/api` repo.
+- Do not modify OWNERS or OWNERS_ALIASES files.
+- Do not modify TLS certificate management code — this functionality is being removed from the operator.
+- Do not assume cloud credentials are available outside of secrets. The operator reads credentials from `image-registry-private-configuration` (and user overrides from `image-registry-private-configuration-user`) to configure storage drivers.
+- Do not add cloud provider SDK calls without ensuring the corresponding storage driver handles credential refresh and error retries.
+- Do not run e2e tests on Kind or Minikube — they require a full OpenShift cluster.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,144 @@
+# Architecture: cluster-image-registry-operator
+
+## Overview
+
+The cluster-image-registry-operator manages the singleton OpenShift internal container image registry. It is responsible for deploying the registry, provisioning cloud storage, managing TLS certificates and routes, handling image pruning, and reporting operator health.
+
+The operator runs in the `openshift-image-registry` namespace and reconciles the `configs.imageregistry.operator.openshift.io/cluster` custom resource.
+
+## Controllers
+
+The operator runs 11+ concurrent controllers, each with its own watches and responsibilities:
+
+| Controller | Purpose |
+|-----------|---------|
+| **Controller** (main) | Reconciles the Config CR — manages registry Deployment, Service, Route, RBAC, storage, and secrets |
+| **ClusterOperatorStatusController** | Aggregates conditions into the `ClusterOperator` CR for cluster-level health reporting |
+| **ImageConfigController** | Syncs external image configuration from `config.openshift.io/images` |
+| **ImageRegistryCertificatesController** | Manages TLS certificates for the registry |
+| **NodeCADaemonController** | Ensures node CA certificates are synced to all nodes via a DaemonSet |
+| **ImagePrunerController** | Manages the image pruner CronJob workload |
+| **AWSTagController** | Applies required tags to AWS S3 buckets |
+| **AzureStackCloudController** | Handles Azure Stack-specific cloud configuration |
+| **AzurePathFixController** | Corrects Azure blob storage path ACLs |
+| **MetricsController** | Exposes Prometheus metrics on port 60000 |
+| **LoggingController** | Manages dynamic log level configuration |
+
+All controllers are started in `pkg/operator/starter.go` via `RunOperator()`, which sets up shared informer factories across multiple namespaces (`openshift-image-registry`, `openshift-config`, `openshift-config-managed`, `kube-system`).
+
+## Reconciliation Flow
+
+The main controller uses a single workqueue key (`"changes"`) — all watched events coalesce into one sync cycle:
+
+```text
+Event (Config CR, Deployment, Secret, ConfigMap, etc.)
+  → Enqueue "changes"
+    → sync()
+      ├── Bootstrap: create default Config CR if missing (with platform-detected storage defaults)
+      ├── Check management state:
+      │   ├── Removed → tear down registry + storage via finalizer
+      │   ├── Unmanaged → skip reconciliation
+      │   └── Managed → full reconciliation
+      ├── Resource generation (resource.Generator.Apply):
+      │   ├── Verify config completeness
+      │   ├── Create/update Deployment, Service, Route, PDB, RBAC, etc.
+      │   └── Configure storage-specific environment and volumes
+      └── Status update: conditions, ready replicas, storage state
+```
+
+The Config CR is read directly from the API server (not from the informer cache) to avoid staleness during rapid updates.
+
+## Storage Architecture
+
+Multi-cloud storage support is implemented via the `storage.Driver` interface:
+
+```go
+type Driver interface {
+    CABundle() (string, bool, error)
+    ConfigEnv() (envvar.List, error)
+    Volumes() ([]Volume, []VolumeMount, error)
+    VolumeSecrets() (map[string]string, error)
+    CreateStorage(*Config) error
+    StorageExists(*Config) (bool, error)
+    RemoveStorage(*Config) (bool, error)
+    StorageChanged(*Config) bool
+    ID() string
+}
+```
+
+Each cloud provider implements this interface:
+
+| Driver | Backend | Auto-detected On |
+|--------|---------|-----------------|
+| `s3` | AWS S3 | AWS |
+| `azure` | Azure Blob Storage | Azure |
+| `gcs` | Google Cloud Storage | GCP |
+| `ibmcos` | IBM Cloud Object Storage | IBM Cloud |
+| `swift` | OpenStack Swift | OpenStack |
+| `pvc` | PersistentVolumeClaim | Baremetal, vSphere |
+| `emptydir` | EmptyDir (ephemeral) | Unknown platforms |
+
+Platform detection reads the `config.openshift.io/infrastructures/cluster` resource. Storage configuration is set at bootstrap and is immutable afterward — changing storage type requires deleting and recreating the Config CR.
+
+## Resource Generation
+
+The `pkg/resource/` package generates all Kubernetes resources the registry needs. The `Generator` type orchestrates creation and updates of:
+
+- **Deployment**: Registry pods with storage-specific volumes, environment variables, and update strategy (Recreate for PVC, RollingUpdate for cloud storage)
+- **Service**: ClusterIP service for internal access
+- **Route**: Optional external route with re-encrypt TLS
+- **PodDisruptionBudget**: Availability guarantees
+- **RBAC**: ClusterRoles and bindings for registry operations
+- **Secrets**: Pull secrets, cloud credentials, TLS certificates
+- **CronJob**: Image pruner schedule (managed by ImagePrunerController)
+- **DaemonSet**: Node CA certificate sync (managed by NodeCADaemonController)
+
+Each resource type implements a `Getter`/`Mutator` pattern — the generator reads the current state, applies mutations, and diffs against the existing object to determine if an update is needed.
+
+## CRDs
+
+The operator reconciles two custom resources (defined in the `openshift/api` repo):
+
+- **`configs.imageregistry.operator.openshift.io/v1`** — Primary configuration: storage, replicas, routes, logging, management state. Status includes conditions, storage state, and ready replica count.
+- **`imagepruners.imageregistry.operator.openshift.io/v1`** — Image pruner configuration: schedule, suspend flag, resource limits, image selectors.
+
+The operator also writes to the **`clusteroperators.config.openshift.io/v1`** resource to report health to the cluster.
+
+## Dependency Map
+
+```text
+cluster-image-registry-operator
+├── depends on
+│   ├── openshift/api              (CRD types: ImageRegistry, ImagePruner, Infrastructure, ClusterOperator)
+│   ├── openshift/client-go        (generated clients for OpenShift APIs)
+│   ├── openshift/library-go       (controller framework, config observers, status helpers)
+│   ├── k8s.io/client-go           (informers, work queues, retry logic)
+│   └── Cloud SDKs                 (aws-sdk-go, azure-sdk-for-go, cloud.google.com/go, ibm-cos-sdk-go, gophercloud)
+│
+├── manages
+│   ├── Registry Deployment        (openshift-image-registry/image-registry)
+│   ├── Registry Service + Route
+│   ├── Cloud storage resources    (S3 buckets, Azure containers, GCS buckets, etc.)
+│   ├── Pruner CronJob
+│   └── Node CA DaemonSet
+│
+└── reports to
+    └── ClusterOperator CR         (consumed by CVO for cluster health)
+```
+
+## Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Single workqueue key | All events coalesce to one sync cycle. Simplifies logic and prevents thundering herd on rapid updates. |
+| Finalizer-based cleanup | Guarantees cloud storage resources are cleaned up when the Config CR is deleted. Prevents orphaned buckets/containers. |
+| Direct API reads for Config CR | Avoids informer cache staleness when the Config CR is patched in quick succession. |
+| Immutable storage config | Storage type and location are set at bootstrap. Prevents accidental data loss from storage migrations. |
+| Recreate strategy for PVC | RollingUpdate with PVC causes new pods to block on exclusive volume access. Cloud storage uses RollingUpdate. |
+| Platform auto-detection | Reads Infrastructure CR to select the right storage driver without user configuration. |
+
+## Testing
+
+- **Unit tests**: Colocated with source in `pkg/`. Mock cloud APIs and fake Kubernetes clients.
+- **E2E tests**: In `test/e2e/`, require a real OpenShift cluster. Use the OTE framework with `[Serial]` and `[Parallel]` labels.
+- **Test framework helpers**: In `test/framework/` for common setup and assertions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,63 +1,94 @@
-# Contributing to the Openshift Image Registry Operator
+# Contributing to cluster-image-registry-operator
 
-The registry operator manages a singleton instance of the openshift registry.  It manages all configuration of the registry including creating storage.
+The cluster-image-registry-operator manages the singleton OpenShift internal container image registry. It handles registry deployment, multi-cloud storage provisioning, TLS certificates, routes, and image pruning.
 
-## Getting the code
+## Development Workflow
 
-To get started, [fork](https://help.github.com/articles/fork-a-repo) the [openshift/cluster-image-registry-operator](https://github.com/openshift/cluster-image-registry-operator) repo.
+1. Fork the repo and clone your fork.
+2. Create a feature branch from `master`.
+3. Make your changes, add or update tests.
+4. Run verification locally before pushing:
 
-## Developing
+```bash
+make build       # Compile operator binary (output: tmp/_output/bin/)
+make test-unit   # Run unit tests
+make verify      # Run gofmt, golangci-lint, dependency checks
+```
+
+5. If you changed dependencies, update the vendor directory:
+
+```bash
+go mod tidy && go mod vendor
+```
+
+The vendor directory is checked in. CI will fail if vendor is stale.
+
+6. Push your branch and open a PR against `openshift/cluster-image-registry-operator:master`.
+
+## Pull Request Guidelines
+
+- Keep PRs focused. One logical change per PR.
+- Write clear commit messages. Reference Jira tickets where applicable (e.g., `OCPBUGS-12345: fix S3 bucket tagging`).
+- Include unit tests for new functionality.
+- PRs require approval from at least one approver listed in the `OWNERS` file.
+- Do not modify `OWNERS` or `OWNERS_ALIASES` files without explicit direction.
+
+## PR Review Rules
+
+- All PRs require `/lgtm` from a reviewer and `/approve` from an approver (OWNERS file). These are separate roles — the approver confirms the change belongs in the repo, the reviewer confirms correctness.
+- Prow enforces required labels: `lgtm` and `approved` must both be present before merge.
+- CI checks (`make verify`, `make test-unit`) must pass. Do not `/lgtm` a PR with failing CI.
+- Changes to storage drivers (`pkg/storage/`) should be reviewed by someone familiar with the target cloud platform.
+- Changes that affect the main reconciliation loop (`pkg/operator/controller.go`) or controller wiring (`pkg/operator/starter.go`) need careful review — all controllers share a single workqueue and these are high-impact paths.
+- Do not approve PRs that modify vendored files, generated files (`zz_generated.*`), or CRD manifests — these are managed upstream.
+- E2E test changes should be validated on a real OpenShift cluster before approval. Confirm `[Serial]` / `[Parallel]` tags are applied correctly.
+
+## Testing
+
+| Command | What it runs |
+|---------|-------------|
+| `make build` | Compile operator + test binaries |
+| `make test-unit` | Unit tests across `./cmd/...`, `./pkg/...`, and `./test/framework/...` |
+| `make test-e2e` | E2E tests (requires a real OpenShift cluster) |
+| `make verify` | Linters, gofmt, dependency checks |
+
+E2E tests use the OTE (OpenShift Tests Extension) framework and require a running OpenShift cluster. Tests are labeled `[Serial]` or `[Parallel]` — respect these labels. Do not run e2e tests on Kind or Minikube.
 
 ### Testing on an OpenShift Cluster
 
-The easiest way to test your changes is to launch an OpenShift 4.x cluster.
-First, go to [try.openshift.com](https://try.openshift.com) to obtain a pull secret and download the installer.
-Follow the instructions to launch a cluster on AWS.
+To test your operator image on a live cluster:
 
-If you want the latest `openshift-install` and `oc` clients, go to the [openshift-release](https://openshift-release.svc.ci.openshift.org/) 
-page, select the channel and build you wish to install, and download the respective `oc` and `openshift-installer` binaries.
-There are three types of channels you can obtain the installer from:
+1. Patch the cluster version to allow your own image:
 
-1. `4-stable` - these are stable releases of OpenShift 4, corresponding to GA or beta releases.
-2. `4.x.0-nightly` - nightly development releases, with payloads published to quay.io.
-3. `4.x.0-ci` - bleeding-edge releases published to the OpenShift CI imagestreams.
-
-**Note**: Installs from the `4.x.0-ci` channel require a pull secret to `registry.svc.ci.openshift.org`, which is only available to Red Hat OpenShift developers.
-
-After your cluster is installed, you will need to do the following:
-
-1. Patch the cluster version so that you can launch your own image-registry operator image:
-
-```
-$ oc patch clusterversion/version --patch '{"spec":{"overrides":[{"kind":"Deployment", "name":"cluster-image-registry-operator","namespace":"openshift-image-registry","unmanaged":true}]}}' --type=merge
+```bash
+oc patch clusterversion/version --patch '{"spec":{"overrides":[{"kind":"Deployment", "name":"cluster-image-registry-operator","namespace":"openshift-image-registry","unmanaged":true}]}}' --type=merge
 ```
 
-2. Make your code changes and build the binary with `make build`.
-3. Build the image using the `Dockerfile` file, giving it a unique tag:
+2. Build and push your image:
 
-```
-$ make build-image IMAGE=<MYREPO>/<MYIMAGE> TAG=<MYTAG> 
-```
-
-or if you are using `buildah`:
-
-```
-$ buildah bud -t <MYREPO>/<MYIMAGE>:<MYTAG> -f Dockerfile .
+```bash
+make build-image IMAGE=<MYREPO>/<MYIMAGE> TAG=<MYTAG>
 ```
 
-4. Push the image to a registry accessible from the cluster (e.g. your repository on quay.io).
-5. Patch the Deployment in the override above to instruct the cluster to use your builder image:
+3. Patch the Deployment to use your image:
 
-```
-$ oc patch deployment cluster-image-registry-operator -n openshift-image-registry --patch '{"spec":{"template":{"spec":{"containers":[{"name":"cluster-image-registry-operator","image":"<MYREPO>/<MYIMAGE>:<MYTAG>"}]}}}}' --type=strategic
+```bash
+oc patch deployment cluster-image-registry-operator -n openshift-image-registry --patch '{"spec":{"template":{"spec":{"containers":[{"name":"cluster-image-registry-operator","image":"<MYREPO>/<MYIMAGE>:<MYTAG>"}]}}}}' --type=strategic
 ```
 
-6. Watch the openshift cluster image-registry operator replicaset rollout (this can take a few minutes):
+## Code Conventions
 
-```
-$ oc get rs cluster-image-registry-operator-<hash> -n openshift-image-registry -w
-```
-## Submitting a Pull Request
+- Follow standard Go conventions (gofmt, govet).
+- Use existing patterns in the package you are modifying.
+- Storage backends implement the `Driver` interface in `pkg/storage/`. New backends must implement the full interface.
+- Use `retry.RetryOnConflict` when updating the Config CR status — multiple controllers may update it concurrently.
 
-Once you are satisfied with your code changes, you may submit a pull request to the [openshift/cluster-image-registry-operator](https://github.com/openshift/cluster-image-registry-operator) repo.
-A member of the OpenShift Developer Experience team will evaluate your change for approval.
+## Areas Requiring Extra Care
+
+- **Storage drivers** (`pkg/storage/`): Each cloud backend has its own credential handling and error retry logic. Test with real cloud credentials when modifying.
+- **CRD types**: CRD definitions live in the `openshift/api` repo, not here. Do not modify vendored CRD manifests.
+- **Generated files**: Files matching `zz_generated.*` are generated upstream. Do not hand-edit.
+
+## CI
+
+CI runs via OpenShift's CI infrastructure (Prow / ci-operator). All `make verify` and `make test-unit` checks must pass for a PR to merge.


### PR DESCRIPTION
## Summary
- Update **CONTRIBUTING.md** with dev workflow, PR guidelines, testing requirements, coding conventions, and areas requiring extra care
- Add **AGENTS.md** with AI agent instructions: repo structure, critical rules, key patterns, build/test commands
- Add **ARCHITECTURE.md** documenting 11 concurrent controllers, storage Driver interface (7 cloud backends), reconciliation flow, CRDs, and design decisions
- Add **CLAUDE.md** as a symlink to AGENTS.md

Part of the Hybrid Platforms Agentic SDLC initiative ([OCPSTRAT-3200](https://redhat.atlassian.net/browse/OCPSTRAT-3200)) — Shift Week contextification effort.

Jira: [CNTRLPLANE-3658](https://redhat.atlassian.net/browse/CNTRLPLANE-3658)

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Review with team for accuracy and completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added repository developer instructions detailing build/verify workflow, architectural constraints, and prohibited change patterns.
  * Introduced an architecture overview covering reconciliation flow, controller components, and multi-backend storage design principles.
  * Updated contributor guidance with a reorganized workflow, clearer pull request/testing expectations (including OpenShift E2E steps), and updated code conventions.
  * Updated `CLAUDE.md` to reference the main developer instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->