### PR TITLE
CORENET-7355: Remove redundant ingress rule from image-registry netpol

### DIFF
--- a/bindata/image-registry-networkpolicy.yaml
+++ b/bindata/image-registry-networkpolicy.yaml
@@ -32,14 +32,8 @@ spec:
     - port: 5000
       protocol: TCP
 
-  # Allow ingress from all namespaces for image pull/push
-  - from:
-      - namespaceSelector: {}
-    ports:
-    - port: 5000
-      protocol: TCP
-
-  # Allow ingress from host network pods (nodes, kubelet)
+  # Allow ingress from all pod-network and host-network pods for image pull/push.
+  # Side effect: this rule does not restrict traffic by source.
   - ports:
     - port: 5000
       protocol: TCP

--- a/test/e2e/network_policy.go
+++ b/test/e2e/network_policy.go
@@ -62,7 +62,7 @@ func testImageRegistryNetworkPolicies() {
 	logNetworkPolicyDetails(npImageRegistryPolicyName, registryPolicy)
 	requirePodSelectorLabel(registryPolicy, "docker-registry", "default")
 	requirePort(registryPolicy, "ingress", corev1.ProtocolTCP, 5000)
-	requireIngressFromAllNamespaces(registryPolicy, 5000)
+	requireIngressAllowAll(registryPolicy, 5000)
 	logIngressFromNamespaceOptional(registryPolicy, 5000, "openshift-monitoring")
 	requireIngressFromNamespaceOrPolicyGroup(registryPolicy, 5000, "openshift-ingress", "policy-group.network.openshift.io/ingress")
 	logIngressHostNetworkOrAllowAll(registryPolicy, 5000)

--- a/test/e2e/network_policy_helpers.go
+++ b/test/e2e/network_policy_helpers.go
@@ -256,14 +256,6 @@ func hasEgressAllowAll(rules []networkingv1.NetworkPolicyEgressRule) bool {
 	return false
 }
 
-func requireIngressFromAllNamespaces(policy *networkingv1.NetworkPolicy, port int32) {
-	g.GinkgoHelper()
-	peers, _ := ingressPeersForPort(policy.Spec.Ingress, port)
-	if !hasPeerFromAllNamespaces(peers) {
-		g.Fail(fmt.Sprintf("%s/%s: expected ingress from all namespaces on port %d", policy.Namespace, policy.Name, port))
-	}
-}
-
 func requireIngressAllowAll(policy *networkingv1.NetworkPolicy, port int32) {
 	g.GinkgoHelper()
 	_, allowAll := ingressPeersForPort(policy.Spec.Ingress, port)


### PR DESCRIPTION
The namespaceSelector: {} peer is a strict subset of the ports-only rule (no `from` field) which already allows ingress from all sources on port 5000. It causes the CNI to maintain a cluster-wide pod IP address set that is recomputed on every pod event.

Keep the monitoring and router ingress rules as they document distinct intent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes / Access Changes**
  * Updated the image registry NetworkPolicy so TCP port **5000** ingress is permitted from **any source** for image pull/push. Previously, access was constrained by namespace/selector-based ingress rules.

* **Tests**
  * Updated e2e NetworkPolicy assertions for the image registry policy on **TCP/5000** to expect **universal allow-all ingress**, removing the prior namespace-scoped expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->