### PR TITLE
OCPBUGS-86308: do not report progressing during cluster scale up

### DIFF
--- a/pkg/operator/nodecadaemon.go
+++ b/pkg/operator/nodecadaemon.go
@@ -41,6 +41,13 @@ type NodeCADaemonController struct {
 	cachesToSync     []cache.InformerSynced
 	queue            workqueue.TypedRateLimitingInterface[any]
 	syncFailureSince time.Time
+
+	// lastSettledObservedGeneration is used to detect when a rollout is
+	// being caused by a change in the DaemonSet configuration. Once a
+	// given generation settles down (progressing = false) we don't want
+	// to report "progressing" anymore until the daemon set configuration
+	// changes or we have misscheduled pods.
+	lastSettledObservedGeneration int64
 }
 
 func NewNodeCADaemonController(
@@ -131,6 +138,7 @@ func (c *NodeCADaemonController) sync() error {
 
 	dsObj, err := gen.Get()
 	if errors.IsNotFound(err) {
+		c.lastSettledObservedGeneration = 0
 		availableCondition.Status = operatorv1.ConditionFalse
 		availableCondition.Reason = "NotFound"
 		availableCondition.Message = "The daemon set node-ca does not exist"
@@ -156,11 +164,21 @@ func (c *NodeCADaemonController) sync() error {
 			availableCondition.Message = "The daemon set node-ca does not have available replicas"
 		}
 
-		if ds.Status.UpdatedNumberScheduled < ds.Status.DesiredNumberScheduled || ds.Status.NumberMisscheduled > 0 {
+		// We are only "progressing" if we have something erroneously
+		// running on a node or if we have caused a new daemonset
+		// rollout by updating it somehow. i.e. we deliberately don't
+		// want to report "progressing" when the daemonset is scaling
+		// up.
+		unsettledObservedGeneration := c.lastSettledObservedGeneration != ds.Status.ObservedGeneration
+		stillToBeScheduled := ds.Status.UpdatedNumberScheduled < ds.Status.DesiredNumberScheduled
+		misScheduled := ds.Status.NumberMisscheduled > 0
+		waitingOnDSController := ds.Generation > ds.Status.ObservedGeneration
+		if waitingOnDSController || misScheduled || (unsettledObservedGeneration && stillToBeScheduled) {
 			progressingCondition.Status = operatorv1.ConditionTrue
 			progressingCondition.Reason = "Progressing"
 			progressingCondition.Message = "The daemon set node-ca is updating node pods"
 		} else {
+			c.lastSettledObservedGeneration = ds.Status.ObservedGeneration
 			progressingCondition.Status = operatorv1.ConditionFalse
 			progressingCondition.Reason = "AsExpected"
 			progressingCondition.Message = "The daemon set node-ca is deployed"

--- a/pkg/operator/nodecadaemon_test.go
+++ b/pkg/operator/nodecadaemon_test.go
@@ -140,7 +140,7 @@ func TestNodeCADaemonControllerConditionsDuringInertia(t *testing.T) {
 func newNodeCATestSetup(t *testing.T, applyError error) (*NodeCADaemonController, *imageregistryfakeclient.Clientset) {
 	t.Helper()
 
-	kubeClient := kubefakeclient.NewClientset(&appsv1.DaemonSet{
+	ds := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "node-ca",
 			Namespace: defaults.ImageRegistryOperatorNamespace,
@@ -150,7 +150,22 @@ func newNodeCATestSetup(t *testing.T, applyError error) (*NodeCADaemonController
 			DesiredNumberScheduled: 3,
 			UpdatedNumberScheduled: 3,
 		},
-	})
+	}
+	controller, kubeClient, regClient := newNodeCATestSetupWithCustomDaemonset(t, ds)
+	if applyError != nil {
+		failDaemonSetWrite := func(action clientgotesting.Action) (bool, runtime.Object, error) {
+			return true, nil, applyError
+		}
+		kubeClient.PrependReactor("create", "daemonsets", failDaemonSetWrite)
+		kubeClient.PrependReactor("update", "daemonsets", failDaemonSetWrite)
+	}
+	return controller, regClient
+}
+
+func newNodeCATestSetupWithCustomDaemonset(t *testing.T, ds *appsv1.DaemonSet) (*NodeCADaemonController, *kubefakeclient.Clientset, *imageregistryfakeclient.Clientset) {
+	t.Helper()
+
+	kubeClient := kubefakeclient.NewClientset(ds)
 	regClient := imageregistryfakeclient.NewClientset(&imageregistryv1.Config{
 		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
 	})
@@ -167,14 +182,6 @@ func newNodeCATestSetup(t *testing.T, applyError error) (*NodeCADaemonController
 	daemonSetLister := kubeInformers.Apps().V1().DaemonSets().Lister().DaemonSets(defaults.ImageRegistryOperatorNamespace)
 	serviceLister := kubeInformers.Core().V1().Services().Lister().Services(defaults.ImageRegistryOperatorNamespace)
 
-	if applyError != nil {
-		failDaemonSetWrite := func(action clientgotesting.Action) (bool, runtime.Object, error) {
-			return true, nil, applyError
-		}
-		kubeClient.PrependReactor("create", "daemonsets", failDaemonSetWrite)
-		kubeClient.PrependReactor("update", "daemonsets", failDaemonSetWrite)
-	}
-
 	ctx := t.Context()
 	kubeInformers.Start(ctx.Done())
 	regInformers.Start(ctx.Done())
@@ -189,7 +196,134 @@ func newNodeCATestSetup(t *testing.T, applyError error) (*NodeCADaemonController
 		serviceLister:   serviceLister,
 	}
 
-	return controller, regClient
+	return controller, kubeClient, regClient
+}
+
+func TestNodeCADaemonControllerProgressing(t *testing.T) {
+	tests := []struct {
+		name                          string
+		dsStatus                      appsv1.DaemonSetStatus
+		metadataGeneration            int64
+		lastSettledObservedGeneration int64
+		expectProgressing             operatorv1.ConditionStatus
+		expectSettledGeneration       int64
+	}{
+		{
+			name: "operator starting with progressing daemonset",
+			dsStatus: appsv1.DaemonSetStatus{
+				ObservedGeneration:     1,
+				DesiredNumberScheduled: 3,
+				CurrentNumberScheduled: 1,
+				UpdatedNumberScheduled: 1,
+				NumberAvailable:        1,
+			},
+			metadataGeneration:            1,
+			lastSettledObservedGeneration: 0,
+			expectProgressing:             operatorv1.ConditionTrue,
+			expectSettledGeneration:       0,
+		},
+		{
+			name: "operator starting with settled daemonset",
+			dsStatus: appsv1.DaemonSetStatus{
+				ObservedGeneration:     5,
+				DesiredNumberScheduled: 3,
+				CurrentNumberScheduled: 3,
+				UpdatedNumberScheduled: 3,
+				NumberAvailable:        3,
+			},
+			metadataGeneration:            5,
+			lastSettledObservedGeneration: 0,
+			expectProgressing:             operatorv1.ConditionFalse,
+			expectSettledGeneration:       5,
+		},
+		{
+			name: "slow daemonset controller",
+			dsStatus: appsv1.DaemonSetStatus{
+				ObservedGeneration:     5,
+				DesiredNumberScheduled: 3,
+				CurrentNumberScheduled: 3,
+				UpdatedNumberScheduled: 3,
+				NumberAvailable:        3,
+			},
+			metadataGeneration:            6,
+			lastSettledObservedGeneration: 5,
+			expectProgressing:             operatorv1.ConditionTrue,
+			expectSettledGeneration:       5,
+		},
+		{
+			name: "progressing after spec change",
+			dsStatus: appsv1.DaemonSetStatus{
+				ObservedGeneration:     2,
+				DesiredNumberScheduled: 3,
+				CurrentNumberScheduled: 3,
+				UpdatedNumberScheduled: 1,
+				NumberAvailable:        3,
+			},
+			metadataGeneration:            2,
+			lastSettledObservedGeneration: 1,
+			expectProgressing:             operatorv1.ConditionTrue,
+			expectSettledGeneration:       1,
+		},
+		{
+			name: "operator finds a new settled generation",
+			dsStatus: appsv1.DaemonSetStatus{
+				ObservedGeneration:     8,
+				DesiredNumberScheduled: 3,
+				CurrentNumberScheduled: 3,
+				UpdatedNumberScheduled: 3,
+				NumberAvailable:        3,
+			},
+			metadataGeneration:            8,
+			lastSettledObservedGeneration: 1,
+			expectProgressing:             operatorv1.ConditionFalse,
+			expectSettledGeneration:       8,
+		},
+		{
+			name: "operator finds misscheduled pod",
+			dsStatus: appsv1.DaemonSetStatus{
+				ObservedGeneration:     8,
+				DesiredNumberScheduled: 3,
+				CurrentNumberScheduled: 3,
+				UpdatedNumberScheduled: 3,
+				NumberAvailable:        3,
+				NumberMisscheduled:     1,
+			},
+			metadataGeneration:            8,
+			lastSettledObservedGeneration: 8,
+			expectProgressing:             operatorv1.ConditionTrue,
+			expectSettledGeneration:       8,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ds := &appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "node-ca",
+					Namespace:  defaults.ImageRegistryOperatorNamespace,
+					Generation: tt.metadataGeneration,
+				},
+				Status: tt.dsStatus,
+			}
+			controller, _, regClient := newNodeCATestSetupWithCustomDaemonset(t, ds)
+			controller.lastSettledObservedGeneration = tt.lastSettledObservedGeneration
+
+			if err := controller.sync(); err != nil {
+				t.Fatalf("unexpected sync error: %v", err)
+			}
+
+			progressing := getNodeCACondition(t, regClient, "NodeCADaemonProgressing")
+			if progressing == nil {
+				t.Fatal("expected NodeCADaemonProgressing condition to exist")
+			}
+			if progressing.Status != tt.expectProgressing {
+				t.Errorf("expected NodeCADaemonProgressing=%s, got %s", tt.expectProgressing, progressing.Status)
+			}
+			if controller.lastSettledObservedGeneration != tt.expectSettledGeneration {
+				t.Errorf("expected lastSettledObservedGeneration=%d, got %d", tt.expectSettledGeneration, controller.lastSettledObservedGeneration)
+			}
+		})
+	}
 }
 
 func getNodeCACondition(t *testing.T, regClient *imageregistryfakeclient.Clientset, condType string) *operatorv1.OperatorCondition {


### PR DESCRIPTION
A "settled generation" is an observed generation for which the Progressing condition has already became false. Taking this definition into account we report progressing only for the following conditions:

1) No generation has settled yet and we are deploying. 
2) We have mis-scheduled pods that aren't yet "addressed". 
3) A new observed generation, different than the current settled generation, is being deployed.

> [!Note]
> This has been specifically tailored to mitigate the chances of a `Progessing` status during cluster scale ups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved rollout status reporting for node daemon updates.
- Progress is now reported while changes are being applied, observations are delayed, or pods are scheduled incorrectly.
- Completed updates remain stable until a new rollout or scheduling issue occurs.
- Improved status handling after configuration changes, settled updates, and when adding nodes.
- Status tracking resets appropriately when the daemon is unavailable.

## Tests

- Added coverage for rollout, settlement, configuration-change, scale-up, delayed-observation, and misscheduled-node scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->