### PR TITLE
OCPBUGS-112551: imageconfig: Preserve ImageStreamImportMode during upgrade race

### DIFF
--- a/pkg/operator/imageconfig.go
+++ b/pkg/operator/imageconfig.go
@@ -187,22 +187,11 @@ func (icc *ImageConfigController) syncImageStatus() error {
 		modified = true
 	}
 	if icc.imageStreamImportModeEnabled {
-		var importmode configapi.ImportModeType
-		if cfg.Spec.ImageStreamImportMode != "" {
-			importmode = cfg.Spec.ImageStreamImportMode
-		} else {
-			cv, err := icc.clusterVersionLister.Get("version")
-			if err != nil {
-				return err
-			}
-			// If the clusterversion reports that the desired architecture (existing or desired) of the
-			// cluster is "Multi", set import mode to PreserveOriginal. Else set it to Legacy
-			if cv.Status.Desired.Architecture == configv1.ClusterVersionArchitectureMulti {
-				importmode = configapi.ImportModePreserveOriginal
-			} else {
-				importmode = configapi.ImportModeLegacy
-			}
+		cv, err := icc.clusterVersionLister.Get("version")
+		if err != nil {
+			return err
 		}
+		importmode := imageStreamImportMode(cfg.Spec.ImageStreamImportMode, cfg.Status.ImageStreamImportMode, cv.Status.Desired.Architecture)
 		if cfg.Status.ImageStreamImportMode != importmode {
 			cfg.Status.ImageStreamImportMode = importmode
 			modified = true
@@ -216,6 +205,38 @@ func (icc *ImageConfigController) syncImageStatus() error {
 	}
 
 	return nil
+}
+
+// imageStreamImportMode returns the import mode that should be written to
+// image.config.openshift.io/cluster status.
+//
+// specMode takes precedence when set by the administrator. Otherwise, the mode
+// is derived from the cluster's desired architecture:
+//   - "Multi" → PreserveOriginal
+//   - anything else → Legacy
+//   - "" (not yet populated) → preserve the existing status value
+//
+// The empty-architecture case arises during upgrades from pre-5.x releases: the
+// CVO only writes Status.Desired.Architecture when its internal
+// StatusReleaseArchitecture gate is on, which is itself enabled by the
+// ImageStreamImportMode feature gate. On any settled 5.x cluster the gate is
+// always on and Architecture is always populated. The "" branch is only
+// reachable during the brief window at upgrade start where the config-operator
+// has already enabled the gate in featuregate/cluster but the CVO has not yet
+// reconciled. Preserving the existing value lets the ClusterVersion informer
+// re-trigger the sync once the correct architecture is written.
+func imageStreamImportMode(specMode, currentMode configapi.ImportModeType, architecture configv1.ClusterVersionArchitecture) configapi.ImportModeType {
+	if specMode != "" {
+		return specMode
+	}
+	switch architecture {
+	case configv1.ClusterVersionArchitectureMulti:
+		return configapi.ImportModePreserveOriginal
+	case "":
+		return currentMode
+	default:
+		return configapi.ImportModeLegacy
+	}
 }
 
 func (icc *ImageConfigController) sync() error {

--- a/pkg/operator/imageconfig_test.go
+++ b/pkg/operator/imageconfig_test.go
@@ -1,0 +1,68 @@
+package operator
+
+import (
+	"testing"
+
+	configapi "github.com/openshift/api/config/v1"
+)
+
+func TestImageStreamImportMode(t *testing.T) {
+	tests := []struct {
+		name         string
+		specMode     configapi.ImportModeType
+		currentMode  configapi.ImportModeType
+		architecture configapi.ClusterVersionArchitecture
+		want         configapi.ImportModeType
+	}{
+		{
+			name:         "spec mode overrides multi-arch cluster",
+			specMode:     configapi.ImportModeLegacy,
+			architecture: configapi.ClusterVersionArchitectureMulti,
+			want:         configapi.ImportModeLegacy,
+		},
+		{
+			name:         "spec mode overrides single-arch cluster",
+			specMode:     configapi.ImportModePreserveOriginal,
+			architecture: "amd64",
+			want:         configapi.ImportModePreserveOriginal,
+		},
+		{
+			name:         "multi-arch cluster returns PreserveOriginal",
+			architecture: configapi.ClusterVersionArchitectureMulti,
+			want:         configapi.ImportModePreserveOriginal,
+		},
+		{
+			name:         "single-arch cluster returns Legacy",
+			architecture: "amd64",
+			want:         configapi.ImportModeLegacy,
+		},
+		{
+			name:         "empty architecture preserves existing PreserveOriginal",
+			currentMode:  configapi.ImportModePreserveOriginal,
+			architecture: "",
+			want:         configapi.ImportModePreserveOriginal,
+		},
+		{
+			name:         "empty architecture preserves existing Legacy",
+			currentMode:  configapi.ImportModeLegacy,
+			architecture: "",
+			want:         configapi.ImportModeLegacy,
+		},
+		{
+			name:         "empty architecture with no existing mode stays empty",
+			currentMode:  "",
+			architecture: "",
+			want:         "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := imageStreamImportMode(tc.specMode, tc.currentMode, tc.architecture)
+			if got != tc.want {
+				t.Errorf("imageStreamImportMode(%q, %q, %q) = %q, want %q",
+					tc.specMode, tc.currentMode, tc.architecture, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
During an upgrade from a pre-5.x release, there is a brief window where the config-operator has already enabled the ImageStreamImportMode feature gate in featuregate/cluster but the CVO has not yet reconciled with those gates. Until the CVO picks up the change it actively clears Status.Desired.Architecture to "". syncImageStatus() was treating an empty architecture as a signal to write "Legacy", which is incorrect for multi-arch clusters and triggered a spurious double rollout of the openshift-apiserver deployment, ultimately causing the Available condition to flip False for one second.

Fix by extracting the import-mode decision into a pure helper imageStreamImportMode() and preserving the existing status value when Architecture is empty. The ClusterVersion informer will re-trigger the sync once the CVO has written the correct architecture. On any settled 5.x cluster with ImageStreamImportMode in the Default feature set, Architecture is always populated and the empty branch is unreachable.

Add unit tests covering all input combinations for the helper.

This actually doesn't have any effect on 5.1 as the field is always set, we need to backport to 5.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image stream import-mode selection based on configured settings and architecture.
  * Preserved the existing import mode when architecture information is unavailable.
  * Applied appropriate defaults for multi-architecture and single-architecture images.

* **Tests**
  * Added coverage for configured overrides, architecture-based defaults, and empty architecture values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->